### PR TITLE
Make usbhub and lsusb use build tag 'usb'.

### DIFF
--- a/experimental/cmd/lsusb/main.go
+++ b/experimental/cmd/lsusb/main.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+// +build usb
+
 // lsusb prints out information about the USB devices.
 package main
 

--- a/experimental/host/usbbus/doc.go
+++ b/experimental/host/usbbus/doc.go
@@ -6,4 +6,9 @@
 //
 // This includes handling the connected devices on process startup and handling
 // of the connection events.
+//
+// This package is only built with the build tag 'usb' because it causes a
+// dependency on https://github.com/kylelemons/gousb. This package uses cgo that
+// depends on libusb being installed. This is generally not the case by
+// default, so it causes a go get failure which is really obnoxious to users.
 package usbbus

--- a/experimental/host/usbbus/usbbus.go
+++ b/experimental/host/usbbus/usbbus.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+// +build usb
+
 package usbbus
 
 import (

--- a/experimental/host/usbbus/usbbus_test.go
+++ b/experimental/host/usbbus/usbbus_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
+// +build usb
+
 package usbbus
 
 import (


### PR DESCRIPTION
This permits not depending on github.com/kylelemons/gousb/usb by default. This
is important because this library uses cgo and it depends on a library that is
usually not installed by default.
