### PR TITLE
i2c and spi: Improve error message when no bus is registered.

### DIFF
--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -206,6 +206,9 @@ func Unregister(name string, busNumber int) error {
 func find(busNumber int) (Opener, error) {
 	mu.Lock()
 	defer mu.Unlock()
+	if len(byNumber) == 0 {
+		return nil, errors.New("no I²C bus found; did you forget to call Init()?")
+	}
 	if busNumber == -1 {
 		if first == nil {
 			return nil, errors.New("no I²C bus found")

--- a/conn/spi/spi.go
+++ b/conn/spi/spi.go
@@ -155,6 +155,9 @@ func Unregister(name string, busNumber int) error {
 func find(busNumber, cs int) (Opener, error) {
 	mu.Lock()
 	defer mu.Unlock()
+	if len(byNumber) == 0 {
+		return nil, errors.New("no SPI bus found; did you forget to call Init()?")
+	}
 	if busNumber == -1 {
 		if first == nil {
 			return nil, errors.New("no SPI bus found")


### PR DESCRIPTION
Hint the user that (s)he may have forgot to call Init(). Hopefully this will
help users not waste time on this oversight.
