### PR TITLE
add 1-wire support using DS2483 i2c bus adapter

### DIFF
--- a/experimental/conn/onewire/crc.go
+++ b/experimental/conn/onewire/crc.go
@@ -1,0 +1,45 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package onewire
+
+// CheckCRC verifies that the last byte of the buffer contains the CRC of the previous bytes.
+func CheckCRC(buf []byte) bool {
+	if len(buf) == 0 {
+		return false
+	}
+	return CalcCRC(buf[:len(buf)-1]) == buf[len(buf)-1]
+}
+
+// CalcCRC calculates the 8-bit CRC across the buffer of bytes and returns it.
+//
+// The Dallas Semi / Maxim Integrated 1-Wire CRC calculation is described in App Note 27:
+// https://www.maximintegrated.com/en/app-notes/index.mvp/id/27.
+func CalcCRC(buf []byte) byte {
+	var crc byte
+	for _, b := range buf {
+		crc = crcTable[crc^b]
+	}
+	return crc
+}
+
+// crcTable comes from https://www.maximintegrated.com/en/app-notes/index.mvp/id/27
+var crcTable = []byte{
+	0, 94, 188, 226, 97, 63, 221, 131, 194, 156, 126, 32, 163, 253, 31, 65,
+	157, 195, 33, 127, 252, 162, 64, 30, 95, 1, 227, 189, 62, 96, 130, 220,
+	35, 125, 159, 193, 66, 28, 254, 160, 225, 191, 93, 3, 128, 222, 60, 98,
+	190, 224, 2, 92, 223, 129, 99, 61, 124, 34, 192, 158, 29, 67, 161, 255,
+	70, 24, 250, 164, 39, 121, 155, 197, 132, 218, 56, 102, 229, 187, 89, 7,
+	219, 133, 103, 57, 186, 228, 6, 88, 25, 71, 165, 251, 120, 38, 196, 154,
+	101, 59, 217, 135, 4, 90, 184, 230, 167, 249, 27, 69, 198, 152, 122, 36,
+	248, 166, 68, 26, 153, 199, 37, 123, 58, 100, 134, 216, 91, 5, 231, 185,
+	140, 210, 48, 110, 237, 179, 81, 15, 78, 16, 242, 172, 47, 113, 147, 205,
+	17, 79, 173, 243, 112, 46, 204, 146, 211, 141, 111, 49, 178, 236, 14, 80,
+	175, 241, 19, 77, 206, 144, 114, 44, 109, 51, 209, 143, 12, 82, 176, 238,
+	50, 108, 142, 208, 83, 13, 239, 177, 240, 174, 76, 18, 145, 207, 45, 115,
+	202, 148, 118, 40, 171, 245, 23, 73, 8, 86, 180, 234, 105, 55, 213, 139,
+	87, 9, 235, 181, 54, 104, 138, 212, 149, 203, 41, 119, 244, 170, 72, 22,
+	233, 183, 85, 11, 136, 214, 52, 106, 43, 117, 151, 201, 74, 20, 246, 168,
+	116, 42, 200, 150, 21, 75, 169, 247, 182, 232, 10, 84, 215, 137, 107, 53,
+}

--- a/experimental/conn/onewire/onewire.go
+++ b/experimental/conn/onewire/onewire.go
@@ -1,0 +1,218 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package onewire defines a Dallas Semiconductor (now Maxim) 1-wire bus
+//
+// It includes an adapter to directly address a 1-wire device on a 1-wire bus
+// without having to continuously specify the address when doing I/O. This
+// enables the support of conn.Conn.
+package onewire
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/google/periph/conn/gpio"
+)
+
+// Conn defines the function a concrete driver for a 1-wire bus must implement.
+//
+// This interface doesn't implement conn.Conn since a device address must be
+// specified. Use onewire.Dev as an adapter to get a conn.Conn compatible
+// object.
+type Conn interface {
+	// Tx performs a "match ROM" command on the bus, which selects at most
+	// one device and then transmits and receives the specified bytes.
+	Tx(addr uint64, w, r []byte) error
+
+	// TxPup performs a "match ROM" command on the bus, which selects at most
+	// one device, then transmits and receives the specified bytes, and ends
+	// by turning-on a strong pull-up on the bus to power devices (such as
+	// temperature sensors performing a conversion).
+	TxPup(addr uint64, w, r []byte) error
+
+	// All performs a "skip ROM" command on the bus, which selects all devices,
+	// and then transmits the specified bytes.
+	All(w []byte) error
+
+	// AllPup performs a "skip ROM" command on the bus, which selects all devices,
+	// then transmits the specified bytes, and ends by turning-on a strong pull-up
+	// on the bus to power devices (such as temperature sensors performing a
+	// conversion).
+	AllPup(w []byte) error
+
+	// Search performs a "search" cycle on the 1-wire bus and returns the
+	// addresses of all devices on the bus if alarmOnly is false and of all
+	// devices in alarm state if alarmOnly is true.
+	Search(alarmOnly bool) ([]uint64, error)
+}
+
+// ConnCloser is a 1-wire bus that can be closed.
+//
+// This interface is meant to be handled by the application.
+type ConnCloser interface {
+	io.Closer
+	Conn
+}
+
+// Pins defines the pins that a 1-wire bus interconnect is using on the host.
+//
+// It is expected that a implementer of Conn also implement Pins but this is
+// not a requirement.
+type Pins interface {
+	// Q returns the 1-wire Q (data) pin
+	Q() gpio.PinIO
+}
+
+// Dev is a device on a 1-wire bus.
+//
+// It implements conn.Conn.
+//
+// It saves from repeatedly specifying the device address and implements
+// utility functions.
+type Dev struct {
+	Conn Conn
+	Addr uint64
+}
+
+func (d *Dev) String() string {
+	return fmt.Sprintf("%s(%d)", d.Conn, d.Addr)
+}
+
+// Tx does a transaction by adding the device's address to each command.
+//
+// It's a wrapper for Dev.Conn.Tx().
+func (d *Dev) Tx(w, r []byte) error {
+	return d.Conn.Tx(d.Addr, w, r)
+}
+
+// TxPup does a transaction ending in a string pull-up by adding the
+// device's address to each command.
+//
+// It's a wrapper for Dev.Conn.TxPup().
+func (d *Dev) TxPup(w, r []byte) error {
+	return d.Conn.TxPup(d.Addr, w, r)
+}
+
+// Write writes to the 1-wire bus without reading, implementing io.Writer.
+//
+// It's a wrapper for Tx()
+func (d *Dev) Write(b []byte) (int, error) {
+	if err := d.Tx(b, nil); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+// All returns all the 1-wire buses available on this host.
+func All() map[string]Opener {
+	mu.Lock()
+	defer mu.Unlock()
+	out := make(map[string]Opener, len(byName))
+	for k, v := range byName {
+		out[k] = v
+	}
+	return out
+}
+
+// New returns an open handle to a 1-wire bus.
+//
+// Specify busNumber -1 to get the first available bus. This is the recommended value.
+func New(busNumber int) (ConnCloser, error) {
+	opener, err := find(busNumber)
+	if err != nil {
+		return nil, err
+	}
+	return opener()
+}
+
+// Opener opens a 1-wire bus.
+type Opener func() (ConnCloser, error)
+
+// Register registers a 1-wire bus.
+//
+// Registering the same bus name twice is an error.
+func Register(name string, busNumber int, opener Opener) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if _, ok := byName[name]; ok {
+		return fmt.Errorf("registering the same 1-wire bus %s twice", name)
+	}
+	if busNumber != -1 {
+		if _, ok := byNumber[busNumber]; ok {
+			return fmt.Errorf("registering the same 1-wire bus %d twice", busNumber)
+		}
+	}
+
+	if first == nil {
+		first = opener
+	}
+	byName[name] = opener
+	if busNumber != -1 {
+		byNumber[busNumber] = opener
+	}
+	return nil
+}
+
+// Unregister removes a previously registered 1-wire bus.
+//
+// This can happen, for example, when a 1-wire bus is exposed via an USB device
+// and the device is unplugged.
+func Unregister(name string, busNumber int) error {
+	mu.Lock()
+	defer mu.Unlock()
+
+	_, ok := byName[name]
+	if !ok {
+		return errors.New("unknown name")
+	}
+	if _, ok := byNumber[busNumber]; !ok {
+		return errors.New("unknown number")
+	}
+
+	delete(byName, name)
+	delete(byNumber, busNumber)
+	first = nil
+	/* TODO(maruel): Figure out a way.
+	if first == bus {
+		first = nil
+		last := ""
+		for name, b := range byName {
+			if last == "" || last > name {
+				last = name
+				first = b
+			}
+		}
+	}
+	*/
+	return nil
+}
+
+//
+
+func find(busNumber int) (Opener, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if busNumber == -1 {
+		if first == nil {
+			return nil, errors.New("no 1-wire bus found")
+		}
+		return first, nil
+	}
+	bus, ok := byNumber[busNumber]
+	if !ok {
+		return nil, fmt.Errorf("no 1-wire bus %d", busNumber)
+	}
+	return bus, nil
+}
+
+var (
+	mu       sync.Mutex
+	byName   = map[string]Opener{}
+	byNumber = map[int]Opener{}
+	first    Opener
+)

--- a/experimental/conn/onewire/onewire_test.go
+++ b/experimental/conn/onewire/onewire_test.go
@@ -1,0 +1,28 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package onewire
+
+import (
+	"fmt"
+	"log"
+	"testing"
+)
+
+func ExampleAll() {
+	fmt.Print("1-wire buses available:\n")
+	for name := range All() {
+		fmt.Printf("- %s\n", name)
+	}
+}
+
+func TestInvalid(t *testing.T) {
+	if _, err := New(-1); err == nil {
+		t.Fail()
+	}
+}
+
+func TestAreInOnewireTest(t *testing.T) {
+	// Real tests are in onewiretest due to cyclic dependency.
+}

--- a/experimental/conn/onewire/onewiretest/onewire_test.go
+++ b/experimental/conn/onewire/onewiretest/onewire_test.go
@@ -1,0 +1,31 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package onewiretest
+
+import (
+	"testing"
+
+	"github.com/google/periph/experimental/conn/onewire"
+)
+
+func TestDev(t *testing.T) {
+	p := Playback{
+		Ops: []IO{
+			{
+				Addr:  23,
+				Write: []byte{10},
+				Read:  []byte{12},
+			},
+		},
+	}
+	d := onewire.Dev{Conn: &p, Addr: 23}
+	v, err := d.ReadRegUint8(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 12 {
+		t.Fail()
+	}
+}

--- a/experimental/conn/onewire/onewiretest/onewiretest.go
+++ b/experimental/conn/onewire/onewiretest/onewiretest.go
@@ -1,0 +1,137 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package i2ctest is meant to be used to test drivers over a fake I²C bus.
+package onewiretest
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/google/periph/conn/gpio"
+	"github.com/google/periph/conn/i2c"
+)
+
+// IO registers the I/O that happened on either a real or fake I²C bus.
+type IO struct {
+	Addr  uint16
+	Write []byte
+	Read  []byte
+}
+
+// Record implements i2c.Conn that records everything written to it.
+//
+// This can then be used to feed to Playback to do "replay" based unit tests.
+type Record struct {
+	sync.Mutex
+	Conn i2c.Conn // Conn can be nil if only writes are being recorded.
+	Ops  []IO
+}
+
+func (r *Record) String() string {
+	return "record"
+}
+
+// Tx implements i2c.Conn.
+func (r *Record) Tx(addr uint16, w, read []byte) error {
+	r.Lock()
+	defer r.Unlock()
+	if r.Conn == nil {
+		if len(read) != 0 {
+			return errors.New("read unsupported when no bus is connected")
+		}
+	} else {
+		if err := r.Conn.Tx(addr, w, read); err != nil {
+			return err
+		}
+	}
+	io := IO{Addr: addr, Write: make([]byte, len(w))}
+	if len(read) != 0 {
+		io.Read = make([]byte, len(read))
+	}
+	copy(io.Write, w)
+	copy(io.Read, read)
+	r.Ops = append(r.Ops, io)
+	return nil
+}
+
+// Speed implements i2c.Conn.
+func (r *Record) Speed(hz int64) error {
+	if r.Conn != nil {
+		return r.Conn.Speed(hz)
+	}
+	return nil
+}
+
+// SCL implements i2c.Pins.
+func (r *Record) SCL() gpio.PinIO {
+	if p, ok := r.Conn.(i2c.Pins); ok {
+		return p.SCL()
+	}
+	return gpio.INVALID
+}
+
+// SDA implements i2c.Pins.
+func (r *Record) SDA() gpio.PinIO {
+	if p, ok := r.Conn.(i2c.Pins); ok {
+		return p.SDA()
+	}
+	return gpio.INVALID
+}
+
+// Playback implements i2c.Conn and plays back a recorded I/O flow.
+//
+// While "replay" type of unit tests are of limited value, they still present
+// an easy way to do basic code coverage.
+type Playback struct {
+	sync.Mutex
+	Ops []IO
+}
+
+func (p *Playback) String() string {
+	return "playback"
+}
+
+// Close implements i2c.ConnCloser.
+func (p *Playback) Close() error {
+	p.Lock()
+	defer p.Unlock()
+	if len(p.Ops) != 0 {
+		return fmt.Errorf("expected playback to be empty:\n%#v", p.Ops)
+	}
+	return nil
+}
+
+// Tx implements i2c.Conn.
+func (p *Playback) Tx(addr uint16, w, r []byte) error {
+	p.Lock()
+	defer p.Unlock()
+	if len(p.Ops) == 0 {
+		// log.Fatal() ?
+		return errors.New("unexpected Tx()")
+	}
+	if addr != p.Ops[0].Addr {
+		return fmt.Errorf("unexpected addr %d != %d", addr, p.Ops[0].Addr)
+	}
+	if !bytes.Equal(p.Ops[0].Write, w) {
+		return fmt.Errorf("unexpected write %#v != %#v", w, p.Ops[0].Write)
+	}
+	if len(p.Ops[0].Read) != len(r) {
+		return fmt.Errorf("unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
+	}
+	copy(r, p.Ops[0].Read)
+	p.Ops = p.Ops[1:]
+	return nil
+}
+
+// Speed implements i2c.Conn.
+func (p *Playback) Speed(hz int64) error {
+	return nil
+}
+
+var _ i2c.Conn = &Record{}
+var _ i2c.Pins = &Record{}
+var _ i2c.Conn = &Playback{}

--- a/experimental/devices/ds18b20/dev.go
+++ b/experimental/devices/ds18b20/dev.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ds18b20
+
+import (
+	"errors"
+
+	"github.com/google/periph/devices"
+	"github.com/google/periph/experimental/conn/onewire"
+)
+
+// Dev is a handle to a Dallas Semi / Maxim DS18B20 temperature sensor on a 1-wire bus.
+type Dev struct {
+	onewire    onewire.Dev // device on 1-wire bus
+	resolution int         // resolution in bits (9..12)
+}
+
+// Temperature performs a conversion and returns the temperature.
+func (d *Dev) Temperature() (devices.Celsius, error) {
+	if err := d.onewire.TxPup([]byte{0x44}, nil); err != nil {
+		return 0, err
+	}
+	conversionSleep(d.resolution)
+	return d.LastTemp()
+}
+
+// TemperatureFloat performs a conversion and returns the temperature.
+func (d *Dev) TemperatureFloat() (float64, error) {
+	t, err := d.Temperature()
+	if err != nil {
+		return 0.0, err
+	}
+	return t.Float64(), nil
+}
+
+// LastTemp reads the temperature resulting from the last conversion from the device.
+// It is useful in combination with ConvertAll.
+func (d *Dev) LastTemp() (devices.Celsius, error) {
+	// Read the scratchpad memory.
+	spad := make([]byte, 9)
+	if err := d.onewire.Tx([]byte{0xbe}, spad); err != nil {
+		return 0, err
+	}
+
+	// Check the scratchpad CRC.
+	if !onewire.CheckCRC(spad) {
+		return 0, errors.New("incorrect DS18B20 scratchpad CRC")
+	}
+
+	// spad[1] is MSB, spad[0] is LSB and has 4 fractional bits. Need to do sign extension
+	// multiply by 1000 to get devices.Millis, divide by 16 due to 4 fractional bits.
+	// Datasheet p.4.
+	return (devices.Celsius(int8(spad[1]))<<8 + devices.Celsius(spad[0])) * 1000 / 16, nil
+}
+
+// LastTempFloat reads the temperature resulting from the last conversion from the device.
+// It is useful in combination with ConvertAll.
+func (d *Dev) LastTempFloat() (float64, error) {
+	t, err := d.LastTemp()
+	if err != nil {
+		return 0.0, err
+	}
+	return t.Float64(), nil
+}

--- a/experimental/devices/ds18b20/ds18b20.go
+++ b/experimental/devices/ds18b20/ds18b20.go
@@ -1,0 +1,81 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package ds18b20 interfaces to Dallas Semi / Maxim 1-wire temperature sensors.
+//
+// Datasheet
+//
+// https://datasheets.maximintegrated.com/en/ds/DS18B20-PAR.pdf
+package ds18b20
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/periph/experimental/conn/onewire"
+)
+
+// New returns an object that communicates over 1-wire to the DS18B20 sensor with the
+// specified 64-bit address (the device code is the least significant byte).
+//
+// resolutionBits must be in the range 9..12 and determines how many bits of precision
+// the readings have. The resolution affects the conversion time: 9bits:94ms, 10bits:188ms,
+// 11bits:375ms, 12bits:750ms.
+// A resolution of 10 bits icorresponds to 0.25C and tends to be a good compromise between
+// conversion time and the device's inherent accuracy of +/-0.5C.
+func New(o onewire.Conn, addr uint64, resolutionBits int) (*Dev, error) {
+	if resolutionBits < 9 || resolutionBits > 12 {
+		return nil, errors.New("invalid resolutionBits")
+	}
+
+	d := &Dev{onewire: onewire.Dev{Conn: o, Addr: addr}, resolution: resolutionBits}
+
+	// Start by reading the scratchpad memory, this will tell us whether we can talk to the
+	// device correctly and also how it's configured.
+	spad := make([]byte, 9)
+	if err := d.onewire.Tx([]byte{0xbe}, spad); err != nil {
+		return nil, err
+	}
+
+	// Check the scratchpad CRC.
+	if !onewire.CheckCRC(spad) {
+		fmt.Fprintf(os.Stderr, "Bad CRC: %#x != %#x %+v\n",
+			onewire.CalcCRC(spad[0:8]), spad[8], spad)
+		return nil, errors.New("incorrect DS18B20 scratchpad CRC")
+	}
+
+	// Change the resolution, if necessary (datasheet p.6).
+	if int(spad[4]>>5) != resolutionBits-9 {
+		// Set the value in the configuration register.
+		d.onewire.Tx([]byte{0x4e, 0, 0, byte((resolutionBits-9)<<5) | 0x1f}, nil)
+		// Copy the scratchpad to EEPROM to save the values.
+		d.onewire.TxPup([]byte{0x48}, nil)
+		// Wait for the write to complete
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return d, nil
+}
+
+// ConvertAll performs a conversion on all DS18B20 devices on the bus.
+//
+// During the conversion it places the bus in strong pull-up mode to power parasitic devices and
+// returns when the conversions have completed. This time period is determined by the maximum
+// resolution of all devices on the bus and must be provided.
+func ConvertAll(o onewire.Conn, maxResolutionBits int) error {
+	if maxResolutionBits < 9 || maxResolutionBits > 12 {
+		return errors.New("invalid maxResolutionBits")
+	}
+	o.AllPup([]byte{0x44})
+	conversionSleep(maxResolutionBits)
+	return nil
+}
+
+// conversionSleep sleeps for the time a conversion takes, whcih depends on the resolution:
+// 9bits:94ms, 10bits:188ms, 11bits:376ms, 12bits:752ms, datasheet p.6.
+func conversionSleep(bits int) {
+	time.Sleep((94 << uint(bits-9)) * time.Millisecond)
+}

--- a/experimental/devices/ds18b20/ds18b20_test.go
+++ b/experimental/devices/ds18b20/ds18b20_test.go
@@ -1,0 +1,130 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ds18b20
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/periph/conn/i2c"
+	"github.com/google/periph/experimental/conn/onewire"
+	"github.com/google/periph/experimental/devices/ds248x"
+	"github.com/google/periph/host"
+)
+
+func TestMain(m *testing.M) {
+	host.Init()
+	os.Exit(m.Run())
+}
+
+func initOnewire(t *testing.T) onewire.Conn {
+	bus, err := i2c.New(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ow, err := ds248x.NewI2C(bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ow
+}
+
+func TestInit(t *testing.T) {
+	ow := initOnewire(t)
+	// Search on the bus and expect two temperature sensors.
+	addrs, err := ow.Search(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("found %d 1-wire devices, expected 2", len(addrs))
+	}
+	for _, a := range addrs {
+		if a&0xff != 0x28 {
+			t.Fatalf("found family %#x, expected 0x28 (DS18B20)", a&0xff)
+		}
+	}
+	// Init each sensor.
+	sens := make([]*Dev, len(addrs))
+	for i := range addrs {
+		sens[i], err = New(ow, addrs[i], 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Run a conversion on all sensors.
+	err = ConvertAll(ow, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Read the temperatures and expect them to be within 5 degrees of one-another.
+	temp0 := 0.0
+	for _, s := range sens {
+		temp, err := s.LastTempFloat()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if temp < 10 || temp > 40 {
+			t.Errorf("Invalid temperature: %f", temp)
+		}
+		if temp0 > 1 && (temp-temp0 > 5 || temp-temp0 < -5) {
+			t.Errorf("Large temperature discrepancy: %f vs %f", temp0, temp)
+		}
+		temp0 = temp
+	}
+}
+
+/* foo
+func TestRead(t *testing.T) {
+	// This data was generated with "bme280 -r"
+	bus := i2ctest.Playback{
+		Ops: []i2ctest.IO{
+			// Chipd ID detection.
+			{Addr: 0x76, Write: []byte{0xd0}, Read: []byte{0x60}},
+			// Calibration data.
+			{
+				Addr:  0x76,
+				Write: []byte{0x88},
+				Read:  []byte{0x10, 0x6e, 0x6c, 0x66, 0x32, 0x0, 0x5d, 0x95, 0xb8, 0xd5, 0xd0, 0xb, 0x77, 0x1e, 0x9d, 0xff, 0xf9, 0xff, 0xac, 0x26, 0xa, 0xd8, 0xbd, 0x10, 0x0, 0x4b},
+			},
+			// Calibration data.
+			{Addr: 0x76, Write: []byte{0xe1}, Read: []byte{0x6e, 0x1, 0x0, 0x13, 0x5, 0x0, 0x1e}},
+			// Configuration.
+			{Addr: 0x76, Write: []byte{0xf4, 0x6c, 0xf2, 0x3, 0xf5, 0xe0, 0xf4, 0x6f}, Read: nil},
+			// Read.
+			{Addr: 0x76, Write: []byte{0xf7}, Read: []byte{0x4a, 0x52, 0xc0, 0x80, 0x96, 0xc0, 0x7a, 0x76}},
+		},
+	}
+	dev, err := NewI2C(&bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := devices.Environment{}
+	if err := dev.Sense(&env); err != nil {
+		t.Fatalf("Sense(): %v", err)
+	}
+	if env.Temperature != 23720 {
+		t.Fatalf("temp %d", env.Temperature)
+	}
+	if env.Pressure != 100943 {
+		t.Fatalf("pressure %d", env.Pressure)
+	}
+	if env.Humidity != 6531 {
+		t.Fatalf("humidity %d", env.Humidity)
+	}
+}
+
+func Example() {
+	bus, err := i2c.New(-1)
+	if err != nil {
+		log.Fatalf("failed to open I²C: %v", err)
+	}
+	defer bus.Close()
+	dev, err := NewI2C(bus, nil)
+	if err != nil {
+		log.Fatalf("failed to initialize ds2483: %v", err)
+	}
+}
+*/

--- a/experimental/devices/ds248x/dev.go
+++ b/experimental/devices/ds248x/dev.go
@@ -1,0 +1,202 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ds248x
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/periph/conn"
+)
+
+// Dev is a handle to a ds248x device and it implements the onewire.Conn interface.
+//
+// Dev implements a persistent error model: if a fatal error is encountered it places
+// itself into an error state and immediately returns the last error on all subsequent
+// calls. A fresh Dev, which reinitializes the hardware, must be created to proceed.
+//
+// A persistent error is only set when there is a problem with the ds248x device itself
+// (or the I²C bus used to access it). Errors on the 1-wire bus do not cause persistent
+// errors and implement the Temporary interface to indicate this fact.
+type Dev struct {
+	i2c      conn.Conn     // i2c device handle for the ds248x
+	isDS2483 bool          // true: ds2483, false: ds2482-100
+	confReg  byte          // value written to configuration register
+	tReset   time.Duration // time to perform a 1-wire reset
+	tSlot    time.Duration // time to perform a 1-bit 1-wire read/write
+	err      error         // persistent error, device will no longer operate
+}
+
+// OneWireBusError holds an error encountered on the 1-wire bus itself (as opposed
+// to an error with the ds248x device). These errors are temporary, i.e. the ds248x
+// can continue to be used.
+type OneWireBusError string
+
+// Temporary returns true.
+func (e OneWireBusError) Temporary() bool { return true }
+
+// Error implements the error interface.
+func (e OneWireBusError) Error() string { return string(e) }
+
+type Temporary interface {
+	Temporary() bool // true if the ds248x Dev can continue to be used
+}
+
+// Tx performs a "match ROM" command on the bus, which selects at most
+// one device and then transmits and receives the specified bytes.
+func (d *Dev) Tx(addr uint64, w, r []byte) error {
+	return d.tx(addr, w, r, false)
+}
+
+// TxPup performs a "match ROM" command on the bus, which selects at most
+// one device, then transmits and receives the specified bytes, and finally
+// turns on a strong pull-up to power devices on the bus.
+func (d *Dev) TxPup(addr uint64, w, r []byte) error {
+	return d.tx(addr, w, r, true)
+}
+
+// All performs a "skip ROM" command on the bus, which selects all devices,
+// and then transmits the specified bytes.
+func (d *Dev) All(w []byte) error {
+	return d.all(w, false)
+}
+
+// AllPup performs a "skip ROM" command on the bus, which selects all devices,
+// then transmits the specified bytes, and finally
+// turns on a strong pull-up to power devices on the bus.
+func (d *Dev) AllPup(w []byte) error {
+	return d.all(w, true)
+}
+
+// tx performs a "match ROM" command on the bus, which selects at most
+// one device and then transmits and receives the specified bytes.
+func (d *Dev) tx(addr uint64, w, r []byte, pup bool) error {
+	// Issue 1-wire bus reset.
+	if present, err := d.reset(); err != nil {
+		return err
+	} else if !present {
+		return OneWireBusError("1-wire: no device present")
+	}
+
+	// Issue ROM match command to select the device followed by the bytes being
+	// written, we then switch to reading.
+	ww := make([]byte, 9, len(w)+9)
+	ww[0] = 0x55 // Match ROM
+	ww[1] = byte(addr >> 0)
+	ww[2] = byte(addr >> 8)
+	ww[3] = byte(addr >> 16)
+	ww[4] = byte(addr >> 24)
+	ww[5] = byte(addr >> 32)
+	ww[6] = byte(addr >> 40)
+	ww[7] = byte(addr >> 48)
+	ww[8] = byte(addr >> 56)
+	ww = append(ww, w...)
+	for i, b := range ww {
+		if pup && i == len(ww)-1 && len(r) == 0 {
+			// This is the last byte, need to activate strong-pull-up
+			d.i2cTx([]byte{cmdWriteConfig, d.confReg&0xbf | 0x4}, nil)
+		}
+		d.i2cTx([]byte{cmd1WWrite, b}, nil)
+		d.waitIdle(7 * d.tSlot)
+	}
+
+	// Now read bytes from one-wire bus
+	for i, _ := range r {
+		if pup && i == len(r)-1 {
+			// This is the last byte, need to activate strong-pull-up
+			d.i2cTx([]byte{cmdWriteConfig, d.confReg&0xbf | 0x4}, nil)
+		}
+		d.i2cTx([]byte{cmd1WRead}, r[i:i+1])
+		d.waitIdle(7 * d.tSlot)
+		d.i2cTx([]byte{cmdSetReadPtr, regRDR}, r[i:i+1])
+	}
+
+	return d.err
+}
+
+func (d *Dev) all(w []byte, pup bool) error {
+	// Issue 1-wire bus reset.
+	if present, err := d.reset(); err != nil {
+		return err
+	} else if !present {
+		return OneWireBusError("1-wire: no device present")
+	}
+
+	// Issue Skip ROM command to select all devices followed by the bytes being written.
+	ww := make([]byte, 1, len(w)+1)
+	ww[0] = 0xCC // Skip ROM
+	ww = append(ww, w...)
+	for i, b := range ww {
+		if pup && i == len(ww)-1 {
+			// This is the last byte, need to activate strong-pull-up
+			d.i2cTx([]byte{cmdWriteConfig, d.confReg&0xbf | 0x4}, nil)
+		}
+		d.i2cTx([]byte{cmd1WWrite, b}, nil)
+		d.waitIdle(7 * d.tSlot)
+	}
+
+	return d.err
+}
+
+// reset issues a reset signal on the 1-wire bus and returns true if any device responded with a
+// presence pulse.
+func (d *Dev) reset() (bool, error) {
+	// Issue reset.
+	d.i2cTx([]byte{cmd1WReset}, nil)
+
+	// Wait for reset to complete.
+	status := d.waitIdle(d.tReset)
+	if d.err != nil {
+		return false, d.err
+	}
+	// Detect bus short and turn into 1-wire error
+	if (status & 4) != 0 {
+		return false, OneWireBusError("1-wire: bus has a short")
+	}
+	return (status & 2) != 0, nil
+}
+
+// i2cTx is a helper function to call i2c.Tx and handle the error by persisting it.
+func (d *Dev) i2cTx(w, r []byte) {
+	if d.err != nil {
+		return
+	}
+	if err := d.i2c.Tx(w, r); err != nil {
+		d.err = err
+	}
+}
+
+// waitIdle waits for the one wire bus to be idle.
+//
+// It initially sleeps for the delay and then polls the status register and sleeps for a tenth of
+// the delay each time the status register indicates that the bus is still busy. The last read
+// status byte is returned. An overall timeout of 3ms is applied to the whole procedure.  waitIdle
+// uses the persistent error model and returns 0 if there is an error.
+func (d *Dev) waitIdle(delay time.Duration) byte {
+	if d.err != nil {
+		return 0
+	}
+	// Overall timeout.
+	tOut := time.Now().Add(3 * time.Millisecond)
+	time.Sleep(delay)
+	for {
+		// Read status register.
+		var status [1]byte
+		d.i2cTx(nil, status[:])
+		// If bus idle complete, return status.
+		// No explicit error check needed here because status[0]==0 on error.
+		if (status[0] & 1) == 0 {
+			return status[0]
+		}
+		// If we're timing out return error. This is an error with the ds248x, not with
+		// devices on the 1-wire bus, hence it is persistent.
+		if time.Now().After(tOut) {
+			d.err = fmt.Errorf("ds248x: timeout waiting for ds248x to finish bus cycle")
+			return 0
+		}
+		// Try not to hog the kernel thread.
+		time.Sleep(delay / 10)
+	}
+}

--- a/experimental/devices/ds248x/ds248x.go
+++ b/experimental/devices/ds248x/ds248x.go
@@ -1,0 +1,166 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package ds248x controls a Maxim DS2483 or DS2482-100 1-wire interface chip over I²C.
+//
+// Datasheets
+//
+// https://www.maximintegrated.com/en/products/digital/one-wire/DS2483.html
+//
+// https://www.maximintegrated.com/en/products/interface/controllers-expanders/DS2482-100.html
+package ds248x
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/periph/conn/i2c"
+)
+
+// PupOhm controls the strength of the passive pull-up resistor
+// on the 1-wire data line. The default value is 1000 Ohm.
+type PupOhm uint8
+
+const (
+	R500Ohm  = 4 // 500 Ohm passive pull-up resistor
+	R1000Ohm = 6 // 1000 Ohm passive pull-up resistor
+)
+
+// Opts contains optional options to pass to the constructor.
+type Opts struct {
+	Address       uint16 // I2C address: must be 0x18 for a ds2483
+	PassivePullup bool   // false:use active pull-up, true: disable active pullup
+
+	// The following options are only available on the ds2483 (not ds2482-100).
+	// The actual value used is the closest possible value (rounded up or down).
+	ResetLowUs       int    // reset low time in us, range 440..740
+	PresenceDetectUs int    // presence detect sample time in us, range 58..76
+	Write0LowUs      int    // write zero low time in us, range 52..70
+	Write0RecoveryNs int    // write zero recovery time in ns, range 2750..25250
+	PullupRes        PupOhm // passive pull-up resistance, true: 500ohm, false: 1kohm
+}
+
+// NewI2C returns an object that communicates over I²C to the DS2482/DS2483 controller.
+func NewI2C(i i2c.Conn, opts *Opts) (*Dev, error) {
+	addr := uint16(0x18)
+	if opts != nil {
+		switch opts.Address {
+		case 0x18, 0x19:
+			addr = opts.Address
+		case 0x00:
+			// do not do anything
+		default:
+			return nil, errors.New("given address not supported by device")
+		}
+	}
+	d := &Dev{i2c: &i2c.Dev{Conn: i, Addr: addr}}
+	if err := d.makeDev(opts); err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+// defaults holds default values for optional parameters.
+var defaults = Opts{
+	PassivePullup:    false,
+	ResetLowUs:       560,
+	PresenceDetectUs: 68,
+	Write0LowUs:      64,
+	Write0RecoveryNs: 5250,
+	PullupRes:        R1000Ohm,
+}
+
+func (d *Dev) makeDev(opts *Opts) error {
+	// Doctor the opts to apply default values.
+	if opts == nil {
+		opts = &defaults
+	}
+	if opts.ResetLowUs == 0 {
+		opts.ResetLowUs = defaults.ResetLowUs
+	}
+	if opts.PresenceDetectUs == 0 {
+		opts.PresenceDetectUs = defaults.PresenceDetectUs
+	}
+	if opts.Write0LowUs == 0 {
+		opts.Write0LowUs = defaults.Write0LowUs
+	}
+	if opts.Write0RecoveryNs == 0 {
+		opts.Write0RecoveryNs = defaults.Write0RecoveryNs
+	}
+	if opts.PullupRes == 0 {
+		opts.PullupRes = defaults.PullupRes
+	}
+	d.tReset = time.Duration(2*opts.ResetLowUs) * microsecond
+	d.tSlot = time.Duration(1000*opts.Write0LowUs + opts.Write0RecoveryNs)
+
+	// Issue a reset command.
+	if err := d.i2c.Tx([]byte{cmdReset}, nil); err != nil {
+		return fmt.Errorf("%s while resetting ds248x", err)
+	}
+
+	// Read the status register to confirm that we have a responding ds248x
+	stat := make([]byte, 1)
+	if err := d.i2c.Tx([]byte{cmdSetReadPtr, regStatus}, stat); err != nil {
+		return fmt.Errorf("%s while reading ds248x status register", err)
+	}
+	if stat[0] != 0x18 {
+		return fmt.Errorf("invalid ds248x status register value: %#x, expected 0x18\n", stat[0])
+	}
+
+	// Write the device configuration register to get the chip out of reset state, immediately
+	// read it back to get confirmation.
+	d.confReg = 0xe1 // standard-speed, no strong pullup, no powerdown, active pull-up
+	if opts.PassivePullup {
+		d.confReg ^= 0x11
+	}
+	dcr := make([]byte, 1)
+	if err := d.i2c.Tx([]byte{cmdWriteConfig, d.confReg}, dcr); err != nil {
+		return fmt.Errorf("%s while writing ds248x device config register", err)
+	}
+	// When reading back we only get the bottom nibble
+	if dcr[0] != d.confReg&0x0f {
+		return fmt.Errorf("failure to write device config register, wrote %#x got %#x back",
+			d.confReg, dcr[0])
+	}
+
+	// Set the read ptr to the port configuration register to determine whether we have a
+	// ds2483 vs ds2482-100. This will fail on the ds2482-100.
+	d.isDS2483 = d.i2c.Tx([]byte{cmdSetReadPtr, regPCR}, nil) == nil
+
+	// Set the options for the ds2483.
+	if d.isDS2483 {
+		buf := []byte{cmdAdjPort,
+			byte(0x00 + ((opts.ResetLowUs - 430) / 20 & 0x0f)),
+			byte(0x20 + ((opts.PresenceDetectUs - 55) / 2 & 0x0f)),
+			byte(0x40 + ((opts.Write0LowUs - 51) / 2 & 0x0f)),
+			byte(0x60 + (((opts.Write0RecoveryNs-1250)/2500 + 5) & 0x0f)),
+			byte(0x80 + (opts.PullupRes & 0x0f)),
+		}
+		if err := d.i2c.Tx(buf, nil); err != nil {
+			return fmt.Errorf("%s while setting ds2483 port config values", err)
+		}
+	}
+
+	return nil
+}
+
+const (
+	microsecond = 1000 * time.Nanosecond
+
+	cmdReset       = 0xf0 // reset ds248x
+	cmdSetReadPtr  = 0xe1 // set the read pointer
+	cmdWriteConfig = 0xd2 // write the device configuration
+	cmdAdjPort     = 0xc3 // adjust 1-wire port
+	cmd1WReset     = 0xb4 // reset the 1-wire bus
+	cmd1WBit       = 0x87 // perform a single-bit transaction on the 1-wire bus
+	cmd1WWrite     = 0xa5 // perform a byte write on the 1-wire bus
+	cmd1WRead      = 0x96 // perform a byte read on the 1-wire bus
+	cmd1WTriplet   = 0x78 // perform a triplet operation (2 bit reads, a bit write)
+
+	regDCR    = 0xc3 // read ptr for device configuration register
+	regStatus = 0xf0 // read ptr for status register
+	regRDR    = 0xe1 // read ptr for read-data register
+	regPCR    = 0xb4 // read ptr for port configuration register
+)

--- a/experimental/devices/ds248x/ds248x_test.go
+++ b/experimental/devices/ds248x/ds248x_test.go
@@ -1,0 +1,82 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ds248x
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/periph/conn/i2c"
+	"github.com/google/periph/host"
+)
+
+func TestMain(m *testing.M) {
+	host.Init()
+	os.Exit(m.Run())
+}
+
+func TestInit(t *testing.T) {
+	bus, err := i2c.New(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewI2C(bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+/* foo
+func TestRead(t *testing.T) {
+	// This data was generated with "bme280 -r"
+	bus := i2ctest.Playback{
+		Ops: []i2ctest.IO{
+			// Chipd ID detection.
+			{Addr: 0x76, Write: []byte{0xd0}, Read: []byte{0x60}},
+			// Calibration data.
+			{
+				Addr:  0x76,
+				Write: []byte{0x88},
+				Read:  []byte{0x10, 0x6e, 0x6c, 0x66, 0x32, 0x0, 0x5d, 0x95, 0xb8, 0xd5, 0xd0, 0xb, 0x77, 0x1e, 0x9d, 0xff, 0xf9, 0xff, 0xac, 0x26, 0xa, 0xd8, 0xbd, 0x10, 0x0, 0x4b},
+			},
+			// Calibration data.
+			{Addr: 0x76, Write: []byte{0xe1}, Read: []byte{0x6e, 0x1, 0x0, 0x13, 0x5, 0x0, 0x1e}},
+			// Configuration.
+			{Addr: 0x76, Write: []byte{0xf4, 0x6c, 0xf2, 0x3, 0xf5, 0xe0, 0xf4, 0x6f}, Read: nil},
+			// Read.
+			{Addr: 0x76, Write: []byte{0xf7}, Read: []byte{0x4a, 0x52, 0xc0, 0x80, 0x96, 0xc0, 0x7a, 0x76}},
+		},
+	}
+	dev, err := NewI2C(&bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env := devices.Environment{}
+	if err := dev.Sense(&env); err != nil {
+		t.Fatalf("Sense(): %v", err)
+	}
+	if env.Temperature != 23720 {
+		t.Fatalf("temp %d", env.Temperature)
+	}
+	if env.Pressure != 100943 {
+		t.Fatalf("pressure %d", env.Pressure)
+	}
+	if env.Humidity != 6531 {
+		t.Fatalf("humidity %d", env.Humidity)
+	}
+}
+
+func Example() {
+	bus, err := i2c.New(-1)
+	if err != nil {
+		log.Fatalf("failed to open I²C: %v", err)
+	}
+	defer bus.Close()
+	dev, err := NewI2C(bus, nil)
+	if err != nil {
+		log.Fatalf("failed to initialize ds2483: %v", err)
+	}
+}
+*/

--- a/experimental/devices/ds248x/search.go
+++ b/experimental/devices/ds248x/search.go
@@ -1,0 +1,122 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ds248x
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/google/periph/experimental/conn/onewire"
+)
+
+// Search performs a "search" cycle on the 1-wire bus and returns
+// the addresses of all devices on the bus if alarmOnly is false and of all devices in
+// alarm state if alarmOnly is true.
+//
+// The addresses are returned as 64-bit integers with the family code in the lower byte and the CRC
+// byte in the top byte.
+//
+// If an error occurs during the search the already-discovered devices are returned with the error.
+//
+// For a description of the search algorithm, see Maxim's AppNote 187
+// https://www.maximintegrated.com/en/app-notes/index.mvp/id/187
+func (d *Dev) Search(alarmOnly bool) ([]uint64, error) {
+	// Loop to do the search. Each iteration detects one device
+	var devices []uint64  // devices we're finding
+	lastDiscrepancy := -1 // how far we need to repeat the same ID in the next iteration
+	var lastDevice uint64 // ID of last device found
+	for {
+		// Reset the bus and if there is no device present (or an error) just return.
+		if present, err := d.reset(); !present {
+			return nil, err
+		}
+
+		// Issue a search command.
+		cmd := byte(0xf0) // plain search
+		if alarmOnly {
+			cmd = 0xec // alarm search
+		}
+		d.i2cTx([]byte{cmd1WWrite, cmd}, nil)
+		d.waitIdle(8 * d.tSlot)
+
+		// Loop to accumulate the 64 bits of an ID.
+		discrepancy := -1   // how far we need to repeat the same ID in this iteration
+		var device uint64   // ID of current device
+		var idBytes [8]byte // ID of device as bytes
+		for bit := 0; bit < 64; bit++ {
+			//fmt.Fprintf(os.Stderr, "*** bit loop %d\n", bit)
+			// Decide which direction to search into: 0 or 1.
+			var dir byte
+			if bit < lastDiscrepancy {
+				// We haven't reached the last discrepancy yet, so we need to
+				// repeat the bits of the last device.
+				dir = byte((lastDevice >> uint8(bit)) & 1)
+			} else if bit == lastDiscrepancy {
+				// We reached the bit where we picked 0 last time and now we need 1.
+				dir = 1
+			}
+
+			// Perform triplet operation and do an explicit error check so we abort the
+			// search on error.
+			status := d.searchTriplet(dir)
+			if d.err != nil {
+				return devices, d.err
+			}
+			gotZero := (status & 0x20) == 0 // some device with 0 in its ID responded
+			gotOne := (status & 0x40) == 0  // some device with 1 in its ID responded
+			taken := status >> 7            // direction taken
+
+			// Check for the absence of devices on the bus. This is a 1-wire bus error
+			// condition and we return a partial result.
+			if !gotZero && !gotOne {
+				return devices,
+					OneWireBusError("1-wire: devices disappeared during search")
+			}
+
+			// Check whether we have devices responding for 0 and 1 and we picked 0.
+			if gotZero && gotOne && taken == 0 {
+				discrepancy = bit
+			}
+
+			// Shift a bit into the current device's ID
+			device = device | (uint64(taken) << uint(bit))
+
+			// If we got a full byte then save it for CRC calculation.
+			if bit&7 == 7 {
+				idBytes[bit>>3] = byte(device >> uint(bit-7))
+			}
+
+			//fmt.Fprintf(os.Stderr, "Bit %2d: dir=%d 0=%t 1=%t ID=%#x\n",
+			//	bit, dir, gotZero, gotOne, device)
+		}
+
+		// Verify the CRC and record device if we got it right.
+		if onewire.CheckCRC(idBytes[:]) {
+			devices = append(devices, device)
+			lastDevice = device
+			lastDiscrepancy = discrepancy
+			if lastDiscrepancy == -1 {
+				return devices, nil // we reached the last device
+			}
+		} else {
+			// CRC error: return partial result. This is a transient error.
+			fmt.Fprintf(os.Stderr, "CRC failed on %+v\n", idBytes)
+			return devices, OneWireBusError("1-wire CRC error during search")
+		}
+	}
+}
+
+// searchTriplet performs a single bit search triplet command on the bus, waits for it to complete
+// and returs the status register, which contains the result. It uses the persistent error model and
+// returns a status of 0 on error.
+func (d *Dev) searchTriplet(direction byte) byte {
+	// Send one-wire triplet command.
+	var dir byte
+	if direction != 0 {
+		dir = 0x80
+	}
+	d.i2cTx([]byte{cmd1WTriplet, dir}, nil)
+	return d.waitIdle(0 * d.tSlot) // in theory 3*tSlot but it's actually overlapped
+}

--- a/experimental/devices/ds248x/search_test.go
+++ b/experimental/devices/ds248x/search_test.go
@@ -1,0 +1,35 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ds248x
+
+import (
+	"testing"
+
+	"github.com/google/periph/conn/i2c"
+)
+
+const testDeviceID = uint64(0x3300000131892a28)
+
+func TestSearch(t *testing.T) {
+	bus, err := i2c.New(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dev, err := NewI2C(bus, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	devices, err := dev.Search(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(devices) != 1 {
+		t.Fatalf("search found %d devices, expected 1", len(devices))
+	}
+	if devices[0] != testDeviceID {
+		t.Errorf("found device %#x, expected %#x", devices[0], testDeviceID)
+	}
+}

--- a/host/odroid_c1/doc.go
+++ b/host/odroid_c1/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2016 The PIO Authors. All rights reserved.
+// Copyright 2016 The Periph Authors. All rights reserved.
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 


### PR DESCRIPTION
**DO NOT MERGE**

Add support for Dallas Semi (now Maxim Integrated) 1-wire bus using a ds2483 i2c bus adapter chip.
