### PR TITLE
Update periph.Type to reduce the type of drivers.

### DIFF
--- a/devices/lirc/lirc.go
+++ b/devices/lirc/lirc.go
@@ -216,7 +216,8 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	// Return the lowest priority, which is Functional.
+	// Use the lowest priority, which is Functional. This is because it looks for
+	// GPIO pin numbers.
 	return periph.Functional
 }
 

--- a/doc/apps/README.md
+++ b/doc/apps/README.md
@@ -204,7 +204,7 @@ import (
 type driver struct{}
 
 func (d *driver) String() string          { return "virtual_i2c" }
-func (d *driver) Type() periph.Type          { return periph.Bus }
+func (d *driver) Type() periph.Type       { return periph.Second }
 func (d *driver) Prerequisites() []string { return nil }
 
 func (d *driver) Init() (bool, error) {

--- a/experimental/driver_skeleton/driver_skeleton.go
+++ b/experimental/driver_skeleton/driver_skeleton.go
@@ -58,7 +58,7 @@ func (d *driver) String() string {
 
 func (d *driver) Type() periph.Type {
 	// FIXME: Change this to be the type of driver.
-	return periph.Device
+	return periph.Second
 }
 
 func (d *driver) Prerequisites() []string {

--- a/experimental/host/sysfs/uart.go
+++ b/experimental/host/sysfs/uart.go
@@ -116,7 +116,7 @@ func (d *driverUART) String() string {
 }
 
 func (d *driverUART) Type() periph.Type {
-	return periph.Bus
+	return periph.Second
 }
 
 func (d *driverUART) Init() (bool, error) {

--- a/experimental/host/usbbus/usbbus.go
+++ b/experimental/host/usbbus/usbbus.go
@@ -109,7 +109,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Bus
+	return periph.Root
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/allwinner/driver.go
+++ b/host/allwinner/driver.go
@@ -29,7 +29,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Processor
+	return periph.Root
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/allwinner_pl/allwinner_pl.go
+++ b/host/allwinner_pl/allwinner_pl.go
@@ -359,7 +359,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Processor
+	return periph.Root
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/bcm283x/bcm283x.go
+++ b/host/bcm283x/bcm283x.go
@@ -700,7 +700,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Processor
+	return periph.Root
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/chip/chip.go
+++ b/host/chip/chip.go
@@ -151,7 +151,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Pins
+	return periph.Functional
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/odroid_c1/c1.go
+++ b/host/odroid_c1/c1.go
@@ -102,7 +102,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Pins
+	return periph.Functional
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/pine64/pine64.go
+++ b/host/pine64/pine64.go
@@ -285,7 +285,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Pins
+	return periph.Functional
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -170,7 +170,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Type() periph.Type {
-	return periph.Pins
+	return periph.Functional
 }
 
 func (d *driver) Prerequisites() []string {

--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -343,8 +343,7 @@ func (d *driverGPIO) String() string {
 }
 
 func (d *driverGPIO) Type() periph.Type {
-	// It intentionally load later than processors.
-	return periph.Pins
+	return periph.Second
 }
 
 func (d *driverGPIO) Prerequisites() []string {

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -309,7 +309,7 @@ func (d *driverI2C) String() string {
 }
 
 func (d *driverI2C) Type() periph.Type {
-	return periph.Bus
+	return periph.Second
 }
 
 func (d *driverI2C) Prerequisites() []string {

--- a/host/sysfs/led.go
+++ b/host/sysfs/led.go
@@ -164,7 +164,7 @@ func (d *driverLED) String() string {
 }
 
 func (d *driverLED) Type() periph.Type {
-	return periph.Pins
+	return periph.Second
 }
 
 func (d *driverLED) Prerequisites() []string {

--- a/host/sysfs/spi.go
+++ b/host/sysfs/spi.go
@@ -218,7 +218,7 @@ func (d *driverSPI) String() string {
 }
 
 func (d *driverSPI) Type() periph.Type {
-	return periph.Bus
+	return periph.Second
 }
 
 func (d *driverSPI) Prerequisites() []string {

--- a/host/sysfs/thermal_sensor.go
+++ b/host/sysfs/thermal_sensor.go
@@ -122,7 +122,7 @@ func (d *driverThermalSensor) String() string {
 }
 
 func (d *driverThermalSensor) Type() periph.Type {
-	return periph.Device
+	return periph.Second
 }
 
 func (d *driverThermalSensor) Prerequisites() []string {

--- a/periph.go
+++ b/periph.go
@@ -39,22 +39,33 @@ import (
 
 // Type represent the type of driver.
 //
-// Lower is more important.
+// Drivers with a lower Type value are loaded first.
 type Type int
 
 const (
-	// Processor is the first driver to be loaded.
-	Processor Type = iota
-	// Pins is basic pin functionality driver, additional to Processor.
+	// Root is for a driver that directly describe hardware without an
+	// interfacing bus.
 	//
-	// This includes all headers description.
-	Pins
-	// Functional is for functionality pin driver, additional to Pins.
+	// It can be used for CPU drivers, USB hub, etc. These drivers require no
+	// assumption about the existence of previous drivers to be loaded.
+	Root Type = iota
+
+	// Second is for higher level features that leverage OS abstractions.
+	//
+	// These drivers implement that may build upon the previously loaded drivers
+	// or that may represent lower priority in term of usefulness compared to
+	// Root. This includes OS provided drivers like sysfs; a GPIO pin exposed by
+	// sysfs is less useful than one exposed by the native CPU driver, thus this
+	// is important that this driver is loaded later.
+	Second
+
+	// Functional is for higher level drivers.
+	//
+	// These drivers require all enumeration (USB devices, GPIO pins exposed over
+	// I²C, etc) to be already loaded. Board headers lookup table should use this
+	// category.
 	Functional
-	// Bus is higher level protocol drivers.
-	Bus
-	// Device is drivers connecting to buses.
-	Device
+
 	nbPriorities
 )
 

--- a/periph_test.go
+++ b/periph_test.go
@@ -46,13 +46,13 @@ func TestInitSimple(t *testing.T) {
 	initTest([]Driver{
 		&driver{
 			name:    "CPU",
-			t:       Processor,
+			t:       Root,
 			prereqs: nil,
 			ok:      true,
 			err:     nil,
 		},
 	})
-	if len(allDrivers[Processor]) != 1 {
+	if len(allDrivers[Root]) != 1 {
 		t.Fatalf("%v", allDrivers)
 	}
 	if len(byName) != 1 {
@@ -74,7 +74,7 @@ func TestInitSkip(t *testing.T) {
 	initTest([]Driver{
 		&driver{
 			name:    "CPU",
-			t:       Processor,
+			t:       Root,
 			prereqs: nil,
 			ok:      false,
 			err:     nil,
@@ -89,7 +89,7 @@ func TestInitErr(t *testing.T) {
 	initTest([]Driver{
 		&driver{
 			name:    "CPU",
-			t:       Processor,
+			t:       Root,
 			prereqs: nil,
 			ok:      true,
 			err:     errors.New("oops"),
@@ -104,14 +104,14 @@ func TestInitBadOrder(t *testing.T) {
 	initTest([]Driver{
 		&driver{
 			name:    "CPU",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"Board"},
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "Board",
-			t:       Pins,
+			t:       Functional,
 			prereqs: nil,
 			ok:      true,
 			err:     nil,
@@ -126,7 +126,7 @@ func TestInitMissing(t *testing.T) {
 	initTest([]Driver{
 		&driver{
 			name:    "CPU",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"Board"},
 			ok:      true,
 			err:     nil,
@@ -144,7 +144,7 @@ func TestRegisterLate(t *testing.T) {
 	}
 	d := &driver{
 		name:    "CPU",
-		t:       Processor,
+		t:       Root,
 		prereqs: nil,
 		ok:      true,
 		err:     nil,
@@ -158,7 +158,7 @@ func TestRegisterTwice(t *testing.T) {
 	reset()
 	d := &driver{
 		name:    "CPU",
-		t:       Processor,
+		t:       Root,
 		prereqs: nil,
 		ok:      true,
 		err:     nil,
@@ -175,7 +175,7 @@ func TestMustRegisterPanic(t *testing.T) {
 	reset()
 	d := &driver{
 		name:    "CPU",
-		t:       Processor,
+		t:       Root,
 		prereqs: nil,
 		ok:      true,
 		err:     nil,
@@ -199,7 +199,7 @@ func TestExplodeStagesSimple(t *testing.T) {
 	d := []Driver{
 		&driver{
 			name:    "CPU",
-			t:       Processor,
+			t:       Root,
 			prereqs: nil,
 			ok:      true,
 			err:     nil,
@@ -220,14 +220,14 @@ func TestExplodeStages1Dep(t *testing.T) {
 	d := []Driver{
 		&driver{
 			name:    "CPU-specialized",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"CPU-generic"},
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "CPU-generic",
-			t:       Processor,
+			t:       Root,
 			prereqs: nil,
 			ok:      true,
 			err:     nil,
@@ -244,14 +244,14 @@ func TestExplodeStagesDifferentType(t *testing.T) {
 	d := []Driver{
 		&driver{
 			name:    "CPU",
-			t:       Processor,
+			t:       Root,
 			prereqs: nil,
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "pins",
-			t:       Pins,
+			t:       Functional,
 			prereqs: []string{"CPU"},
 			ok:      true,
 			err:     nil,
@@ -272,21 +272,21 @@ func TestExplodeStagesCycle(t *testing.T) {
 	d := []Driver{
 		&driver{
 			name:    "A",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"B"},
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "B",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"C"},
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "C",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"A"},
 			ok:      true,
 			err:     nil,
@@ -307,28 +307,28 @@ func TestExplodeStages3Dep(t *testing.T) {
 	d := []Driver{
 		&driver{
 			name:    "base2",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"root"},
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "base1",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"root"},
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "root",
-			t:       Processor,
+			t:       Root,
 			prereqs: nil,
 			ok:      true,
 			err:     nil,
 		},
 		&driver{
 			name:    "super",
-			t:       Processor,
+			t:       Root,
 			prereqs: []string{"base1", "base2"},
 			ok:      true,
 			err:     nil,


### PR DESCRIPTION
Reducing the number of Type values improves parallelism.


The value names still do not make sense to me so help is appreciated here.