### PR TITLE
conn: Simplify Conn, rename i2c.Conn to i2c.Bus.

### DIFF
--- a/cmd/bme280/main.go
+++ b/cmd/bme280/main.go
@@ -131,9 +131,9 @@ func mainImpl() error {
 			printPin("SCL", p.SCL())
 			printPin("SDA", p.SDA())
 		}
-		var base i2c.Conn = bus
+		var base i2c.Bus = bus
 		if *record {
-			recorder.Conn = bus
+			recorder.Bus = bus
 			base = &recorder
 		}
 		if dev, err = bme280.NewI2C(base, &opts); err != nil {

--- a/cmd/i2c/main.go
+++ b/cmd/i2c/main.go
@@ -77,7 +77,7 @@ func mainImpl() error {
 	if p, ok := bus.(i2c.Pins); ok {
 		log.Printf("Using pins SCL: %s  SDA: %s", p.SCL(), p.SDA())
 	}
-	d := i2c.Dev{Conn: bus, Addr: uint16(*addr)}
+	d := i2c.Dev{Bus: bus, Addr: uint16(*addr)}
 	if *write {
 		_, err = d.Write(buf)
 	} else {

--- a/conn/conn.go
+++ b/conn/conn.go
@@ -4,11 +4,6 @@
 
 package conn
 
-import (
-	"fmt"
-	"io"
-)
-
 // Conn defines the interface for a connection on a point-to-point
 // communication channel.
 //
@@ -17,11 +12,12 @@ import (
 //
 // This is the lowest common denominator for all point-to-point communication
 // channels.
+//
+// Implementation are expected to also implement the following interfaces:
+// - fmt.Stringer which returns something meaningful to the user like "SPI0.1",
+//   "I2C1.76", "COM6", etc.
+// - io.Writer as an way to use io.Copy() on a write-only device.
 type Conn interface {
-	// Every connection has a name, e.g. "SPI0.1", "I2C1.76", "COM6", etc.
-	fmt.Stringer
-	// io.Writer can be used for a write-only device.
-	io.Writer
 	// Tx does a single transaction.
 	//
 	// For full duplex protocols (SPI, UART), the two buffers must have the same

--- a/conn/i2c/i2ctest/i2c_test.go
+++ b/conn/i2c/i2ctest/i2c_test.go
@@ -20,7 +20,7 @@ func TestDev(t *testing.T) {
 			},
 		},
 	}
-	d := i2c.Dev{Conn: &p, Addr: 23}
+	d := i2c.Dev{Bus: &p, Addr: 23}
 	v, err := d.ReadRegUint8(10)
 	if err != nil {
 		t.Fatal(err)

--- a/conn/spi/spi.go
+++ b/conn/spi/spi.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn"
 	"github.com/google/periph/conn/gpio"
 )
 
@@ -32,8 +31,12 @@ const (
 )
 
 // Conn defines the interface a concrete SPI driver must implement.
+//
+// It implements conn.Conn.
 type Conn interface {
-	conn.Conn
+	fmt.Stringer
+	io.Writer
+	Tx(w, r []byte) error
 	// Speed changes the bus speed.
 	Speed(hz int64) error
 	// Configure changes the communication parameters of the bus.

--- a/conn/uart/uart.go
+++ b/conn/uart/uart.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn"
 	"github.com/google/periph/conn/gpio"
 )
 
@@ -44,8 +43,12 @@ const (
 )
 
 // Conn defines the interface a concrete UART driver must implement.
+//
+// It implements conn.Conn.
 type Conn interface {
-	conn.Conn
+	fmt.Stringer
+	io.Writer
+	Tx(w, r []byte) error
 	// Speed changes the bus speed.
 	Speed(baud int64) error
 	// Configure changes the communication parameters of the bus.

--- a/devices/bme280/bme280.go
+++ b/devices/bme280/bme280.go
@@ -137,7 +137,7 @@ type Opts struct {
 //
 // It is recommended to call Stop() when done with the device so it stops
 // sampling.
-func NewI2C(i i2c.Conn, opts *Opts) (*Dev, error) {
+func NewI2C(b i2c.Bus, opts *Opts) (*Dev, error) {
 	addr := uint16(0x76)
 	if opts != nil {
 		switch opts.Address {
@@ -149,7 +149,7 @@ func NewI2C(i i2c.Conn, opts *Opts) (*Dev, error) {
 			return nil, errors.New("given address not supported by device")
 		}
 	}
-	d := &Dev{d: &i2c.Dev{Conn: i, Addr: addr}, isSPI: false}
+	d := &Dev{d: &i2c.Dev{Bus: b, Addr: addr}, isSPI: false}
 	if err := d.makeDev(opts); err != nil {
 		return nil, err
 	}
@@ -294,8 +294,7 @@ func (d *Dev) writeCommands(b []byte) error {
 			b[i] &^= 0x80
 		}
 	}
-	_, err := d.d.Write(b)
-	return err
+	return d.d.Tx(b, nil)
 }
 
 // Register table:

--- a/devices/ssd1306/ssd1306.go
+++ b/devices/ssd1306/ssd1306.go
@@ -88,8 +88,8 @@ func NewSPI(s spi.Conn, w, h int, rotated bool) (*Dev, error) {
 //
 // As per datasheet, maximum clock speed is 1/2.5µs = 400KHz. It's worth
 // bumping up from default bus speed of 100KHz if possible.
-func NewI2C(i i2c.Conn, w, h int, rotated bool) (*Dev, error) {
-	return newDev(&i2c.Dev{Conn: i, Addr: 0x3C}, w, h, rotated)
+func NewI2C(i i2c.Bus, w, h int, rotated bool) (*Dev, error) {
+	return newDev(&i2c.Dev{Bus: i, Addr: 0x3C}, w, h, rotated)
 }
 
 // newDev is the common initialization code that is independent of the bus

--- a/doc/apps/README.md
+++ b/doc/apps/README.md
@@ -14,7 +14,7 @@ host it is running on. It differentiates between drivers that _enable_
 functionality on the host and drivers for devices connected _to_ the host.
 
 Most micro computers expose at least some of the following:
-[I²C bus](https://godoc.org/github.com/google/periph/conn/i2c#Conn),
+[I²C bus](https://godoc.org/github.com/google/periph/conn/i2c#Bus),
 [SPI bus](https://godoc.org/github.com/google/periph/conn/spi#Conn),
 [gpio
 pins](https://godoc.org/github.com/google/periph/conn/gpio#PinIO),
@@ -127,10 +127,8 @@ func (a *adaptor) Close() error {
 
 ### I²C connection
 
-An
-[i2c.Conn](https://godoc.org/github.com/google/periph/conn/i2c#Conn)
-is **not** a
-[conn.Conn](https://godoc.org/github.com/google/periph/conn#Conn).
+An [i2c.Bus](https://godoc.org/github.com/google/periph/conn/i2c#Bus) is **not**
+a [conn.Conn](https://godoc.org/github.com/google/periph/conn#Conn).
 This is because an I²C bus is **not** a point-to-point connection but instead is
 a real bus where multiple devices can be connected simultaneously, like a USB
 bus. To create a point-to-point connection to a device which does implement
@@ -214,7 +212,7 @@ func (d *driver) Init() (bool, error) {
     if err := virtual_i2c.Load(); err != nil {
         return true, err
     }
-    err := i2c.Register("foo", 10, func() (i2c.ConnCloser, error) {
+    err := i2c.Register("foo", 10, func() (i2c.BusCloser, error) {
         // You may have to create a struct to convert the API:
         return virtual_i2c.Open()
     })

--- a/experimental/devices/bitbang/i2c.go
+++ b/experimental/devices/bitbang/i2c.go
@@ -35,12 +35,12 @@ func (i *I2C) String() string {
 	return fmt.Sprintf("bitbang/i2c(%s, %s)", i.scl, i.sda)
 }
 
-// Close implements i2c.ConnCloser.
+// Close implements i2c.BusCloser.
 func (i *I2C) Close() error {
 	return nil
 }
 
-// Tx implements i2c.Conn.
+// Tx implements i2c.Bus.
 func (i *I2C) Tx(addr uint16, w, r []byte) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -88,7 +88,7 @@ func (i *I2C) Tx(addr uint16, w, r []byte) error {
 	return nil
 }
 
-// Speed implements i2c.Conn.
+// Speed implements i2c.Bus.
 func (i *I2C) Speed(hz int64) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -254,4 +254,4 @@ func (i *I2C) sleepHalfCycle() {
 	host.Nanospin(i.halfCycle)
 }
 
-var _ i2c.Conn = &I2C{}
+var _ i2c.Bus = &I2C{}

--- a/experimental/driver_skeleton/driver_skeleton.go
+++ b/experimental/driver_skeleton/driver_skeleton.go
@@ -22,8 +22,8 @@ type Dev struct {
 }
 
 // New opens a handle to the device. FIXME.
-func New(i i2c.Conn) (*Dev, error) {
-	d := &Dev{&i2c.Dev{Conn: i, Addr: 42}}
+func New(i i2c.Bus) (*Dev, error) {
+	d := &Dev{&i2c.Dev{Bus: i, Addr: 42}}
 	// FIXME: Simulate a setup dance.
 	var b [2]byte
 	if err := d.c.Tx([]byte("in"), b[:]); err != nil {

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -123,7 +123,7 @@ func (i *I2C) Tx(addr uint16, w, r []byte) error {
 	return i.ioctl(ioctlRdwr, pp)
 }
 
-// Speed implements i2c.Conn.
+// Speed implements i2c.Bus.
 func (i *I2C) Speed(hz int64) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
@@ -334,7 +334,7 @@ func (d *driverI2C) Init() (bool, error) {
 		if err != nil {
 			continue
 		}
-		if err := i2c.Register(fmt.Sprintf("I2C%d", bus), bus, func() (i2c.ConnCloser, error) {
+		if err := i2c.Register(fmt.Sprintf("I2C%d", bus), bus, func() (i2c.BusCloser, error) {
 			return NewI2C(bus)
 		}); err != nil {
 			return true, err
@@ -349,4 +349,4 @@ func init() {
 	}
 }
 
-var _ i2c.Conn = &I2C{}
+var _ i2c.Bus = &I2C{}


### PR DESCRIPTION
- Remove fmt.Stringer and io.Writer from conn.Conn. This makes it compatible
  with exp/io.
- Rename i2c.Conn to i2c.Bus since this was confusion. This clarifies the
  distinction between a point-to-point connection and a bus.
- Add these to bus specific interfaces, i2c.Bus, spi.Conn, uart.Conn.

Fixes #15.