### PR TITLE
sysfs/gpio: fix incorrect level.

### DIFF
--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -299,8 +299,8 @@ const (
 
 var (
 	bIn      = []byte("in")
-	bLow     = []byte("high")
-	bHigh    = []byte("low")
+	bLow     = []byte("low")
+	bHigh    = []byte("high")
 	bNone    = []byte("none")
 	bRising  = []byte("rising")
 	bFalling = []byte("falling")


### PR DESCRIPTION
This happens only when switching a sysfs gpio pin from input to output. It
didn't happen when a CPU driver handled the gpio level so this is why smoke test
likely didn't catch it. (I haven't tried).

Fixes #37.