### PR TITLE
periph: Remove Type.

### DIFF
--- a/conn/gpio/gpiotest/gpio_test.go
+++ b/conn/gpio/gpiotest/gpio_test.go
@@ -46,17 +46,21 @@ func TestByFunction(t *testing.T) {
 //
 
 var (
-	gpio2 = &Pin{N: "GPIO2", Num: 2, Fn: "I2C1_SDA"}
-	gpio3 = &Pin{N: "GPIO3", Num: 3, Fn: "I2C1_SCL"}
+	gpio2  = &Pin{N: "GPIO2", Num: 2, Fn: "I2C1_SDA"}
+	gpio2a = &Pin{N: "GPIO2a", Num: 2}
+	gpio3  = &Pin{N: "GPIO3", Num: 3, Fn: "I2C1_SCL"}
 )
 
 func init() {
-	if err := gpio.Register(gpio2); err != nil {
+	if err := gpio.Register(gpio2, true); err != nil {
 		panic(err)
 	}
-	if err := gpio.Register(gpio3); err != nil {
+	if err := gpio.Register(gpio2a, false); err != nil {
 		panic(err)
 	}
-	gpio.MapFunction(gpio2.Function(), gpio2)
-	gpio.MapFunction(gpio3.Function(), gpio3)
+	if err := gpio.Register(gpio3, false); err != nil {
+		panic(err)
+	}
+	gpio.MapFunction(gpio2.Function(), gpio2.Number())
+	gpio.MapFunction(gpio3.Function(), gpio3.Number())
 }

--- a/devices/lirc/lirc.go
+++ b/devices/lirc/lirc.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio"
 	"github.com/google/periph/conn/ir"
 )
@@ -215,33 +214,16 @@ func (d *driver) String() string {
 	return "lirc"
 }
 
-func (d *driver) Type() periph.Type {
-	// Return the lowest priority, which is Functional.
-	return periph.Functional
-}
-
 func (d *driver) Init() (bool, error) {
 	in, out := getPins()
 	if in == -1 && out == -1 {
 		return false, nil
 	}
 	if in != -1 {
-		if pin := gpio.ByNumber(in); pin != nil {
-			gpio.MapFunction("IR_IN", pin)
-		} else {
-			gpio.MapFunction("IR_IN", gpio.INVALID)
-		}
-	} else {
-		gpio.MapFunction("IR_IN", gpio.INVALID)
+		gpio.MapFunction("IR_IN", in)
 	}
 	if out != -1 {
-		if pin := gpio.ByNumber(out); pin != nil {
-			gpio.MapFunction("IR_OUT", pin)
-		} else {
-			gpio.MapFunction("IR_OUT", gpio.INVALID)
-		}
-	} else {
-		gpio.MapFunction("IR_OUT", gpio.INVALID)
+		gpio.MapFunction("IR_IN", out)
 	}
 	return true, nil
 }

--- a/experimental/driver_skeleton/driver_skeleton.go
+++ b/experimental/driver_skeleton/driver_skeleton.go
@@ -56,11 +56,6 @@ func (d *driver) String() string {
 	return "driver_skeleton"
 }
 
-func (d *driver) Type() periph.Type {
-	// FIXME: Change this to be the type of driver.
-	return periph.Device
-}
-
 func (d *driver) Prerequisites() []string {
 	// FIXME: Declare prerequisites drivers if relevant.
 	return nil

--- a/experimental/host/sysfs/uart.go
+++ b/experimental/host/sysfs/uart.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio"
 	"github.com/google/periph/conn/uart"
 )
@@ -113,10 +112,6 @@ type driverUART struct {
 
 func (d *driverUART) String() string {
 	return "sysfs-uart"
-}
-
-func (d *driverUART) Type() periph.Type {
-	return periph.Bus
 }
 
 func (d *driverUART) Init() (bool, error) {

--- a/host/allwinner/driver.go
+++ b/host/allwinner/driver.go
@@ -28,10 +28,6 @@ func (d *driver) String() string {
 	return "allwinner"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Processor
-}
-
 func (d *driver) Prerequisites() []string {
 	return nil
 }

--- a/host/allwinner/pins.go
+++ b/host/allwinner/pins.go
@@ -501,13 +501,13 @@ var (
 func initPins() error {
 	for i := range cpupins {
 		// register the pin with gpio
-		if err := gpio.Register(cpupins[i]); err != nil {
+		if err := gpio.Register(cpupins[i], true); err != nil {
 			return err
 		}
 		// iterate through alternate functions and register function->pin mapping
 		for _, f := range cpupins[i].altFunc {
 			if f != "" {
-				gpio.MapFunction(f, cpupins[i])
+				gpio.MapFunction(f, cpupins[i].Number())
 			}
 		}
 	}

--- a/host/allwinner_pl/allwinner_pl.go
+++ b/host/allwinner_pl/allwinner_pl.go
@@ -358,10 +358,6 @@ func (d *driver) String() string {
 	return "allwinner_pl"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Processor
-}
-
 func (d *driver) Prerequisites() []string {
 	return []string{"allwinner"}
 }
@@ -381,11 +377,11 @@ func (d *driver) Init() (bool, error) {
 
 	for i := range Pins {
 		p := &Pins[i]
-		if err := gpio.Register(p); err != nil {
+		if err := gpio.Register(p, true); err != nil {
 			return true, err
 		}
 		if f := p.Function(); f[:2] != "In" && f[:3] != "Out" {
-			gpio.MapFunction(f, p)
+			gpio.MapFunction(f, p.Number())
 		}
 	}
 	return true, nil

--- a/host/bcm283x/bcm283x.go
+++ b/host/bcm283x/bcm283x.go
@@ -699,10 +699,6 @@ func (d *driver) String() string {
 	return "bcm283x"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Processor
-}
-
 func (d *driver) Prerequisites() []string {
 	return nil
 }
@@ -781,7 +777,7 @@ func (d *driver) Init() (bool, error) {
 
 	// TODO(maruel): Remove all the functional variables?
 	for i := range Pins {
-		if err := gpio.Register(&Pins[i]); err != nil {
+		if err := gpio.Register(&Pins[i], true); err != nil {
 			return true, err
 		}
 		if i < 46 {
@@ -791,7 +787,7 @@ func (d *driver) Init() (bool, error) {
 		}
 	}
 	for k, v := range functional {
-		gpio.MapFunction(k, v)
+		gpio.MapFunction(k, v.Number())
 	}
 	return true, nil
 }

--- a/host/chip/chip.go
+++ b/host/chip/chip.go
@@ -150,10 +150,6 @@ func (d *driver) String() string {
 	return "chip"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	// has allwinner cpu, needs sysfs for XIO0-XIO7 "gpio" pins
 	return []string{"allwinner", "sysfs-gpio"}

--- a/host/odroid_c1/c1.go
+++ b/host/odroid_c1/c1.go
@@ -101,10 +101,6 @@ func (d *driver) String() string {
 	return "odroid_c1"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	return []string{"sysfs-gpio"}
 }

--- a/host/pine64/pine64.go
+++ b/host/pine64/pine64.go
@@ -284,10 +284,6 @@ func (d *driver) String() string {
 	return "pine64"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	return []string{"allwinner_pl"}
 }

--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -169,10 +169,6 @@ func (d *driver) String() string {
 	return "rpi"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	return []string{"bcm283x"}
 }

--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -342,11 +342,6 @@ func (d *driverGPIO) String() string {
 	return "sysfs-gpio"
 }
 
-func (d *driverGPIO) Type() periph.Type {
-	// It intentionally load later than processors.
-	return periph.Pins
-}
-
 func (d *driverGPIO) Prerequisites() []string {
 	return nil
 }
@@ -406,12 +401,8 @@ func (d *driverGPIO) parseGPIOChip(path string) error {
 			root:   fmt.Sprintf("/sys/class/gpio/gpio%d/", i),
 		}
 		Pins[i] = p
-		// Try to register real pin, but it may already be registered by the processor
-		// driver. In that case register an alias instead.
-		if gpio.Register(p) != nil {
-			realPin := gpio.ByNumber(i)
-			alias := &gpio.PinAlias{N: p.name, PinIO: realPin}
-			gpio.RegisterAlias(alias)
+		if err := gpio.Register(p, false); err != nil {
+			return err
 		}
 		// We cannot use gpio.MapFunction() since there is no API to determine this.
 	}

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -308,10 +308,6 @@ func (d *driverI2C) String() string {
 	return "sysfs-i2c"
 }
 
-func (d *driverI2C) Type() periph.Type {
-	return periph.Bus
-}
-
 func (d *driverI2C) Prerequisites() []string {
 	return nil
 }

--- a/host/sysfs/led.go
+++ b/host/sysfs/led.go
@@ -163,10 +163,6 @@ func (d *driverLED) String() string {
 	return "sysfs-led"
 }
 
-func (d *driverLED) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driverLED) Prerequisites() []string {
 	return nil
 }

--- a/host/sysfs/spi.go
+++ b/host/sysfs/spi.go
@@ -217,10 +217,6 @@ func (d *driverSPI) String() string {
 	return "sysfs-spi"
 }
 
-func (d *driverSPI) Type() periph.Type {
-	return periph.Bus
-}
-
 func (d *driverSPI) Prerequisites() []string {
 	return nil
 }

--- a/host/sysfs/thermal_sensor.go
+++ b/host/sysfs/thermal_sensor.go
@@ -121,10 +121,6 @@ func (d *driverThermalSensor) String() string {
 	return "sysfs-thermal"
 }
 
-func (d *driverThermalSensor) Type() periph.Type {
-	return periph.Device
-}
-
 func (d *driverThermalSensor) Prerequisites() []string {
 	return nil
 }


### PR DESCRIPTION
DO NOT MERGE.

Type is an approximation to enforce priority ordering. This can be fixed
instead.

In practice only gpio is a problem.