### PR TITLE
periph: Remove Type; gpio: improve pin registering

### DIFF
--- a/cmd/gpio-list/README.md
+++ b/cmd/gpio-list/README.md
@@ -32,11 +32,12 @@ For more information for enabling functional pins, see
 [![GoDoc](https://godoc.org/github.com/google/periph/host/rpi?status.svg)](https://godoc.org/github.com/google/periph/host/rpi).
 
 
-### Functional
+### Aliases
 
-Print the GPIO pins per special functionality:
+When possible, aliases are created per functionality. Print the GPIO aliases
+with:
 
-    $ gpio-list -f
+    $ gpio-list -l
     GPCLK1   : GPIO42
     GPCLK2   : GPIO43
     I2C1_SCL : GPIO3

--- a/cmd/periph-smoketest/main.go
+++ b/cmd/periph-smoketest/main.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio/gpiosmoketest"
+	"github.com/google/periph/host"
 	"github.com/google/periph/host/chip/chipsmoketest"
 	"github.com/google/periph/host/odroid_c1/odroidc1smoketest"
 )
@@ -60,7 +60,7 @@ func usage() {
 }
 
 func mainImpl() error {
-	state, err := periph.Init()
+	state, err := host.Init()
 	if err != nil {
 		return fmt.Errorf("error loading drivers: %v", err)
 	}

--- a/conn/gpio/gpio_test.go
+++ b/conn/gpio/gpio_test.go
@@ -17,12 +17,6 @@ func ExampleAll() {
 	}
 }
 
-func ExampleByFunction() {
-	for _, f := range []string{"I2C0_SDA", "I2C0_SCL"} {
-		fmt.Printf("%s: %s\n", f, ByFunction(f))
-	}
-}
-
 func ExampleByName() {
 	p := ByName("GPIO6")
 	if p == nil {
@@ -36,7 +30,7 @@ func ExampleByName_alias() {
 	if p == nil {
 		log.Fatal("Failed to find LCD-D2")
 	}
-	if rp, ok := p.(*PinAlias); ok {
+	if rp, ok := p.(RealPin); ok {
 		fmt.Printf("%s is an alias for %s\n", p, rp.Real())
 	} else {
 		fmt.Printf("%s is not an alias!\n", p)

--- a/conn/gpio/gpiotest/gpio_test.go
+++ b/conn/gpio/gpiotest/gpio_test.go
@@ -34,29 +34,24 @@ func TestByName(t *testing.T) {
 	}
 }
 
-func TestByFunction(t *testing.T) {
-	if gpio.ByFunction("SPI1_MOSI") != nil {
-		t.Fatal("spi doesn't exist")
-	}
-	if gpio.ByFunction("I2C1_SDA") != gpio2 {
-		t.Fatal("I2C1_SDA should have been found")
-	}
-}
-
 //
 
 var (
-	gpio2 = &Pin{N: "GPIO2", Num: 2, Fn: "I2C1_SDA"}
-	gpio3 = &Pin{N: "GPIO3", Num: 3, Fn: "I2C1_SCL"}
+	gpio2  = &Pin{N: "GPIO2", Num: 2, Fn: "I2C1_SDA"}
+	gpio2a = &Pin{N: "GPIO2a", Num: 2}
+	gpio3  = &Pin{N: "GPIO3", Num: 3, Fn: "I2C1_SCL"}
 )
 
 func init() {
-	if err := gpio.Register(gpio2); err != nil {
+	if err := gpio.Register(gpio2, true); err != nil {
 		panic(err)
 	}
-	if err := gpio.Register(gpio3); err != nil {
+	if err := gpio.Register(gpio2a, false); err != nil {
 		panic(err)
 	}
-	gpio.MapFunction(gpio2.Function(), gpio2)
-	gpio.MapFunction(gpio3.Function(), gpio3)
+	if err := gpio.Register(gpio3, false); err != nil {
+		panic(err)
+	}
+	gpio.RegisterAlias(gpio2.Function(), gpio2.Number())
+	gpio.RegisterAlias(gpio3.Function(), gpio3.Number())
 }

--- a/devices/lirc/lirc.go
+++ b/devices/lirc/lirc.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio"
 	"github.com/google/periph/conn/ir"
 )
@@ -215,33 +214,20 @@ func (d *driver) String() string {
 	return "lirc"
 }
 
-func (d *driver) Type() periph.Type {
-	// Return the lowest priority, which is Functional.
-	return periph.Functional
-}
-
 func (d *driver) Init() (bool, error) {
 	in, out := getPins()
 	if in == -1 && out == -1 {
 		return false, nil
 	}
 	if in != -1 {
-		if pin := gpio.ByNumber(in); pin != nil {
-			gpio.MapFunction("IR_IN", pin)
-		} else {
-			gpio.MapFunction("IR_IN", gpio.INVALID)
+		if err := gpio.RegisterAlias("IR_IN", in); err != nil {
+			return true, err
 		}
-	} else {
-		gpio.MapFunction("IR_IN", gpio.INVALID)
 	}
 	if out != -1 {
-		if pin := gpio.ByNumber(out); pin != nil {
-			gpio.MapFunction("IR_OUT", pin)
-		} else {
-			gpio.MapFunction("IR_OUT", gpio.INVALID)
+		if err := gpio.RegisterAlias("IR_OUT", out); err != nil {
+			return true, err
 		}
-	} else {
-		gpio.MapFunction("IR_OUT", gpio.INVALID)
 	}
 	return true, nil
 }

--- a/experimental/driver_skeleton/driver_skeleton.go
+++ b/experimental/driver_skeleton/driver_skeleton.go
@@ -56,11 +56,6 @@ func (d *driver) String() string {
 	return "driver_skeleton"
 }
 
-func (d *driver) Type() periph.Type {
-	// FIXME: Change this to be the type of driver.
-	return periph.Device
-}
-
 func (d *driver) Prerequisites() []string {
 	// FIXME: Declare prerequisites drivers if relevant.
 	return nil

--- a/experimental/host/sysfs/uart.go
+++ b/experimental/host/sysfs/uart.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio"
 	"github.com/google/periph/conn/uart"
 )
@@ -113,10 +112,6 @@ type driverUART struct {
 
 func (d *driverUART) String() string {
 	return "sysfs-uart"
-}
-
-func (d *driverUART) Type() periph.Type {
-	return periph.Bus
 }
 
 func (d *driverUART) Init() (bool, error) {

--- a/host/allwinner/driver.go
+++ b/host/allwinner/driver.go
@@ -28,10 +28,6 @@ func (d *driver) String() string {
 	return "allwinner"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Processor
-}
-
 func (d *driver) Prerequisites() []string {
 	return nil
 }

--- a/host/bcm283x/bcm283x.go
+++ b/host/bcm283x/bcm283x.go
@@ -244,9 +244,9 @@ var (
 
 // PinIO implementation.
 
-// String returns the pin name and number, ex: "GPIO10(10)".
+// String returns the pin name, ex: "GPIO10".
 func (p *Pin) String() string {
-	return fmt.Sprintf("%s(%d)", p.name, p.number)
+	return p.name
 }
 
 // Name returns the pin name, ex: "GPIO10".
@@ -699,10 +699,6 @@ func (d *driver) String() string {
 	return "bcm283x"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Processor
-}
-
 func (d *driver) Prerequisites() []string {
 	return nil
 }
@@ -781,7 +777,7 @@ func (d *driver) Init() (bool, error) {
 
 	// TODO(maruel): Remove all the functional variables?
 	for i := range Pins {
-		if err := gpio.Register(&Pins[i]); err != nil {
+		if err := gpio.Register(&Pins[i], true); err != nil {
 			return true, err
 		}
 		if i < 46 {
@@ -790,8 +786,10 @@ func (d *driver) Init() (bool, error) {
 			}
 		}
 	}
-	for k, v := range functional {
-		gpio.MapFunction(k, v)
+	for name, p := range functional {
+		if err := gpio.RegisterAlias(name, p.Number()); err != nil {
+			return true, err
+		}
 	}
 	return true, nil
 }

--- a/host/chip/chip.go
+++ b/host/chip/chip.go
@@ -150,10 +150,6 @@ func (d *driver) String() string {
 	return "chip"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	// has allwinner cpu, needs sysfs for XIO0-XIO7 "gpio" pins
 	return []string{"allwinner", "sysfs-gpio"}
@@ -251,13 +247,10 @@ func (d *driver) Init() (bool, error) {
 	for alias, real := range aliases {
 		r := gpio.ByName(real)
 		if r == nil {
-			return true, fmt.Errorf("Cannot create alias for %s: it doesn't exist",
-				real)
+			return true, fmt.Errorf("Cannot create alias for %s: it doesn't exist", real)
 		}
-		a := &gpio.PinAlias{N: alias, PinIO: r}
-		if err := gpio.RegisterAlias(a); err != nil {
-			return true, fmt.Errorf("Cannot create alias %s for %s: %s",
-				alias, real, err)
+		if err := gpio.RegisterAlias(alias, r.Number()); err != nil {
+			return true, err
 		}
 	}
 

--- a/host/chip/chipsmoketest/chipsmoketest.go
+++ b/host/chip/chipsmoketest/chipsmoketest.go
@@ -117,20 +117,13 @@ func testChipAliases() error {
 		if p == nil {
 			return fmt.Errorf("failed to open %s", a)
 		}
-		pa, ok := p.(*gpio.PinAlias)
+		pa, ok := p.(gpio.RealPin)
 		if !ok {
-			return fmt.Errorf("expected that pin %s is an alias, not %T", a, pa)
+			return fmt.Errorf("expected that pin %s is an alias, not %T", a, p)
 		}
-		if pa.Name() != a {
-			return fmt.Errorf("the name of alias %s is %s not %s", a, pa.Name(), a)
-		}
-		pr, ok := p.(gpio.RealPin)
-		if !ok {
-			return fmt.Errorf("expected that pin alias %s implement RealPin", a)
-		}
-		if pr.Real().Name() != r {
+		if pr := pa.Real(); pr.Name() != r {
 			return fmt.Errorf("expected that alias %s have real pin %s but it's %s",
-				a, r, pr.Real().Name())
+				a, r, pr.Name())
 		}
 	}
 	return nil

--- a/host/odroid_c1/c1.go
+++ b/host/odroid_c1/c1.go
@@ -101,10 +101,6 @@ func (d *driver) String() string {
 	return "odroid_c1"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	return []string{"sysfs-gpio"}
 }
@@ -194,10 +190,8 @@ func (d *driver) Init() (bool, error) {
 			return true, fmt.Errorf("Cannot create alias for %s: it doesn't exist",
 				real)
 		}
-		a := &gpio.PinAlias{N: alias, PinIO: r}
-		if err := gpio.RegisterAlias(a); err != nil {
-			return true, fmt.Errorf("Cannot create alias %s for %s: %s",
-				alias, real, err)
+		if err := gpio.RegisterAlias(alias, r.Number()); err != nil {
+			return true, err
 		}
 	}
 

--- a/host/odroid_c1/odroidc1smoketest/odroidc1smoketest.go
+++ b/host/odroid_c1/odroidc1smoketest/odroidc1smoketest.go
@@ -106,20 +106,13 @@ func testOdroidC1Aliases() error {
 		if p == nil {
 			return fmt.Errorf("failed to open %s", a)
 		}
-		pa, ok := p.(*gpio.PinAlias)
+		pa, ok := p.(gpio.RealPin)
 		if !ok {
-			return fmt.Errorf("expected that pin %s is an alias, not %T", a, pa)
+			return fmt.Errorf("expected that pin %s is an alias, not %T", a, p)
 		}
-		if pa.Name() != a {
-			return fmt.Errorf("the name of alias %s is %s not %s", a, pa.Name(), a)
-		}
-		pr, ok := p.(gpio.RealPin)
-		if !ok {
-			return fmt.Errorf("expected that pin alias %s implement RealPin", a)
-		}
-		if pr.Real().Name() != r {
+		if pr := pa.Real(); pr.Name() != r {
 			return fmt.Errorf("expected that alias %s have real pin %s but it's %s",
-				a, r, pr.Real().Name())
+				a, r, pr.Name())
 		}
 	}
 	return nil

--- a/host/pine64/pine64.go
+++ b/host/pine64/pine64.go
@@ -284,10 +284,6 @@ func (d *driver) String() string {
 	return "pine64"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	return []string{"allwinner_pl"}
 }

--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -169,10 +169,6 @@ func (d *driver) String() string {
 	return "rpi"
 }
 
-func (d *driver) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driver) Prerequisites() []string {
 	return []string{"bcm283x"}
 }

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -170,10 +170,10 @@ func (i *I2C) ioctl(op uint, arg uintptr) error {
 func (i *I2C) initPins() {
 	i.mu.Lock()
 	if i.scl == nil {
-		if i.scl = gpio.ByFunction(fmt.Sprintf("I2C%d_SCL", i.busNumber)); i.scl == nil {
+		if i.scl = gpio.ByName(fmt.Sprintf("I2C%d_SCL", i.busNumber)); i.scl == nil {
 			i.scl = gpio.INVALID
 		}
-		if i.sda = gpio.ByFunction(fmt.Sprintf("I2C%d_SDA", i.busNumber)); i.sda == nil {
+		if i.sda = gpio.ByName(fmt.Sprintf("I2C%d_SDA", i.busNumber)); i.sda == nil {
 			i.sda = gpio.INVALID
 		}
 	}
@@ -306,10 +306,6 @@ type driverI2C struct {
 
 func (d *driverI2C) String() string {
 	return "sysfs-i2c"
-}
-
-func (d *driverI2C) Type() periph.Type {
-	return periph.Bus
 }
 
 func (d *driverI2C) Prerequisites() []string {

--- a/host/sysfs/led.go
+++ b/host/sysfs/led.go
@@ -163,10 +163,6 @@ func (d *driverLED) String() string {
 	return "sysfs-led"
 }
 
-func (d *driverLED) Type() periph.Type {
-	return periph.Pins
-}
-
 func (d *driverLED) Prerequisites() []string {
 	return nil
 }

--- a/host/sysfs/spi.go
+++ b/host/sysfs/spi.go
@@ -194,16 +194,16 @@ func (s *SPI) ioctl(op uint, arg unsafe.Pointer) error {
 
 func (s *SPI) initPins() {
 	if s.clk == nil {
-		if s.clk = gpio.ByFunction(fmt.Sprintf("SPI%d_CLK", s.busNumber)); s.clk == nil {
+		if s.clk = gpio.ByName(fmt.Sprintf("SPI%d_CLK", s.busNumber)); s.clk == nil {
 			s.clk = gpio.INVALID
 		}
-		if s.miso = gpio.ByFunction(fmt.Sprintf("SPI%d_MISO", s.busNumber)); s.miso == nil {
+		if s.miso = gpio.ByName(fmt.Sprintf("SPI%d_MISO", s.busNumber)); s.miso == nil {
 			s.miso = gpio.INVALID
 		}
-		if s.mosi = gpio.ByFunction(fmt.Sprintf("SPI%d_MOSI", s.busNumber)); s.mosi == nil {
+		if s.mosi = gpio.ByName(fmt.Sprintf("SPI%d_MOSI", s.busNumber)); s.mosi == nil {
 			s.mosi = gpio.INVALID
 		}
-		if s.cs = gpio.ByFunction(fmt.Sprintf("SPI%d_CS%d", s.busNumber, s.chipSelect)); s.cs == nil {
+		if s.cs = gpio.ByName(fmt.Sprintf("SPI%d_CS%d", s.busNumber, s.chipSelect)); s.cs == nil {
 			s.cs = gpio.INVALID
 		}
 	}
@@ -215,10 +215,6 @@ type driverSPI struct {
 
 func (d *driverSPI) String() string {
 	return "sysfs-spi"
-}
-
-func (d *driverSPI) Type() periph.Type {
-	return periph.Bus
 }
 
 func (d *driverSPI) Prerequisites() []string {

--- a/host/sysfs/thermal_sensor.go
+++ b/host/sysfs/thermal_sensor.go
@@ -121,10 +121,6 @@ func (d *driverThermalSensor) String() string {
 	return "sysfs-thermal"
 }
 
-func (d *driverThermalSensor) Type() periph.Type {
-	return periph.Device
-}
-
 func (d *driverThermalSensor) Prerequisites() []string {
 	return nil
 }


### PR DESCRIPTION
periph:
- Type was an approximation to enforce priority ordering. Remove the need for
  approximate ordering by improving gpio instead to support out-of-order pin
  registration. This has the side effect of increasing parallelism. This saved
  ~5ms on "gpio-list" runtime (out of 30ms) when run on a Raspberry Pi 3.

gpio:
- Redo RegisterAlias() to support out of order registration.
- Replace Functional() with Aliases(), which is much more generic.
- Unexport PinAlias, it is not necessary anymore.
- Improve error messages by wrapping the error, it helps legibility in case of
  errors.
- Remove Unregister(), it will be added back when there's an actual call site.
- Remove the (%d) number on sysfs-gpio and bcm283x since it wasn't useful.
- sysfs-gpio: Fix edge when switching output.

lirc:
- Stop mapping IR_IN and IR_OUT when the pin is not mapped.

periph-smoketest:
- Fix to use host.Init(), otherwise drivers weren't correctly loaded.