### PR TITLE
Convert struct mapping from unsafe.Pointer to reflect.Value.

### DIFF
--- a/host/allwinner/driver.go
+++ b/host/allwinner/driver.go
@@ -11,9 +11,9 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"strconv"
 	"strings"
-	"unsafe"
 
 	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio"
@@ -46,7 +46,9 @@ func (d *driver) Init() (bool, error) {
 		}
 		return true, err
 	}
-	m.Struct(unsafe.Pointer(&gpioMemory))
+	if err := m.Struct(reflect.ValueOf(&gpioMemory)); err != nil {
+		return true, err
+	}
 
 	switch {
 	case IsA64():

--- a/host/allwinner_pl/allwinner_pl.go
+++ b/host/allwinner_pl/allwinner_pl.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio"
@@ -373,7 +373,9 @@ func (d *driver) Init() (bool, error) {
 		}
 		return true, err
 	}
-	m.Struct(unsafe.Pointer(&gpioMemory))
+	if err := m.Struct(reflect.ValueOf(&gpioMemory)); err != nil {
+		return true, err
+	}
 
 	for i := range Pins {
 		p := &Pins[i]

--- a/host/bcm283x/bcm283x.go
+++ b/host/bcm283x/bcm283x.go
@@ -10,10 +10,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/google/periph"
 	"github.com/google/periph/conn/gpio"
@@ -727,7 +727,9 @@ func (d *driver) Init() (bool, error) {
 			return true, err
 		}
 	}
-	m.Struct(unsafe.Pointer(&gpioMemory))
+	if err := m.Struct(reflect.ValueOf(&gpioMemory)); err != nil {
+		return true, err
+	}
 
 	// https://www.raspberrypi.org/wp-content/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
 	// Page 102.

--- a/host/pmem/alloc.go
+++ b/host/pmem/alloc.go
@@ -1,0 +1,62 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package pmem
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ReadPageMap reads a physical address mapping for a virtual page address from
+// /proc/self/pagemap.
+//
+// It returns the physical address that corresponds to the start of the virtual
+// page within which the virtual address virtAddr is located.
+//
+// The meaning of the return value is documented at
+// https://www.kernel.org/doc/Documentation/vm/pagemap.txt
+func ReadPageMap(virtAddr uintptr) (uint64, error) {
+	if !isLinux {
+		return nil, errors.New("pmem: pagemap is not supported on this platform")
+	}
+	var b [8]byte
+	mu.Lock()
+	defer mu.Unlock()
+	// Convert address to page number, then index in uint64 array.
+	if _, err := pageMap.Seek(int64(virtAddr/4096*8), os.SEEK_SET); err != nil {
+		return 0, err
+	}
+	n, err := pageMap.Read(b[:])
+	if err != nil {
+		return 0, err
+	}
+	if n != len(b) {
+		return 0, fmt.Errorf("pmem: failed to read the amount of data %d", len(b))
+	}
+	return binary.LittleEndian.Uint64(b[:]), nil
+}
+
+//
+
+var (
+	pageMap    *os.File
+	pageMapErr error
+)
+
+// openPageMapLinux() opens /proc/self/pagemap.
+//
+// It is a uint64 array where the index represents the virtual 4Kb page number
+// and the value represents the physical page properties backing this virtual
+// page.
+func openPageMapLinux() (*os.File, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if pageMap == nil && pageMapErr == nil {
+		pageMap, pageMapErr = os.OpenFile("/proc/self/pagemap", os.O_RDONLY|os.O_SYNC, 0)
+	}
+	return pageMap, pageMapErr
+}

--- a/host/pmem/view_test.go
+++ b/host/pmem/view_test.go
@@ -1,0 +1,50 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package pmem
+
+import (
+	"reflect"
+	"testing"
+)
+
+type simpleStruct struct {
+	u uint32
+}
+
+func TestSlice(t *testing.T) {
+	// Assumes binary.LittleEndian. Correct if this code is ever run on BigEndian.
+	s := Slice([]byte{4, 3, 2, 1})
+	u32 := s.Uint32()
+	if len(u32) != 1 || u32[0] != 0x01020304 {
+		t.Fatalf("%v", u32)
+	}
+	var v *simpleStruct
+	if err := s.Struct(reflect.ValueOf(&v)); err != nil {
+		t.Fatalf("%v", err)
+	}
+	if v == nil {
+		t.FailNow()
+	}
+	if v.u != 0x01020304 {
+		t.Fatalf("%v", v.u)
+	}
+	if s.Struct(reflect.ValueOf(nil)) == nil {
+		t.FailNow()
+	}
+	if s.Struct(reflect.ValueOf(v)) == nil {
+		t.FailNow()
+	}
+	var p *uint32
+	if s.Struct(reflect.ValueOf(p)) == nil {
+		t.FailNow()
+	}
+	if s.Struct(reflect.ValueOf(&p)) == nil {
+		t.FailNow()
+	}
+	s = Slice([]byte{1})
+	if s.Struct(reflect.ValueOf(&v)) == nil {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
This makes the code slightly safer and pmem.Slice will be leveraged when
allocating physical memory in a follow up commit.

Add ReadPageMap which will also be leveraged in a follow up.