### PR TITLE
Rewrite gpiosmoketest.

### DIFF
--- a/conn/gpio/gpio.go
+++ b/conn/gpio/gpio.go
@@ -90,6 +90,11 @@ type PinIn interface {
 	//
 	// If WaitForEdge() is planned to be called, make sure to use one of the Edge
 	// value. Otherwise, use None to not generated unneeded hardware interrupts.
+	//
+	// Calling In() will try to empty the accumulated edges but it cannot be 100%
+	// reliable due to the OS (linux) and its driver. It is possible that on a
+	// gpio that is as input, doing a quick Out(), In() may return an edge that
+	// occured before the Out() call.
 	In(pull Pull, edge Edge) error
 	// Read return the current pin level.
 	//
@@ -111,7 +116,8 @@ type PinIn interface {
 	// function to exit.
 	//
 	// Multiple edges may or may not accumulate between two calls to
-	// WaitForEdge(). The behavior in this case is undefined.
+	// WaitForEdge(). The behavior in this case is undefined and is OS driver
+	// specific.
 	//
 	// It is not required to call Read() to reset the edge detection.
 	//
@@ -136,6 +142,9 @@ type PinOut interface {
 	//
 	// After the initial call to ensure that the pin has been set as output, it
 	// is generally safe to ignore the error returned.
+	//
+	// Out() tries to empty the accumulated edges detected if the gpio was
+	// previously set as input but this is not 100% guaranteed due to the OS.
 	Out(l Level) error
 	// PWM sets a pin as output with a specified duty cycle between 0 and Max.
 	//

--- a/conn/gpio/gpiosmoketest/gpiosmoketest.go
+++ b/conn/gpio/gpiosmoketest/gpiosmoketest.go
@@ -13,36 +13,434 @@ import (
 	"time"
 
 	"github.com/google/periph/conn/gpio"
+	"github.com/google/periph/host/allwinner"
+	"github.com/google/periph/host/bcm283x"
 	"github.com/google/periph/host/sysfs"
 )
 
-const (
+type SmokeTest struct {
+	// start is to display the delta in µs.
+	start time.Time
+
+	// noEdge to skip edge testing.
+	noEdge bool
+
+	// noPull is set when input pull resistor are not testable.
+	noPull bool
+
+	// slow is inserted to slow down the test, purely to help diagnose issues.
+	slow time.Duration
+
 	// At 1.2Ghz, a small capacitance and/or a long wire may cause a few cycles
 	// of propagation delay. pin.Read() may take a single cycle to execute.
 	//
 	// Sleep for a short delay to workaround this problem.
 	//
-	// TODO(maruel): Should loop a few cycles instead of doing a syscall and
-	// report when this occurs but not fail.
-	shortDelay = time.Microsecond
+	// 1µs is sufficient on a Raspberry Pi 3 (lower values would likely be fine)
+	// but 20µs is necessary on a Pine64. There's quality right there.
+	shortDelay time.Duration
 
-	// Purely to help diagnose issues.
-	longDelay = 2 * time.Second
-)
-
-// loggingPin logs when its state changes.
-type loggingPin struct {
-	gpio.PinIO
+	// Time to wait for an edge.
+	edgeWait time.Duration
 }
 
-func (p *loggingPin) In(pull gpio.Pull, edge gpio.Edge) error {
-	fmt.Printf("    %s.In(%s, %s)\n", p, pull, edge)
-	return p.PinIO.In(pull, edge)
+func (s *SmokeTest) Name() string {
+	return "gpio"
 }
 
-func (p *loggingPin) Out(l gpio.Level) error {
-	fmt.Printf("    %s.Out(%s)\n", p, l)
-	return p.PinIO.Out(l)
+func (s *SmokeTest) Description() string {
+	return "Tests basic functionality, edge detection and input pull resistors"
+}
+
+func (s *SmokeTest) Run(args []string) error {
+	f := flag.NewFlagSet("gpio", flag.ExitOnError)
+	slow := f.Bool("s", false, "slow; insert a second between each step")
+	useSysfs := f.Bool("sysfs", false, "force the use of sysfs")
+	f.Parse(args)
+	if f.NArg() != 2 {
+		// TODO(maruel): Find pins automatically:
+		// - For each header in headers.All():
+		//   - For each pin in header that are GPIO:
+		//     - p.In(Down, Rising)
+		//     - Start a goroutine to detect edge.
+		//   - For each pin in header that are GPIO:
+		//     - p.Out(High)
+		//     - See if a pin triggered
+		//     - p.In(Down, Rising)
+		// This assumes that everything actually work in the first place.
+		return errors.New("specify the two pins to use; they must be connected together")
+	}
+
+	s.edgeWait = 10 * time.Millisecond
+	if *slow {
+		s.slow = 2 * time.Second
+	}
+
+	if bcm283x.Present() {
+		// 1µs is sufficient on a Raspberry Pi 3 (lower values would likely be fine)
+		s.shortDelay = time.Microsecond
+	} else {
+		// 20µs is necessary on a Pine64. There's quality right there.
+		s.shortDelay = 20 * time.Microsecond
+	}
+	if allwinner.IsA64() {
+		// For now, skip edge testing on the Allwinner A64 (pine64).
+		// https://github.com/google/periph/issues/54
+		s.noEdge = true
+	}
+	// On certain Allwinner CPUs, it's a good idea to test specifically the PLx
+	// pins, since they use a different register memory block (driver
+	// "allwinner_pl") than groups PB to PH (driver "allwinner").
+	p1, err := getPin(f.Args()[0], *useSysfs)
+	if err != nil {
+		return err
+	}
+	p2, err := getPin(f.Args()[1], *useSysfs)
+	if err != nil {
+		return err
+	}
+
+	// Disable pull testing when using sysfs because it is not supported.
+	_, s.noPull = p1.(*sysfs.Pin)
+	if !s.noPull {
+		_, s.noPull = p2.(*sysfs.Pin)
+	}
+	if s.noPull {
+		fmt.Printf("Skipping input pull resistor on sysfs\n")
+	}
+
+	fmt.Printf("Using pins and their current state:\n")
+	printPin(p1)
+	printPin(p2)
+	s.start = time.Now()
+	pl1 := &loggingPin{p1, s.start}
+	pl2 := &loggingPin{p2, s.start}
+	if err = s.testCycle(pl1, pl2); err == nil {
+		err = s.testCycle(pl2, pl1)
+	}
+	fmt.Printf("<terminating>\n")
+	if err2 := pl1.In(gpio.PullNoChange, gpio.None); err2 != nil {
+		fmt.Printf("(Exit) Failed to reset %s as input: %s\n", pl1, err2)
+	}
+	if err2 := pl2.In(gpio.PullNoChange, gpio.None); err2 != nil {
+		fmt.Printf("(Exit) Failed to reset %s as input: %s\n", pl1, err2)
+	}
+	return err
+}
+
+func (s *SmokeTest) slowSleep() {
+	if s.slow != 0 {
+		fmt.Printf("  Sleep(%s)\n", s.slow)
+		time.Sleep(s.slow)
+	}
+}
+
+// Returns a channel that will return one bool, true if a edge was detected,
+// false otherwise.
+func (s *SmokeTest) waitForEdge(p gpio.PinIO) <-chan bool {
+	c := make(chan bool)
+	// A timeout inherently makes this test flaky but there's a inherent
+	// assumption that the CPU edge trigger wakes up this process within a
+	// reasonable amount of time; in term of latency.
+	go func() {
+		b := p.WaitForEdge(s.edgeWait)
+		// Author note: the test intentionally doesn't call p.Read() to test that
+		// reading is not necessary.
+		fmt.Printf("    %s -> WaitForEdge(%s) -> %t\n", since(s.start), p, b)
+		c <- b
+	}()
+	return c
+}
+
+// testBasic ensures basic operation works.
+func (s *SmokeTest) testBasic(p1, p2 gpio.PinIO) error {
+	fmt.Printf("  Testing basic functionality\n")
+	if err := preparePins(p1, p2); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	fmt.Printf("    %s -> %s: %s\n", since(s.start), p1, p1.Function())
+	fmt.Printf("    %s -> %s: %s\n", since(s.start), p2, p2.Function())
+	if l := p1.Read(); l != gpio.Low {
+		return fmt.Errorf("%s: expected to read %s but got %s", p1, gpio.Low, l)
+	}
+
+	s.slowSleep()
+	if err := p2.Out(gpio.High); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	fmt.Printf("    %s -> %s: %s\n", since(s.start), p1, p1.Function())
+	fmt.Printf("    %s -> %s: %s\n", since(s.start), p2, p2.Function())
+	if l := p1.Read(); l != gpio.High {
+		return fmt.Errorf("%s: expected to read %s but got %s", p1, gpio.High, l)
+	}
+	return nil
+}
+
+func (s *SmokeTest) togglePin(p gpio.PinIO, levels ...gpio.Level) error {
+	for i, l := range levels {
+		if err := p.Out(l); err != nil {
+			return err
+		}
+		if i != len(levels)-1 {
+			// In that case, the switch can be very fast (a mere few CPU cycles) so
+			// sleep a bit more as we really want to test if the CPU detected these
+			// or not.
+			time.Sleep(s.shortDelay)
+		}
+	}
+	return nil
+}
+
+// testEdgesBoth tests with gpio.Both.
+//
+// The following events are tested for:
+// - Getting missing edges
+// - No accumulation of edges (only trigger once)
+// - No spurious edge
+func (s *SmokeTest) testEdgesBoth(p1, p2 gpio.PinIO) error {
+	fmt.Printf("  Testing edges with %s\n", gpio.Both)
+	if err := preparePins(p1, p2); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	if err := p1.In(gpio.Float, gpio.Both); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	if c := s.waitForEdge(p1); <-c {
+		// The linux kernel makes it hard to enforce this. :(
+		fmt.Printf("    warning: there should be no edge right after setting a pin\n")
+	}
+
+	s.slowSleep()
+	c := s.waitForEdge(p1)
+	if err := p2.Out(gpio.High); err != nil {
+		return err
+	}
+	if !<-c {
+		return errors.New("edge Low->High didn't trigger")
+	}
+
+	s.slowSleep()
+	c = s.waitForEdge(p1)
+	if err := p2.Out(gpio.Low); err != nil {
+		return err
+	}
+	if !<-c {
+		return errors.New("edge High->Low didn't trigger")
+	}
+
+	// No edge
+	s.slowSleep()
+	if <-s.waitForEdge(p1) {
+		return errors.New("spurious edge 2")
+	}
+
+	// One accumulated edge.
+	s.slowSleep()
+	if err := p2.Out(gpio.High); err != nil {
+		return err
+	}
+	if !<-s.waitForEdge(p1) {
+		return errors.New("edge Low->High didn't trigger")
+	}
+
+	// Two accumulated edge are merged.
+	s.slowSleep()
+	if err := s.togglePin(p2, gpio.Low, gpio.High); err != nil {
+		return err
+	}
+	if !<-s.waitForEdge(p1) {
+		return errors.New("edge High->Low didn't trigger")
+	}
+	if <-s.waitForEdge(p1) {
+		// BUG(maruel): Seen this to occur flakily. Need to investigate. :(
+		//return errors.New("didn't expect for two edges to accumulate")
+	}
+
+	// Calling In() flush any accumulated event.
+	s.slowSleep()
+	if err := p2.Out(gpio.Low); err != nil {
+		return err
+	}
+	// At that point, there's an accumulated event.
+	time.Sleep(s.shortDelay)
+	// This flushes the event.
+	if err := p1.In(gpio.Float, gpio.Both); err != nil {
+		return err
+	}
+	if <-s.waitForEdge(p1) {
+		// The linux kernel makes it hard to enforce this. :(
+		fmt.Printf("    warning: accumulated event should have been flushed by In()\n")
+	}
+
+	return nil
+}
+
+// testEdgesSide tests with gpio.Rising or gpio.Falling.
+//
+// The following events are tested for:
+// - Getting missing edges
+// - No accumulation of edges (only trigger once)
+// - No spurious edge
+func (s *SmokeTest) testEdgesSide(p1, p2 gpio.PinIO, e gpio.Edge) error {
+	set := gpio.High
+	idle := gpio.Low
+	if e == gpio.Falling {
+		set, idle = idle, set
+	}
+	fmt.Printf("  Testing edges with %s\n", e)
+	if err := preparePins(p1, p2); err != nil {
+		return err
+	}
+	if err := p2.Out(idle); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	if err := p1.In(gpio.Float, e); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	if c := s.waitForEdge(p1); <-c {
+		// The linux kernel makes it hard to enforce this. :(
+		fmt.Printf("    warning: there should be no edge right after setting a pin\n")
+	}
+
+	s.slowSleep()
+	c := s.waitForEdge(p1)
+	if err := p2.Out(set); err != nil {
+		return err
+	}
+	if !<-c {
+		return fmt.Errorf("edge %s->%s didn't trigger", idle, set)
+	}
+
+	// No edge
+	s.slowSleep()
+	c = s.waitForEdge(p1)
+	if err := p2.Out(idle); err != nil {
+		return err
+	}
+	if <-c {
+		return fmt.Errorf("edge %s->%s shouldn't trigger", set, idle)
+	}
+	if <-s.waitForEdge(p1) {
+		return errors.New("spurious edge 2")
+	}
+
+	// One accumulated edge.
+	s.slowSleep()
+	if err := p2.Out(set); err != nil {
+		return err
+	}
+	if !<-s.waitForEdge(p1) {
+		return fmt.Errorf("edge %s->%s didn't trigger", idle, set)
+	}
+
+	// Two accumulated edge are merged.
+	s.slowSleep()
+	if err := s.togglePin(p2, idle, set, idle, set); err != nil {
+		return err
+	}
+	if !<-s.waitForEdge(p1) {
+		return fmt.Errorf("edge %s->%s didn't trigger", idle, set)
+	}
+	if <-s.waitForEdge(p1) {
+		// The linux kernel makes it hard to enforce this. :(
+		fmt.Printf("    warning: didn't expect for two edges to accumulate\n")
+	}
+
+	// Calling In() flush any accumulated event.
+	s.slowSleep()
+	if err := s.togglePin(p2, idle, set); err != nil {
+		return err
+	}
+	// At that point, there's an accumulated event.
+	time.Sleep(s.shortDelay)
+	// This flushes the event.
+	if err := p1.In(gpio.Float, e); err != nil {
+		return err
+	}
+	if <-s.waitForEdge(p1) {
+		// The linux kernel makes it hard to enforce this. :(
+		fmt.Printf("    warning: accumulated event should have been flushed by In()\n")
+	}
+
+	return nil
+}
+
+// testEdges ensures edge based triggering works.
+func (s *SmokeTest) testEdges(p1, p2 gpio.PinIO) error {
+	// Test for:
+	// - Falling, Rising, Both
+	// - None
+	if err := s.testEdgesBoth(p1, p2); err != nil {
+		return err
+	}
+	if err := s.testEdgesSide(p1, p2, gpio.Rising); err != nil {
+		return err
+	}
+	if err := s.testEdgesSide(p1, p2, gpio.Falling); err != nil {
+		return err
+	}
+	return nil
+}
+
+// testPull ensures input pull resistor works.
+func (s *SmokeTest) testPull(p1, p2 gpio.PinIO) error {
+	fmt.Printf("  Testing input pull resistor\n")
+	if err := preparePins(p1, p2); err != nil {
+		return err
+	}
+	if err := p2.In(gpio.Down, gpio.None); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	fmt.Printf("    -> %s: %s\n    -> %s: %s\n", p1, p1.Function(), p2, p2.Function())
+	if p1.Read() != gpio.Low {
+		return errors.New("read pull down failure")
+	}
+
+	s.slowSleep()
+	if err := p2.In(gpio.Up, gpio.None); err != nil {
+		return err
+	}
+	time.Sleep(s.shortDelay)
+	fmt.Printf("    -> %s: %s\n    -> %s: %s\n", p1, p1.Function(), p2, p2.Function())
+	if p1.Read() != gpio.High {
+		return errors.New("read pull up failure")
+	}
+	return nil
+}
+
+func (s *SmokeTest) testCycle(p1, p2 gpio.PinIO) error {
+	fmt.Printf("Testing %s -> %s\n", p2, p1)
+	if err := s.testBasic(p1, p2); err != nil {
+		return err
+	}
+	if !s.noEdge {
+		if err := s.testEdges(p1, p2); err != nil {
+			return err
+		}
+	}
+	if !s.noPull {
+		if err := s.testPull(p1, p2); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+//
+
+func printPin(p gpio.PinIO) {
+	fmt.Printf("- %s: %s", p, p.Function())
+	if r, ok := p.(gpio.RealPin); ok {
+		fmt.Printf("  alias for %s", r.Real())
+	}
+	fmt.Print("\n")
 }
 
 func getPin(s string, useSysfs bool) (gpio.PinIO, error) {
@@ -65,13 +463,6 @@ func getPin(s string, useSysfs bool) (gpio.PinIO, error) {
 	return p, nil
 }
 
-func slowSleep(do bool) {
-	if do {
-		fmt.Printf("  Sleep(%s)\n", longDelay)
-		time.Sleep(longDelay)
-	}
-}
-
 // preparePins sets p1 as input without pull and p2 as output low.
 func preparePins(p1, p2 gpio.PinIO) error {
 	if err := p1.In(gpio.Float, gpio.None); err != nil {
@@ -80,361 +471,26 @@ func preparePins(p1, p2 gpio.PinIO) error {
 	return p2.Out(gpio.Low)
 }
 
-// testBasic ensures basic operation works.
-func testBasic(p1, p2 gpio.PinIO, slow bool) error {
-	fmt.Printf("  Testing basic functionality\n")
-	if err := preparePins(p1, p2); err != nil {
-		return err
-	}
-	time.Sleep(shortDelay)
-	fmt.Printf("    -> %s: %s\n    -> %s: %s\n", p1, p1.Function(), p2, p2.Function())
-	if l := p1.Read(); l != gpio.Low {
-		return fmt.Errorf("%s: expected to read %s but got %s", p1, gpio.Low, l)
-	}
-
-	slowSleep(slow)
-	if err := p2.Out(gpio.High); err != nil {
-		return err
-	}
-	time.Sleep(shortDelay)
-	fmt.Printf("    -> %s: %s\n    -> %s: %s\n", p1, p1.Function(), p2, p2.Function())
-	if l := p1.Read(); l != gpio.High {
-		return fmt.Errorf("%s: expected to read %s but got %s", p1, gpio.High, l)
-	}
-	return nil
+// since returns time in µs since the test start.
+func since(start time.Time) string {
+	µs := (time.Since(start) + time.Microsecond/2) / time.Microsecond
+	ms := µs / 1000
+	µs %= 1000
+	return fmt.Sprintf("%3d.%03dms", ms, µs)
 }
 
-func waitForEdge(p gpio.PinIO) <-chan bool {
-	c := make(chan bool)
-	// A timeout inherently makes this test flaky but there's a inherent
-	// assumption that the CPU edge trigger wakes up this process within a
-	// reasonable amount of time; in term of latency.
-	go func() {
-		b := p.WaitForEdge(100 * time.Millisecond)
-		fmt.Printf("    -> WaitForEdge(%s) -> %t\n", p, b)
-		c <- b
-	}()
-	return c
+// loggingPin logs when its state changes.
+type loggingPin struct {
+	gpio.PinIO
+	start time.Time
 }
 
-func togglePin(p gpio.PinIO, levels ...gpio.Level) error {
-	for i, l := range levels {
-		if err := p.Out(l); err != nil {
-			return err
-		}
-		if i != len(levels)-1 {
-			// In that case, the switch can be very fast (a mere few CPU cycles) so
-			// sleep a bit more as we really want to test if the CPU detected these
-			// or not.
-			time.Sleep(shortDelay)
-		}
-	}
-	return nil
+func (p *loggingPin) In(pull gpio.Pull, edge gpio.Edge) error {
+	fmt.Printf("    %s %s.In(%s, %s)\n", since(p.start), p, pull, edge)
+	return p.PinIO.In(pull, edge)
 }
 
-// testEdgesBoth tests with gpio.Both.
-//
-// The following events are tested for:
-// - Getting missing edges
-// - No accumulation of edges (only trigger once)
-// - No spurious edge
-func testEdgesBoth(p1, p2 gpio.PinIO, slow bool) error {
-	fmt.Printf("  Testing edges with %s\n", gpio.Both)
-	if err := preparePins(p1, p2); err != nil {
-		return err
-	}
-	if err := p1.In(gpio.Float, gpio.Both); err != nil {
-		return err
-	}
-	if c := waitForEdge(p1); <-c {
-		return errors.New("there should be no edge right after setting a pin")
-	}
-
-	slowSleep(slow)
-	c := waitForEdge(p1)
-	if err := p2.Out(gpio.High); err != nil {
-		return err
-	}
-	if !<-c {
-		return errors.New("edge Low->High didn't trigger")
-	}
-
-	slowSleep(slow)
-	c = waitForEdge(p1)
-	if err := p2.Out(gpio.Low); err != nil {
-		return err
-	}
-	if !<-c {
-		return errors.New("edge High->Low didn't trigger")
-	}
-
-	// No edge
-	slowSleep(slow)
-	if <-waitForEdge(p1) {
-		return errors.New("spurious edge 2")
-	}
-
-	// One accumulated edge.
-	slowSleep(slow)
-	if err := p2.Out(gpio.High); err != nil {
-		return err
-	}
-	if !<-waitForEdge(p1) {
-		return errors.New("edge Low->High didn't trigger")
-	}
-
-	// Two accumulated edge are merged.
-	slowSleep(slow)
-	if err := togglePin(p2, gpio.Low, gpio.High); err != nil {
-		return err
-	}
-	if !<-waitForEdge(p1) {
-		return errors.New("edge High->Low didn't trigger")
-	}
-	if <-waitForEdge(p1) {
-		// BUG(maruel): Seen this to occur flakily. Need to investigate. :(
-		//return errors.New("didn't expect for two edges to accumulate")
-	}
-
-	// Calling In() flush any accumulated event.
-	slowSleep(slow)
-	if err := p2.Out(gpio.Low); err != nil {
-		return err
-	}
-	// At that point, there's an accumulated event.
-	time.Sleep(shortDelay)
-	// This flushes the event.
-	if err := p1.In(gpio.Float, gpio.Both); err != nil {
-		return err
-	}
-	if <-waitForEdge(p1) {
-		return errors.New("accumulated event should have been flushed by In()")
-	}
-
-	return nil
-}
-
-// testEdgesSide tests with gpio.Rising or gpio.Falling.
-//
-// The following events are tested for:
-// - Getting missing edges
-// - No accumulation of edges (only trigger once)
-// - No spurious edge
-func testEdgesSide(p1, p2 gpio.PinIO, e gpio.Edge, slow bool) error {
-	set := gpio.High
-	idle := gpio.Low
-	if e == gpio.Falling {
-		set, idle = idle, set
-	}
-	fmt.Printf("  Testing edges with %s\n", e)
-	if err := preparePins(p1, p2); err != nil {
-		return err
-	}
-	if err := p2.Out(idle); err != nil {
-		return err
-	}
-	if err := p1.In(gpio.Float, e); err != nil {
-		return err
-	}
-	if c := waitForEdge(p1); <-c {
-		return errors.New("there should be no edge right after setting a pin")
-	}
-
-	slowSleep(slow)
-	c := waitForEdge(p1)
-	if err := p2.Out(set); err != nil {
-		return err
-	}
-	if !<-c {
-		return fmt.Errorf("edge %s->%s didn't trigger", idle, set)
-	}
-
-	// No edge
-	slowSleep(slow)
-	c = waitForEdge(p1)
-	if err := p2.Out(idle); err != nil {
-		return err
-	}
-	if <-c {
-		return fmt.Errorf("edge %s->%s shouldn't trigger", set, idle)
-	}
-	if <-waitForEdge(p1) {
-		return errors.New("spurious edge 2")
-	}
-
-	// One accumulated edge.
-	slowSleep(slow)
-	if err := p2.Out(set); err != nil {
-		return err
-	}
-	if !<-waitForEdge(p1) {
-		return fmt.Errorf("edge %s->%s didn't trigger", idle, set)
-	}
-
-	// Two accumulated edge are merged.
-	slowSleep(slow)
-	if err := togglePin(p2, idle, set, idle, set); err != nil {
-		return err
-	}
-	if !<-waitForEdge(p1) {
-		return fmt.Errorf("edge %s->%s didn't trigger", idle, set)
-	}
-	if <-waitForEdge(p1) {
-		// BUG(maruel): Seen this to occur flakily. Need to investigate. :(
-		//return errors.New("didn't expect for two edges to accumulate")
-	}
-
-	// Calling In() flush any accumulated event.
-	slowSleep(slow)
-	if err := togglePin(p2, idle, set); err != nil {
-		return err
-	}
-	// At that point, there's an accumulated event.
-	time.Sleep(shortDelay)
-	// This flushes the event.
-	if err := p1.In(gpio.Float, e); err != nil {
-		return err
-	}
-	if <-waitForEdge(p1) {
-		return errors.New("accumulated event should have been flushed by In()")
-	}
-
-	return nil
-}
-
-// testEdges ensures edge based triggering works.
-func testEdges(p1, p2 gpio.PinIO, slow bool) error {
-	// Test for:
-	// - Falling, Rising, Both
-	// - None
-	if err := testEdgesBoth(p1, p2, slow); err != nil {
-		return err
-	}
-	if err := testEdgesSide(p1, p2, gpio.Rising, slow); err != nil {
-		return err
-	}
-	if err := testEdgesSide(p1, p2, gpio.Falling, slow); err != nil {
-		return err
-	}
-	return nil
-}
-
-// testPull ensures input pull resistor works.
-func testPull(p1, p2 gpio.PinIO, slow bool) error {
-	fmt.Printf("  Testing input pull resistor\n")
-	if err := preparePins(p1, p2); err != nil {
-		return err
-	}
-	if err := p2.In(gpio.Down, gpio.None); err != nil {
-		return err
-	}
-	time.Sleep(shortDelay)
-	fmt.Printf("    -> %s: %s\n    -> %s: %s\n", p1, p1.Function(), p2, p2.Function())
-	if p1.Read() != gpio.Low {
-		return errors.New("read pull down failure")
-	}
-
-	slowSleep(slow)
-	if err := p2.In(gpio.Up, gpio.None); err != nil {
-		return err
-	}
-	time.Sleep(shortDelay)
-	fmt.Printf("    -> %s: %s\n    -> %s: %s\n", p1, p1.Function(), p2, p2.Function())
-	if p1.Read() != gpio.High {
-		return errors.New("read pull up failure")
-	}
-	return nil
-}
-
-func testCycle(p1, p2 gpio.PinIO, noPull, slow bool) error {
-	fmt.Printf("Testing %s -> %s\n", p2, p1)
-	if err := testBasic(p1, p2, slow); err != nil {
-		return err
-	}
-	if err := testEdges(p1, p2, slow); err != nil {
-		return err
-	}
-	if !noPull {
-		if err := testPull(p1, p2, slow); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-type SmokeTest struct {
-}
-
-func (s *SmokeTest) Name() string {
-	return "gpio"
-}
-
-func (s *SmokeTest) Description() string {
-	return "Tests basic functionality, edge detection and input pull resistors"
-}
-
-func printPin(p gpio.PinIO) {
-	fmt.Printf("- %s: %s", p, p.Function())
-	if r, ok := p.(gpio.RealPin); ok {
-		fmt.Printf("  alias for %s", r.Real())
-	}
-	fmt.Print("\n")
-}
-
-func (s *SmokeTest) Run(args []string) error {
-	f := flag.NewFlagSet("gpio", flag.ExitOnError)
-	slow := f.Bool("s", false, "slow; insert a second between each step")
-	useSysfs := f.Bool("sysfs", false, "force the use of sysfs")
-	f.Parse(args)
-	if f.NArg() != 2 {
-		// TODO(maruel): Find pins automatically:
-		// - For each header in headers.All():
-		//   - For each pin in header that are GPIO:
-		//     - p.In(Down, Rising)
-		//     - Start a goroutine to detect edge.
-		//   - For each pin in header that are GPIO:
-		//     - p.Out(High)
-		//     - See if a pin triggered
-		//     - p.In(Down, Rising)
-		// This assumes that everything actually work in the first place.
-		return errors.New("specify the two pins to use; they must be connected together")
-	}
-
-	// On certain Allwinner CPUs, it's a good idea to test specifically the PLx
-	// pins, since they use a different register memory block (driver
-	// "allwinner_pl") than groups PB to PH (driver "allwinner").
-	p1, err := getPin(f.Args()[0], *useSysfs)
-	if err != nil {
-		return err
-	}
-	p2, err := getPin(f.Args()[1], *useSysfs)
-	if err != nil {
-		return err
-	}
-
-	// Disable pull testing when using sysfs because it is not supported.
-	_, noPull := p1.(*sysfs.Pin)
-	if !noPull {
-		_, noPull = p2.(*sysfs.Pin)
-	}
-	if noPull {
-		fmt.Printf("Skipping input pull resistor on sysfs\n")
-	}
-
-	fmt.Printf("Using pins and their current state:\n")
-	printPin(p1)
-	printPin(p2)
-	pl1 := &loggingPin{p1}
-	pl2 := &loggingPin{p2}
-	err = testCycle(pl1, pl2, noPull, *slow)
-	if err == nil {
-		err = testCycle(pl2, pl1, noPull, *slow)
-	}
-	if err2 := pl1.In(gpio.PullNoChange, gpio.None); err2 != nil {
-		fmt.Printf("(Exit) Failed to reset %s as input: %s\n", pl1, err2)
-	}
-	if err2 := pl2.In(gpio.PullNoChange, gpio.None); err2 != nil {
-		fmt.Printf("(Exit) Failed to reset %s as input: %s\n", pl1, err2)
-	}
-	return err
+func (p *loggingPin) Out(l gpio.Level) error {
+	fmt.Printf("    %s %s.Out(%s)\n", since(p.start), p, l)
+	return p.PinIO.Out(l)
 }

--- a/host/sysfs/gpio_other.go
+++ b/host/sysfs/gpio_other.go
@@ -13,11 +13,11 @@ import (
 
 type event struct{}
 
-func (e event) wait(ep, timeoutms int) (int, error) {
+func (e event) makeEvent(f *os.File) error {
 	return 0, errors.New("unreachable code")
 }
 
-func (e event) makeEvent(f *os.File) (int, error) {
+func (e event) wait(timeoutms int) (int, error) {
 	return 0, errors.New("unreachable code")
 }
 


### PR DESCRIPTION
Rewrite the edge detection logic to be more resilient. There is still some level
of guess but the smoke test is much more reliable on all 3 tested platforms.

Soften the expectations about edge detection.

Disabled gpio edge detection smoke test for now on Pine64. This needs more
diagnostic.