### PR TITLE
Add onewrite.Pull.String().

### DIFF
--- a/experimental/conn/onewire/onewire.go
+++ b/experimental/conn/onewire/onewire.go
@@ -70,6 +70,13 @@ const (
 	StrongPullup Pullup = true
 )
 
+func (p Pullup) String() string {
+	if p {
+		return "Strong"
+	}
+	return "Weak"
+}
+
 // BusCloser is a 1-wire bus that can be closed.
 //
 // It is expected that an implementer of Bus also implement BusCloser, but

--- a/experimental/conn/onewire/onewiretest/onewiretest.go
+++ b/experimental/conn/onewire/onewiretest/onewiretest.go
@@ -117,7 +117,7 @@ func (p *Playback) Tx(w, r []byte, pull onewire.Pullup) error {
 		return fmt.Errorf("onewire: unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
 	}
 	if pull != p.Ops[0].Pull {
-		return fmt.Errorf("onewire: unexpected pullup %d != %d", pull, p.Ops[0].Pull)
+		return fmt.Errorf("onewire: unexpected pullup %s != %s", pull, p.Ops[0].Pull)
 	}
 	// Determine whether this starts a search and reset search state.
 	if len(w) > 0 && w[0] == 0xf0 {


### PR DESCRIPTION
This fixes the go vet failure on pine64.