### PR TITLE
allwinner_pl: refactor in preparation for merging back into allwinner.

### DIFF
--- a/host/allwinner_pl/doc.go
+++ b/host/allwinner_pl/doc.go
@@ -10,6 +10,7 @@
 // Datasheet
 //
 // A64: http://files.pine64.org/doc/datasheet/pine64/Allwinner_A64_User_Manual_V1.0.pdf
+//
 // H3: http://dl.linux-sunxi.org/H3/Allwinner_H3_Datasheet_V1.0.pdf
 //
 // Physical overview: http://files.pine64.org/doc/datasheet/pine64/A64_Datasheet_V1.1.pdf

--- a/host/pine64/pine64.go
+++ b/host/pine64/pine64.go
@@ -285,7 +285,7 @@ func (d *driver) String() string {
 }
 
 func (d *driver) Prerequisites() []string {
-	return []string{"allwinner_pl"}
+	return []string{"allwinner-gpio-pl"}
 }
 
 func (d *driver) Init() (bool, error) {


### PR DESCRIPTION
Make this module more coherent, each one will be refactored in a similar way.

This goal of this change is to clean up the godoc page. In particular the global
variables are now shown on a single line. While here there's only 11 variables
it isn't a big deal, it'll make a drastic improvement in package allwinner and
bcm283x.