### PR TITLE
Increase polish.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ your platform.
 **Every commit is [tested on real hardware](doc/drivers/CONTRIBUTING.md#testing)
 via [gohci](https://github.com/maruel/gohci) workers.**
 
-We gladly accept contributions from device driver developers via GitHub pull
-requests, as long as the author has signed the Google Contributor License.
-Please see [doc/drivers/CONTRIBUTING.md](doc/drivers/CONTRIBUTING.md) for more
-details.
+We gladly accept contributions for documentation improvements and from device
+driver developers via GitHub pull requests, as long as the author has signed the
+Google Contributor License. Please see
+[doc/drivers/CONTRIBUTING.md](doc/drivers/CONTRIBUTING.md) for more details.
 
 
 ## Philosophy

--- a/conn/conntest/conntest.go
+++ b/conn/conntest/conntest.go
@@ -74,7 +74,7 @@ func (r *Record) Tx(w, read []byte) error {
 	defer r.Unlock()
 	if r.Conn == nil {
 		if len(read) != 0 {
-			return errors.New("read unsupported when no bus is connected")
+			return errors.New("conntest: read unsupported when no bus is connected")
 		}
 	} else {
 		if err := r.Conn.Tx(w, read); err != nil {
@@ -117,14 +117,13 @@ func (p *Playback) Tx(w, r []byte) error {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.Ops) == 0 {
-		// log.Fatal() ?
-		return errors.New("unexpected Tx()")
+		return errors.New("conntest: unexpected Tx()")
 	}
 	if !bytes.Equal(p.Ops[0].Write, w) {
-		return fmt.Errorf("unexpected write %#v != %#v", w, p.Ops[0].Write)
+		return fmt.Errorf("conntest: unexpected write %#v != %#v", w, p.Ops[0].Write)
 	}
 	if len(p.Ops[0].Read) != len(r) {
-		return fmt.Errorf("unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
+		return fmt.Errorf("conntest: unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
 	}
 	copy(r, p.Ops[0].Read)
 	p.Ops = p.Ops[1:]

--- a/conn/gpio/gpio.go
+++ b/conn/gpio/gpio.go
@@ -373,7 +373,7 @@ func RegisterAlias(name string, number int) error {
 //
 
 // errInvalidPin is returned when trying to use INVALID.
-var errInvalidPin = errors.New("invalid pin")
+var errInvalidPin = errors.New("gpio: invalid pin")
 
 var (
 	mu sync.Mutex

--- a/conn/gpio/gpiotest/gpiotest.go
+++ b/conn/gpio/gpiotest/gpiotest.go
@@ -58,7 +58,7 @@ func (p *Pin) In(pull gpio.Pull, edge gpio.Edge) error {
 		p.L = gpio.High
 	}
 	if edge != gpio.None && p.EdgesChan == nil {
-		return errors.New("please set p.EdgesChan first")
+		return errors.New("gpiotest: please set p.EdgesChan first")
 	}
 	for {
 		select {

--- a/conn/i2c/i2ctest/i2ctest.go
+++ b/conn/i2c/i2ctest/i2ctest.go
@@ -41,7 +41,7 @@ func (r *Record) Tx(addr uint16, w, read []byte) error {
 	defer r.Unlock()
 	if r.Bus == nil {
 		if len(read) != 0 {
-			return errors.New("read unsupported when no bus is connected")
+			return errors.New("i2ctest: read unsupported when no bus is connected")
 		}
 	} else {
 		if err := r.Bus.Tx(addr, w, read); err != nil {
@@ -100,7 +100,7 @@ func (p *Playback) Close() error {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.Ops) != 0 {
-		return fmt.Errorf("expected playback to be empty:\n%#v", p.Ops)
+		return fmt.Errorf("i2ctest: expected playback to be empty:\n%#v", p.Ops)
 	}
 	return nil
 }
@@ -110,17 +110,16 @@ func (p *Playback) Tx(addr uint16, w, r []byte) error {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.Ops) == 0 {
-		// log.Fatal() ?
-		return errors.New("unexpected Tx()")
+		return errors.New("i2ctest: unexpected Tx()")
 	}
 	if addr != p.Ops[0].Addr {
-		return fmt.Errorf("unexpected addr %d != %d", addr, p.Ops[0].Addr)
+		return fmt.Errorf("i2ctest: unexpected addr %d != %d", addr, p.Ops[0].Addr)
 	}
 	if !bytes.Equal(p.Ops[0].Write, w) {
-		return fmt.Errorf("unexpected write %#v != %#v", w, p.Ops[0].Write)
+		return fmt.Errorf("i2ctest: unexpected write %#v != %#v", w, p.Ops[0].Write)
 	}
 	if len(p.Ops[0].Read) != len(r) {
-		return fmt.Errorf("unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
+		return fmt.Errorf("i2ctest: unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
 	}
 	copy(r, p.Ops[0].Read)
 	p.Ops = p.Ops[1:]

--- a/conn/spi/spitest/spitest.go
+++ b/conn/spi/spitest/spitest.go
@@ -69,7 +69,7 @@ func (r *Record) Tx(w, read []byte) error {
 	defer r.Unlock()
 	if r.Conn == nil {
 		if len(read) != 0 {
-			return errors.New("read unsupported when no bus is connected")
+			return errors.New("spitest: read unsupported when no bus is connected")
 		}
 	} else {
 		if err := r.Conn.Tx(w, read); err != nil {

--- a/devices/apa102/apa102.go
+++ b/devices/apa102/apa102.go
@@ -300,6 +300,6 @@ func New(s spi.Conn, numLights int, intensity uint8, temperature uint16) (*Dev, 
 
 //
 
-var errLength = errors.New("invalid RGB stream length")
+var errLength = errors.New("apa102: invalid RGB stream length")
 
 var _ devices.Display = &Dev{}

--- a/devices/bme280/bme280.go
+++ b/devices/bme280/bme280.go
@@ -146,7 +146,7 @@ func NewI2C(b i2c.Bus, opts *Opts) (*Dev, error) {
 		case 0x00:
 			// do not do anything
 		default:
-			return nil, errors.New("given address not supported by device")
+			return nil, errors.New("bme280: given address not supported by device")
 		}
 	}
 	d := &Dev{d: &i2c.Dev{Bus: b, Addr: addr}, isSPI: false}
@@ -232,7 +232,7 @@ func (d *Dev) makeDev(opts *Opts) error {
 		return err
 	}
 	if chipID[0] != 0x60 {
-		return errors.New("unexpected chip id; is this a BME280?")
+		return errors.New("bme280: unexpected chip id; is this a BME280?")
 	}
 	// Read calibration data t1~3, p1~9, 8bits padding, h1.
 	var tph [0xA2 - 0x88]byte

--- a/devices/devicestest/display.go
+++ b/devices/devicestest/display.go
@@ -21,7 +21,7 @@ type Display struct {
 // Write implements devices.Display.
 func (d *Display) Write(pixels []byte) (int, error) {
 	if len(pixels)%3 != 0 {
-		return 0, errors.New("invalid RGB stream length")
+		return 0, errors.New("devicetest: invalid RGB stream length")
 	}
 	copy(d.Img.Pix, pixels)
 	return len(pixels), nil

--- a/devices/ssd1306/image1bit/image1bit.go
+++ b/devices/ssd1306/image1bit/image1bit.go
@@ -56,7 +56,7 @@ func New(r image.Rectangle) (*Image, error) {
 	h := r.Dy()
 	w := r.Dx()
 	if h&7 != 0 {
-		return nil, errors.New("height must be multiple of 8")
+		return nil, errors.New("image1bit: height must be multiple of 8")
 	}
 	return &Image{w, h, make([]byte, w*h/8)}, nil
 }

--- a/experimental/conn/onewire/onewiretest/onewiretest.go
+++ b/experimental/conn/onewire/onewiretest/onewiretest.go
@@ -41,7 +41,7 @@ func (r *Record) Tx(w, read []byte, pull onewire.Pullup) error {
 	defer r.Unlock()
 	if r.Bus == nil {
 		if len(read) != 0 {
-			return errors.New("onewire: read unsupported when no bus is connected")
+			return errors.New("onewiretest: read unsupported when no bus is connected")
 		}
 	} else {
 		if err := r.Bus.Tx(w, read, pull); err != nil {
@@ -97,7 +97,7 @@ func (p *Playback) Close() error {
 	p.Lock()
 	defer p.Unlock()
 	if len(p.Ops) != 0 {
-		return fmt.Errorf("onewire: expected playback to be empty:\n%#v", p.Ops)
+		return fmt.Errorf("onewiretest: expected playback to be empty:\n%#v", p.Ops)
 	}
 	return nil
 }
@@ -108,16 +108,16 @@ func (p *Playback) Tx(w, r []byte, pull onewire.Pullup) error {
 	defer p.Unlock()
 	if len(p.Ops) == 0 {
 		// log.Fatal() ?
-		return errors.New("onewire: unexpected Tx()")
+		return errors.New("onewiretest: unexpected Tx()")
 	}
 	if !bytes.Equal(p.Ops[0].Write, w) {
-		return fmt.Errorf("onewire: unexpected write %#v != %#v", w, p.Ops[0].Write)
+		return fmt.Errorf("onewiretest: unexpected write %#v != %#v", w, p.Ops[0].Write)
 	}
 	if len(p.Ops[0].Read) != len(r) {
-		return fmt.Errorf("onewire: unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
+		return fmt.Errorf("onewiretest: unexpected read buffer length %d != %d", len(r), len(p.Ops[0].Read))
 	}
 	if pull != p.Ops[0].Pull {
-		return fmt.Errorf("onewire: unexpected pullup %s != %s", pull, p.Ops[0].Pull)
+		return fmt.Errorf("onewiretest: unexpected pullup %s != %s", pull, p.Ops[0].Pull)
 	}
 	// Determine whether this starts a search and reset search state.
 	if len(w) > 0 && w[0] == 0xf0 {
@@ -139,10 +139,10 @@ func (p *Playback) Search(alarmOnly bool) ([]onewire.Address, error) {
 func (p *Playback) SearchTriplet(direction byte) (onewire.TripletResult, error) {
 	tr := onewire.TripletResult{}
 	if p.searchBit > 63 {
-		return tr, errors.New("onewire: search performs more than 64 triplet operations")
+		return tr, errors.New("onewiretest: search performs more than 64 triplet operations")
 	}
 	if len(p.inactive) != len(p.Devices) {
-		return tr, errors.New("onewire: Devices must be initialized before starting seach")
+		return tr, errors.New("onewiretest: Devices must be initialized before starting seach")
 	}
 	// Figure out the devices' response.
 	for i := range p.Devices {

--- a/experimental/conn/onewire/search.go
+++ b/experimental/conn/onewire/search.go
@@ -80,7 +80,7 @@ func Search(bus BusSearcher, alarmOnly bool) ([]Address, error) {
 			// Check for the absence of devices on the bus. This is a 1-wire
 			// bus error condition and we return a partial result.
 			if !result.GotZero && !result.GotOne {
-				return devices, fmt.Errorf("1-wire: devices disappeared during search")
+				return devices, fmt.Errorf("onewire: devices disappeared during search")
 			}
 
 			// Check whether we have devices responding for 0 and 1 and we
@@ -101,7 +101,7 @@ func Search(bus BusSearcher, alarmOnly bool) ([]Address, error) {
 		// Verify the CRC and record device if we got it right.
 		if !CheckCRC(idBytes[:]) {
 			// CRC error: return partial result.  This is a transient error.
-			e := fmt.Sprintf("1-wire: CRC error during search, addr=%+v", idBytes)
+			e := fmt.Sprintf("onewire: CRC error during search, addr=%+v", idBytes)
 			return devices, busError(e)
 		}
 		devices = append(devices, Address(device))

--- a/experimental/conn/uart/uart.go
+++ b/experimental/conn/uart/uart.go
@@ -110,17 +110,14 @@ func Register(name string, busNumber int, opener Opener) error {
 	mu.Lock()
 	defer mu.Unlock()
 	if _, ok := byName[name]; ok {
-		return fmt.Errorf("registering the same UART %s twice", name)
+		return fmt.Errorf("uart: registering the same port %s twice", name)
 	}
 	if busNumber != -1 {
 		if _, ok := byNumber[busNumber]; ok {
-			return fmt.Errorf("registering the same UART #%d twice", busNumber)
+			return fmt.Errorf("uart: registering the same port #%d twice", busNumber)
 		}
 	}
 
-	if first == nil {
-		first = opener
-	}
 	byName[name] = opener
 	if busNumber != -1 {
 		byNumber[busNumber] = opener
@@ -137,27 +134,14 @@ func Unregister(name string, busNumber int) error {
 	defer mu.Unlock()
 	_, ok := byName[name]
 	if !ok {
-		return errors.New("unknown name")
+		return fmt.Errorf("uart: unknown port name %s", name)
 	}
 	if _, ok := byNumber[busNumber]; !ok {
-		return errors.New("unknown number")
+		return fmt.Errorf("uart: unknown port number %d", busNumber)
 	}
 
 	delete(byName, name)
 	delete(byNumber, busNumber)
-	first = nil
-	/* TODO(maruel): Figure out a way.
-	if first == bus {
-		first = nil
-		last := ""
-		for name, b := range byName {
-			if last == "" || last > name {
-				last = name
-				first = b
-			}
-		}
-	}
-	*/
 	return nil
 }
 
@@ -166,22 +150,26 @@ func Unregister(name string, busNumber int) error {
 func find(busNumber int) (Opener, error) {
 	mu.Lock()
 	defer mu.Unlock()
+	if len(byNumber) == 0 {
+		return nil, errors.New("uart: no port found; did you forget to call Init()?")
+	}
 	if busNumber == -1 {
-		if first == nil {
-			return nil, errors.New("no UART bus found")
+		busNumber = int((^uint(0)) >> 1)
+		for n := range byNumber {
+			if busNumber > n {
+				busNumber = n
+			}
 		}
-		return first, nil
 	}
 	bus, ok := byNumber[busNumber]
 	if !ok {
-		return nil, fmt.Errorf("no UART bus %d", busNumber)
+		return nil, fmt.Errorf("uart: no port %d found", busNumber)
 	}
 	return bus, nil
 }
 
 var (
 	mu       sync.Mutex
-	first    Opener
 	byName   = map[string]Opener{}
 	byNumber = map[int]Opener{}
 )

--- a/experimental/conn/usb/usb.go
+++ b/experimental/conn/usb/usb.go
@@ -48,7 +48,7 @@ func Register(id ID, opener Opener) error {
 	mu.Lock()
 	defer mu.Unlock()
 	if _, ok := byID[id]; ok {
-		return fmt.Errorf("registering the same USB id %s twice", id)
+		return fmt.Errorf("usb: registering the same USB device id %s twice", id)
 	}
 
 	byID[id] = opener

--- a/experimental/devices/bitbang/i2c.go
+++ b/experimental/devices/bitbang/i2c.go
@@ -54,7 +54,7 @@ func (i *I2C) Tx(addr uint16, w, r []byte) error {
 		if addr > 0xFF {
 			// Page 15, section 3.1.11 10-bit addressing
 			// TOOD(maruel): Implement if desired; prefix 0b11110xx.
-			return errors.New("invalid address")
+			return errors.New("bitbang-i2c: invalid address")
 		}
 		// Page 13, section 3.1.10 The slave address and R/W bit
 		addr <<= 1
@@ -66,7 +66,7 @@ func (i *I2C) Tx(addr uint16, w, r []byte) error {
 			return err
 		}
 		if !ack {
-			return errors.New("i2c: got NACK")
+			return errors.New("bitbang-i2c: got NACK")
 		}
 	}
 	for _, b := range w {
@@ -75,7 +75,7 @@ func (i *I2C) Tx(addr uint16, w, r []byte) error {
 			return err
 		}
 		if !ack {
-			return errors.New("i2c: got NACK")
+			return errors.New("bitbang-i2c: got NACK")
 		}
 	}
 	for x := range r {

--- a/experimental/devices/bitbang/spi.go
+++ b/experimental/devices/bitbang/spi.go
@@ -71,7 +71,7 @@ func (s *SPI) Configure(mode spi.Mode, bits int) error {
 // BUG(maruel): Test if read works.
 func (s *SPI) Tx(w, r []byte) error {
 	if len(r) != 0 && len(w) != len(r) {
-		return errors.New("write and read buffers must be the same length")
+		return errors.New("bitbang-spi: write and read buffers must be the same length")
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/experimental/devices/piblaster/piblaster.go
+++ b/experimental/devices/piblaster/piblaster.go
@@ -29,7 +29,7 @@ import (
 // duty must be [0, 1].
 func SetPWM(p gpio.PinIO, duty float32) error {
 	if duty < 0 || duty > 1 {
-		return fmt.Errorf("duty %f is invalid for blaster", duty)
+		return fmt.Errorf("piblaster: duty %f is invalid for blaster", duty)
 	}
 	err := openPiblaster()
 	if err == nil {

--- a/experimental/driver_skeleton/driver_skeleton.go
+++ b/experimental/driver_skeleton/driver_skeleton.go
@@ -30,7 +30,7 @@ func New(i i2c.Bus) (*Dev, error) {
 		return nil, err
 	}
 	if b[0] != 'I' || b[1] != 'N' {
-		return nil, errors.New("unexpected reply")
+		return nil, errors.New("driver_skeleton: unexpected reply")
 	}
 	return d, nil
 }

--- a/experimental/host/sysfs/uart.go
+++ b/experimental/host/sysfs/uart.go
@@ -66,22 +66,22 @@ func (u *UART) String() string {
 
 // Configure implements uart.Conn.
 func (u *UART) Configure(stopBit uart.Stop, parity uart.Parity, bits int) error {
-	return errors.New("uart: not implemented")
+	return errors.New("sysfs-uart: not implemented")
 }
 
 // Write implements uart.Conn.
 func (u *UART) Write(b []byte) (int, error) {
-	return 0, errors.New("uart: not implemented")
+	return 0, errors.New("sysfs-uart: not implemented")
 }
 
 // Tx implements uart.Conn.
 func (u *UART) Tx(w, r []byte) error {
-	return errors.New("uart: not implemented")
+	return errors.New("sysfs-uart: not implemented")
 }
 
 // Speed implements uart.Conn.
 func (u *UART) Speed(hz int64) error {
-	return errors.New("uart: not implemented")
+	return errors.New("sysfs-uart: not implemented")
 }
 
 // RX implements uart.Pins.

--- a/host/chip/chip.go
+++ b/host/chip/chip.go
@@ -275,7 +275,7 @@ func (d *driver) Init() (bool, error) {
 	for alias, real := range aliases {
 		r := gpio.ByName(real)
 		if r == nil {
-			return true, fmt.Errorf("Cannot create alias for %s: it doesn't exist", real)
+			return true, fmt.Errorf("cannot create alias for %s: it doesn't exist", real)
 		}
 		if err := gpio.RegisterAlias(alias, r.Number()); err != nil {
 			return true, err

--- a/host/headers/headers.go
+++ b/host/headers/headers.go
@@ -19,8 +19,17 @@ import (
 func All() map[string][][]pins.Pin {
 	mu.Lock()
 	defer mu.Unlock()
-	// TODO(maruel): Return a copy?
-	return allHeaders
+	out := make(map[string][][]pins.Pin, len(allHeaders))
+	for k, v := range allHeaders {
+		outV := make([][]pins.Pin, len(v))
+		for i, w := range v {
+			outW := make([]pins.Pin, len(w))
+			copy(outW, w)
+			outV[i] = outW
+		}
+		out[k] = outV
+	}
+	return out
 }
 
 // Position returns the position on a pin if found.

--- a/host/pmem/view.go
+++ b/host/pmem/view.go
@@ -150,7 +150,7 @@ func mapLinux(base uint64, size int) (*View, error) {
 		syscall.PROT_READ|syscall.PROT_WRITE,
 		syscall.MAP_SHARED)
 	if err != nil {
-		return nil, fmt.Errorf("physview: mapping at 0x%x failed: %v", base, err)
+		return nil, fmt.Errorf("pmem: mapping at 0x%x failed: %v", base, err)
 	}
 	return &View{Slice: i[offset:size], orig: i}, nil
 }

--- a/host/sysfs/gpio_other.go
+++ b/host/sysfs/gpio_other.go
@@ -14,11 +14,11 @@ import (
 type event struct{}
 
 func (e event) makeEvent(f *os.File) error {
-	return 0, errors.New("unreachable code")
+	return 0, errors.New("sysfs-gpio: unreachable code")
 }
 
 func (e event) wait(timeoutms int) (int, error) {
-	return 0, errors.New("unreachable code")
+	return 0, errors.New("sysfs-gpio: unreachable code")
 }
 
 func isErrBusy(err error) bool {

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -44,7 +44,7 @@ func NewI2C(busNumber int) (*I2C, error) {
 	if isLinux {
 		return newI2C(busNumber)
 	}
-	return nil, errors.New("sysfs.i2c is not supported on this platform")
+	return nil, errors.New("sysfs-i2c: is not supported on this platform")
 }
 
 func newI2C(busNumber int) (*I2C, error) {
@@ -56,8 +56,9 @@ func newI2C(busNumber int) (*I2C, error) {
 		//   edited to enable I²C then the device must be rebooted.
 		// - permission denied. In this case, the user has to be added to plugdev.
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("sysfs-i2c: I²C bus #%d is not configured: %v", busNumber, err)
+			return nil, fmt.Errorf("sysfs-i2c: bus #%d is not configured: %v", busNumber, err)
 		}
+		// TODO(maruel): This is a debianism.
 		return nil, fmt.Errorf("sysfs-i2c: are you member of group 'plugdev'? %v", err)
 	}
 	i := &I2C{f: f, busNumber: busNumber}
@@ -137,7 +138,7 @@ func (i *I2C) Speed(hz int64) error {
 	// Sadly it doesn't seem like Allwinner drivers implement the same
 	// functionality:
 	// - /sys/module/i2c_sunxi/
-	return errors.New("not supported")
+	return errors.New("sysfs-i2c: not supported")
 }
 
 // SCL implements i2c.Pins.
@@ -162,7 +163,7 @@ func (i *I2C) SDA() gpio.PinIO {
 
 func (i *I2C) ioctl(op uint, arg uintptr) error {
 	if err := ioctl(i.f.Fd(), op, arg); err != nil {
-		return fmt.Errorf("i²c ioctl: %v", err)
+		return fmt.Errorf("sysfs-i2c: ioctl: %v", err)
 	}
 	return nil
 }

--- a/host/sysfs/led.go
+++ b/host/sysfs/led.go
@@ -36,7 +36,7 @@ func LEDByName(name string) (*LED, error) {
 			return led, nil
 		}
 	}
-	return nil, errors.New("invalid LED name")
+	return nil, errors.New("sysfs-led: invalid LED name")
 }
 
 // LED represents one LED on the system.
@@ -75,10 +75,10 @@ func (l *LED) Function() string {
 // In implements gpio.PinIn.
 func (l *LED) In(pull gpio.Pull, edge gpio.Edge) error {
 	if pull != gpio.Float && pull != gpio.PullNoChange {
-		return errors.New("pull is not supported on LED")
+		return errors.New("sysfs-led: pull is not supported on LED")
 	}
 	if edge != gpio.None {
-		return errors.New("edge is not supported on LED")
+		return errors.New("sysfs-led: edge is not supported on LED")
 	}
 	return nil
 }
@@ -135,7 +135,7 @@ func (l *LED) Out(level gpio.Level) error {
 
 // PWM implements gpio.PinOut.
 func (l *LED) PWM(duty int) error {
-	return errors.New("pwm is not supported")
+	return errors.New("sysfs-led: pwm is not supported")
 }
 
 //

--- a/host/sysfs/spi.go
+++ b/host/sysfs/spi.go
@@ -47,10 +47,10 @@ type SPI struct {
 
 func newSPI(busNumber, chipSelect int) (*SPI, error) {
 	if busNumber < 0 || busNumber > 255 {
-		return nil, errors.New("invalid bus")
+		return nil, fmt.Errorf("sysfs-spi: invalid bus %d", busNumber)
 	}
 	if chipSelect < 0 || chipSelect > 255 {
-		return nil, errors.New("invalid chip select")
+		return nil, fmt.Errorf("sysfs-spi: invalid chip select %d", chipSelect)
 	}
 	// Use the devfs path for now.
 	f, err := os.OpenFile(fmt.Sprintf("/dev/spidev%d.%d", busNumber, chipSelect), os.O_RDWR, os.ModeExclusive)
@@ -80,7 +80,7 @@ func (s *SPI) String() string {
 // Speed implements spi.Conn.
 func (s *SPI) Speed(hz int64) error {
 	if hz < 1000 {
-		return errors.New("invalid speed")
+		return fmt.Errorf("sysfs-spi: invalid speed %d", hz)
 	}
 	return s.setFlag(spiIOCMaxSpeedHz, uint64(hz))
 }
@@ -88,7 +88,7 @@ func (s *SPI) Speed(hz int64) error {
 // Configure implements spi.Conn.
 func (s *SPI) Configure(mode spi.Mode, bits int) error {
 	if bits < 1 || bits > 256 {
-		return errors.New("invalid bits")
+		return fmt.Errorf("sysfs-spi: invalid bits %d", bits)
 	}
 	if err := s.setFlag(spiIOCMode, uint64(mode)); err != nil {
 		return err
@@ -180,14 +180,14 @@ func (s *SPI) setFlag(op uint, arg uint64) error {
 		return err
 	}
 	if actual != arg {
-		return fmt.Errorf("spi op 0x%x: set 0x%x, read 0x%x", op, arg, actual)
+		return fmt.Errorf("sysfs-spi: op 0x%x: set 0x%x, read 0x%x", op, arg, actual)
 	}
 	return nil
 }
 
 func (s *SPI) ioctl(op uint, arg unsafe.Pointer) error {
 	if err := ioctl(s.f.Fd(), op, uintptr(arg)); err != nil {
-		return fmt.Errorf("spi ioctl: %v", err)
+		return fmt.Errorf("sysfs-spi: ioctl: %v", err)
 	}
 	return nil
 }

--- a/host/sysfs/sysfs_other.go
+++ b/host/sysfs/sysfs_other.go
@@ -11,5 +11,5 @@ import "errors"
 const isLinux = false
 
 func ioctl(f uintptr, op uint, arg uintptr) error {
-	return errors.New("ioctl not supported on non-linux")
+	return errors.New("sysfs: ioctl not supported on non-linux")
 }

--- a/host/sysfs/thermal_sensor.go
+++ b/host/sysfs/thermal_sensor.go
@@ -31,7 +31,7 @@ func ThermalSensorByName(name string) (*ThermalSensor, error) {
 			return t, nil
 		}
 	}
-	return nil, errors.New("invalid thermal sensor name")
+	return nil, errors.New("sysfs-thermal: invalid sensor name")
 }
 
 // ThermalSensor represents one thermal sensor on the system.
@@ -88,7 +88,7 @@ func (t *ThermalSensor) Sense(env *devices.Environment) error {
 		return err
 	}
 	if n < 2 {
-		return errors.New("failed to read temperature")
+		return errors.New("sysfs-thermal: failed to read temperature")
 	}
 	i, err := strconv.Atoi(string(buf[:n-1]))
 	if err != nil {
@@ -139,7 +139,7 @@ func (d *driverThermalSensor) Init() (bool, error) {
 		return true, err
 	}
 	if len(items) == 0 {
-		return false, errors.New("no thermal sensor found")
+		return false, errors.New("sysfs-thermal: no sensor found")
 	}
 	sort.Strings(items)
 	for _, item := range items {


### PR DESCRIPTION
- Make error more consistent and more helpful. Not all errors are wrapped yet
  but a fair part is now.
- Remove the 'first' pattern in i2c, spi, uart and make it work.
- Add allwinner.Pin.wrap() for coherence with PinPL and bcm283x.Pin.
- headers.All() return a copy.