### PR TITLE
gpio: Make ByName() also support numbers.

### DIFF
--- a/cmd/gpio-read/main.go
+++ b/cmd/gpio-read/main.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"strconv"
 
 	"github.com/google/periph/conn/gpio"
 	"github.com/google/periph/host"
@@ -58,11 +57,7 @@ func mainImpl() error {
 		return err
 	}
 
-	pin, err := strconv.Atoi(flag.Args()[0])
-	if err != nil {
-		return err
-	}
-	p := gpio.ByNumber(pin)
+	p := gpio.ByName(flag.Args()[0])
 	if p == nil {
 		return errors.New("specify a valid GPIO pin number")
 	}
@@ -70,7 +65,7 @@ func mainImpl() error {
 	if *edges {
 		edge = gpio.Both
 	}
-	if err = p.In(pull, edge); err != nil {
+	if err := p.In(pull, edge); err != nil {
 		return err
 	}
 	if *edges {

--- a/cmd/gpio-write/main.go
+++ b/cmd/gpio-write/main.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/google/periph/conn/gpio"
 	"github.com/google/periph/host"
@@ -18,10 +17,6 @@ import (
 func mainImpl() error {
 	if len(os.Args) != 3 {
 		return errors.New("specify GPIO pin to write to and its level (0 or 1)")
-	}
-	pin, err := strconv.Atoi(os.Args[1])
-	if err != nil {
-		return err
 	}
 
 	l := gpio.Low
@@ -37,7 +32,7 @@ func mainImpl() error {
 		return err
 	}
 
-	p := gpio.ByNumber(pin)
+	p := gpio.ByName(os.Args[1])
 	if p == nil {
 		return errors.New("invalid GPIO pin number")
 	}

--- a/cmd/tm1637/main.go
+++ b/cmd/tm1637/main.go
@@ -20,8 +20,8 @@ import (
 )
 
 func mainImpl() error {
-	clk := flag.Int("c", 4, "CLK pin number")
-	data := flag.Int("d", 5, "DIO pin number")
+	clk := flag.String("c", "4", "CLK pin number")
+	data := flag.String("d", "5", "DIO pin number")
 	off := flag.Bool("o", false, "set display as off")
 	b1 := flag.Bool("b1", false, "set PWM to 1/16")
 	b2 := flag.Bool("b2", false, "set PWM to 2/16")
@@ -107,11 +107,11 @@ func mainImpl() error {
 		return err
 	}
 
-	pClk := gpio.ByNumber(*clk)
+	pClk := gpio.ByName(*clk)
 	if pClk == nil {
 		return errors.New("specify a valid pin for clock")
 	}
-	pData := gpio.ByNumber(*data)
+	pData := gpio.ByName(*data)
 	if pData == nil {
 		return errors.New("specify a valid pin for data")
 	}

--- a/conn/gpio/gpiosmoketest/gpiosmoketest.go
+++ b/conn/gpio/gpiosmoketest/gpiosmoketest.go
@@ -444,19 +444,18 @@ func printPin(p gpio.PinIO) {
 }
 
 func getPin(s string, useSysfs bool) (gpio.PinIO, error) {
-	number, err := strconv.Atoi(s)
-	if err != nil {
-		return nil, err
-	}
-	var p gpio.PinIO
 	if useSysfs {
-		ok := false
-		if p, ok = sysfs.Pins[number]; !ok {
+		number, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, err
+		}
+		p, ok := sysfs.Pins[number]
+		if !ok {
 			return nil, fmt.Errorf("pin %s is not exported by sysfs", p)
 		}
-	} else {
-		p = gpio.ByNumber(number)
+		return p, nil
 	}
+	p := gpio.ByName(s)
 	if p == nil {
 		return nil, errors.New("invalid pin number")
 	}

--- a/conn/i2c/i2csmoketest/i2csmoketest.go
+++ b/conn/i2c/i2csmoketest/i2csmoketest.go
@@ -36,7 +36,7 @@ func (s *SmokeTest) Description() string {
 func (s *SmokeTest) Run(args []string) error {
 	f := flag.NewFlagSet("i2c", flag.ExitOnError)
 	busNum := f.Int("bus", -1, "bus number, -1 for lowest numbered bus")
-	wc := f.Int("wc", 0, "gpio pin number for EEPROM write-control pin")
+	wc := f.String("wc", "", "gpio pin for EEPROM write-control pin")
 	seed := f.Int64("seed", 0, "random number seed, default is to use the time")
 	f.Parse(args)
 
@@ -49,9 +49,9 @@ func (s *SmokeTest) Run(args []string) error {
 
 	// Open the WC pin.
 	var wcPin gpio.PinIO
-	if *wc != 0 {
-		if wcPin = gpio.ByNumber(*wc); wcPin == nil {
-			return fmt.Errorf("i2c-smoke: cannot open gpio pin %d for EEPROM write control", *wc)
+	if *wc != "" {
+		if wcPin = gpio.ByName(*wc); wcPin == nil {
+			return fmt.Errorf("i2c-smoke: cannot open gpio pin %s for EEPROM write control", *wc)
 		}
 	}
 

--- a/host/allwinner/a64.go
+++ b/host/allwinner/a64.go
@@ -6,14 +6,11 @@
 
 package allwinner
 
-import (
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/pins"
-)
+import "github.com/google/periph/conn/pins"
 
 // A64 specific pins.
 var (
-	X32KFOUT *gpio.BasicPin // Clock output of 32Khz crystal
+	X32KFOUT *pins.BasicPin // Clock output of 32Khz crystal
 	KEY_ADC  *pins.BasicPin // 6 bits resolution ADC for key application; can work up to 250Hz conversion rate; reference voltage is 2.0V
 	EAROUTP  *pins.BasicPin // Earpiece amplifier negative differential output
 	EAROUTN  *pins.BasicPin // Earpiece amplifier positive differential output
@@ -22,7 +19,7 @@ var (
 //
 
 func init() {
-	X32KFOUT = &gpio.BasicPin{N: "X32KFOUT"}
+	X32KFOUT = &pins.BasicPin{N: "X32KFOUT"}
 	// BUG(maruel): These need to be converted to an analog.PinIO implementation
 	// once analog support is implemented.
 	KEY_ADC = &pins.BasicPin{N: "KEY_ADC"}

--- a/host/allwinner/r8.go
+++ b/host/allwinner/r8.go
@@ -7,36 +7,33 @@
 
 package allwinner
 
-import (
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/pins"
-)
+import "github.com/google/periph/conn/pins"
 
 // R8 specific pins.
 var (
 	FEL            *pins.BasicPin // Boot mode selection
-	MIC_IN         *gpio.BasicPin // Microphone in
+	MIC_IN         *pins.BasicPin // Microphone in
 	MIC_GND        *pins.BasicPin // Microphone ground
-	HP_LEFT        *gpio.BasicPin // Left speaker out
-	HP_RIGHT       *gpio.BasicPin // Right speaker out
+	HP_LEFT        *pins.BasicPin // Left speaker out
+	HP_RIGHT       *pins.BasicPin // Right speaker out
 	HP_COM         *pins.BasicPin // Speaker common
-	X1, X2, Y1, Y2 *gpio.BasicPin // Touch screen pins
+	X1, X2, Y1, Y2 *pins.BasicPin // Touch screen pins
 )
 
 //
 
 func init() {
 	FEL = &pins.BasicPin{N: "FEL"}
-	MIC_IN = &gpio.BasicPin{N: "MIC_IN"}
+	MIC_IN = &pins.BasicPin{N: "MIC_IN"}
 	MIC_GND = &pins.BasicPin{N: "MIC_GND"}
-	HP_LEFT = &gpio.BasicPin{N: "HP_LEFT"}
-	HP_RIGHT = &gpio.BasicPin{N: "HP_RIGHT"}
+	HP_LEFT = &pins.BasicPin{N: "HP_LEFT"}
+	HP_RIGHT = &pins.BasicPin{N: "HP_RIGHT"}
 	HP_COM = &pins.BasicPin{N: "HP_COM"}
 
-	X1 = &gpio.BasicPin{N: "X1"}
-	X2 = &gpio.BasicPin{N: "X2"}
-	Y1 = &gpio.BasicPin{N: "Y1"}
-	Y2 = &gpio.BasicPin{N: "Y2"}
+	X1 = &pins.BasicPin{N: "X1"}
+	X2 = &pins.BasicPin{N: "X2"}
+	Y1 = &pins.BasicPin{N: "Y1"}
+	Y2 = &pins.BasicPin{N: "Y2"}
 }
 
 // mappingR8 describes the mapping of each processor pin to its alternate

--- a/host/chip/chip.go
+++ b/host/chip/chip.go
@@ -20,8 +20,8 @@ import (
 
 // C.H.I.P. hardware pins.
 var (
-	TEMP_SENSOR = &gpio.BasicPin{N: "TEMP_SENSOR"}
-	PWR_SWITCH  = &gpio.BasicPin{N: "PWR_SWITCH"}
+	TEMP_SENSOR = &pins.BasicPin{N: "TEMP_SENSOR"}
+	PWR_SWITCH  = &pins.BasicPin{N: "PWR_SWITCH"}
 	// XIO "gpio" pins attached to the pcf8574 I²C port extender.
 	XIO0, XIO1, XIO2, XIO3, XIO4, XIO5, XIO6, XIO7 gpio.PinIO
 )

--- a/host/pine64/pine64.go
+++ b/host/pine64/pine64.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
 	"github.com/google/periph/conn/pins"
 	"github.com/google/periph/host/allwinner"
 	"github.com/google/periph/host/headers"
@@ -31,11 +30,11 @@ func Present() bool {
 var (
 	VCC         = &pins.BasicPin{N: "VCC"}         //
 	IOVCC       = &pins.BasicPin{N: "IOVCC"}       // Power supply for port A
-	TEMP_SENSOR = &gpio.BasicPin{N: "TEMP_SENSOR"} //
-	IR_RX       = &gpio.BasicPin{N: "IR_RX"}       // IR Data Receive
-	CHARGER_LED = &gpio.BasicPin{N: "CHARGER_LED"} //
-	RESET       = &gpio.BasicPin{N: "RESET"}       //
-	PWR_SWITCH  = &gpio.BasicPin{N: "PWR_SWITCH "} //
+	TEMP_SENSOR = &pins.BasicPin{N: "TEMP_SENSOR"} //
+	IR_RX       = &pins.BasicPin{N: "IR_RX"}       // IR Data Receive
+	CHARGER_LED = &pins.BasicPin{N: "CHARGER_LED"} //
+	RESET       = &pins.BasicPin{N: "RESET"}       //
+	PWR_SWITCH  = &pins.BasicPin{N: "PWR_SWITCH "} //
 )
 
 // All the individual pins on the headers.


### PR DESCRIPTION
- Replace all commands to use gpio.ByName() instead of gpio.ByNumber(). This
  makes the tool accept much more values; it can be the number or the name of
  the pin.
- Remove gpio.BasicPin, it couldn't be registered anyway because of
  Number()==-1.
- Make gpio.Register() and gpio.RegisterAlias() much more strict about what they
  accept. This reduces potential confusion by driver writers.
- Increase gpio test coverage.
- Remove bitbang code from apa102, it didn't work anyway.