### PR TITLE
analog: cleanup the junk.

### DIFF
--- a/conn/gpio/gpio.go
+++ b/conn/gpio/gpio.go
@@ -171,7 +171,7 @@ type PinIO interface {
 }
 
 // INVALID implements PinIO and fails on all access.
-var INVALID PinIO = invalidPin{}
+var INVALID PinIO
 
 // RealPin is implemented by aliased pin and allows the retrieval of the real
 // pin underlying an alias.
@@ -356,6 +356,10 @@ var (
 	byName   = [2]map[string]PinIO{map[string]PinIO{}, map[string]PinIO{}}
 	byAlias  = map[string]*pinAlias{}
 )
+
+func init() {
+	INVALID = invalidPin{}
+}
 
 // invalidPin implements PinIO for compability but fails on all access.
 type invalidPin struct {

--- a/experimental/conn/analog/analog.go
+++ b/experimental/conn/analog/analog.go
@@ -7,7 +7,6 @@ package analog
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/google/periph/conn/pins"
 )
@@ -15,88 +14,23 @@ import (
 // ADC is an analog-to-digital-conversion input.
 type ADC interface {
 	pins.Pin
-	// In setups a pin as an input.
-	ADC() error
 	// Range returns the maximum supported range [min, max] of the values.
 	Range() (int32, int32)
-	// Measure return the current pin level.
-	//
-	// Behavior is undefined if In() wasn't used before.
-	//
-	// In some rare case, it is possible that Read() fails silently. This happens
-	// if another process on the host messes up with the pin after In() was
-	// called. In this case, call In() again.
-	Measure() int32
+	// Read returns the current pin level.
+	Read() int32
 }
 
 // DAC is an digital-to-analog-conversion output.
 type DAC interface {
 	pins.Pin
-	// DAC sets a pin as output if it wasn't already and sets the value.
-	//
-	// After the initial call to ensure that the pin has been set as output, it
-	// is generally safe to ignore the error returned.
-	DAC(v int32) error
-}
-
-// PinIO is a pin that supports both input and output.
-//
-// It may fail at either input and or output, for example ground, vcc and other
-// similar pins.
-type PinIO interface {
-	pins.Pin
-	ADC() error
+	// Range returns the maximum supported range [min, max] of the values.
 	Range() (int32, int32)
-	Measure() int32
-	DAC(v int32) error
+	// Out sets an analog output value.
+	DAC(v int32)
 }
 
-// INVALID implements PinIO and fails on all access.
-var INVALID PinIO = invalidPin{}
-
-// BasicPin implements Pin as a non-functional pin.
-type BasicPin struct {
-	N string
-}
-
-func (b *BasicPin) String() string {
-	return b.N
-}
-
-// Number implements pins.Pin.
-func (b *BasicPin) Number() int {
-	return -1
-}
-
-// Name implements pins.Pin.
-func (b *BasicPin) Name() string {
-	return b.N
-}
-
-// Function implements pins.Pin.
-func (b *BasicPin) Function() string {
-	return ""
-}
-
-// ADC implements ADC.
-func (b *BasicPin) ADC() error {
-	return fmt.Errorf("%s cannot be used as ADC", b.N)
-}
-
-// Range implements ADC.
-func (b *BasicPin) Range() (int32, int32) {
-	return 0, 0
-}
-
-// Measure implements ADC.
-func (b *BasicPin) Measure() int32 {
-	return 0
-}
-
-// DAC implements DAC.
-func (b *BasicPin) DAC(v int32) error {
-	return fmt.Errorf("%s cannot be used as DAC", b.N)
-}
+// INVALID implements both ADC and DAC and fails on all access.
+var INVALID invalidPin
 
 //
 
@@ -123,18 +57,13 @@ func (invalidPin) Function() string {
 	return ""
 }
 
-func (invalidPin) ADC() error {
-	return errInvalidPin
-}
-
 func (invalidPin) Range() (int32, int32) {
 	return 0, 0
 }
 
-func (invalidPin) Measure() int32 {
+func (invalidPin) Read() int32 {
 	return 0
 }
 
-func (invalidPin) DAC(v int32) error {
-	return errInvalidPin
+func (invalidPin) DAC(v int32) {
 }


### PR DESCRIPTION
It's still underspecified but a lot of the code didn't make sense anyway.

Simplify gpio.INVALID documentation.