### PR TITLE
host: Rename from <package>.go to gpio.go; allwinner: fix crashers

### DIFF
--- a/host/allwinner/a64.go
+++ b/host/allwinner/a64.go
@@ -2,11 +2,16 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// This file contains pin mapping information that is specific to the Allwinner A64 model.
+// This file contains pin mapping information that is specific to the Allwinner
+// A64 model.
 
 package allwinner
 
-import "github.com/google/periph/conn/pins"
+import (
+	"strings"
+
+	"github.com/google/periph/conn/pins"
+)
 
 // A64 specific pins.
 var (
@@ -27,8 +32,11 @@ func init() {
 	EAROUTN = &pins.BasicPin{N: "EAROUTN"}
 }
 
-// mappingA64 describes the mapping of each processor pin to its alternate
-// functions. It omits the in & out functions which are available on all pins.
+// mappingA64 describes the mapping of the A64 processor gpios to their
+// alternate functions.
+//
+// It omits the in & out functions which are available on all gpio.
+//
 // The mapping comes from the datasheet page 23:
 // http://files.pine64.org/doc/datasheet/pine64/A64_Datasheet_V1.1.pdf
 //
@@ -91,7 +99,7 @@ var mappingA64 = map[string][5]string{
 	"PD21": {"LCD_VSYNC", "LVDS_VN3", "RGMII_CLKI"},
 	"PD22": {"PWM0", "", "MDC"},
 	"PD23": {"", "", "MDIO"},
-	"PD24": {"", ""},
+	"PD24": {""},
 	"PE0":  {"CSI_PCLK", "", "TS_CLK"},
 	"PE1":  {"CSI_MCLK", "", "TS_ERR"},
 	"PE2":  {"CSI_HSYNC", "", "TS_SYNC"},
@@ -108,15 +116,15 @@ var mappingA64 = map[string][5]string{
 	"PE13": {"CSI_SDA"},
 	"PE14": {"PLL_LOCK_DBG", "I2C2_SCL"},
 	"PE15": {"", "I2C2_SDA"},
-	"PE16": {},
-	"PE17": {"", ""},
+	"PE16": {""},
+	"PE17": {""},
 	"PF0":  {"SDC0_D1", "JTAG_MS1"},
 	"PF1":  {"SDC0_D0", "JTAG_DI1"},
 	"PF2":  {"SDC0_CLK", "UART0_TX"},
 	"PF3":  {"SDC0_CMD", "JTAG_DO1"},
 	"PF4":  {"SDC0_D3", "UART0_RX"},
 	"PF5":  {"SDC0_D2", "JTAG_CK1"},
-	"PF6":  {"", "", ""},
+	"PF6":  {""},
 	"PG0":  {"SDC1_CLK", "", "", "", "PG_EINT0"},
 	"PG1":  {"SDC1_CMD", "", "", "", "PG_EINT1"},
 	"PG2":  {"SDC1_D0", "", "", "", "PG_EINT2"},
@@ -145,13 +153,17 @@ var mappingA64 = map[string][5]string{
 	"PH11": {"MIC_DATA", "", "", "", "PH_EINT11"},
 }
 
-// mapA64Pins uses mappingA64 to actually set the altFunc fields of all pins. It is called by the
-// generic allwinner processor code if an A64 is indeed detected.
+// mapA64Pins uses mappingA64 to actually set the altFunc fields of all gpio
+// and mark them as available.
+//
+// It is called by the generic allwinner processor code if an A64 is detected.
 func mapA64Pins() {
-	// set the altFunc fields of all pins that are on the A64
 	for name, altFuncs := range mappingA64 {
-		if pin := cpupins[name]; pin != nil {
-			pin.altFunc = altFuncs
+		pin := cpupins[name]
+		pin.altFunc = altFuncs
+		pin.available = true
+		if strings.Contains(altFuncs[4], "EINT") {
+			pin.supportEdge = true
 		}
 	}
 }

--- a/host/allwinner/detect.go
+++ b/host/allwinner/detect.go
@@ -2,14 +2,11 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// This file contains the CPU detection logic that determines whether we have an Allwinner CPU and
-// if so, which exact model. Sadly there is no science behind this, it's more of a trial and error
-// using as many boards and OS flavors as possible.
-
 package allwinner
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/google/periph/host/distro"
 )
@@ -18,35 +15,58 @@ import (
 //
 // https://en.wikipedia.org/wiki/Allwinner_Technology
 func Present() bool {
-	// BUG(maruel): There doesn't seem to be a generic way to detect Allwinner
-	// CPUs.
-	return IsR8() || IsA64()
+	detection.do()
+	return detection.isAllwinner
 }
 
 // IsR8 detects whether the host CPU is an Allwinner R8 CPU.
 //
 // It looks for the string "sun5i-r8" in /proc/device-tree/compatible.
 func IsR8() bool {
-	if isArm {
-		for _, c := range distro.DTCompatible() {
-			if strings.Contains(c, "sun5i-r8") {
-				return true
-			}
-		}
-	}
-	return false
+	detection.do()
+	return detection.isR8
 }
 
 // IsA64 detects whether the host CPU is an Allwinner A64 CPU.
 //
 // It looks for the string "sun50iw1p1" in /proc/device-tree/compatible.
 func IsA64() bool {
-	if isArm {
-		for _, c := range distro.DTCompatible() {
-			if strings.Contains(c, "sun50iw1p1") {
-				return true
+	detection.do()
+	return detection.isA64
+}
+
+//
+
+type detectionS struct {
+	mu          sync.Mutex
+	done        bool
+	isAllwinner bool
+	isR8        bool
+	isA64       bool
+}
+
+var detection detectionS
+
+// do contains the CPU detection logic that determines whether we have an
+// Allwinner CPU and if so, which exact model.
+//
+// Sadly there is no science behind this, it's more of a trial and error using
+// as many boards and OS flavors as possible.
+func (d *detectionS) do() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if !d.done {
+		d.done = true
+		if isArm {
+			for _, c := range distro.DTCompatible() {
+				if strings.Contains(c, "sun50iw1p1") {
+					d.isA64 = true
+				}
+				if strings.Contains(c, "sun5i-r8") {
+					d.isR8 = true
+				}
 			}
+			d.isAllwinner = d.isA64 || d.isR8
 		}
 	}
-	return false
 }

--- a/host/allwinner/doc.go
+++ b/host/allwinner/doc.go
@@ -18,3 +18,6 @@
 //
 // Physical overview: http://files.pine64.org/doc/datasheet/pine64/A64_Datasheet_V1.1.pdf
 package allwinner
+
+// The most active kernel branch is
+// https://github.com/linux-sunxi/linux-sunxi/commits/sunxi-next

--- a/host/allwinner/gpio_pl.go
+++ b/host/allwinner/gpio_pl.go
@@ -269,19 +269,19 @@ var gpioMemoryPL *gpioGroup
 // See ../allwinner/allwinner.go for details.
 // TODO(maruel): Figure out what the S_ prefix means.
 var mapping = [13][5]string{
-	{"S_RSB_SCK", "S_I2C_SCL", "", "", "S_PL_EINT0"}, // PL0
-	{"S_RSB_SDA", "S_I2C_SDA", "", "", "S_PL_EINT1"}, // PL1
-	{"S_UART_TX", "", "", "", "S_PL_EINT2"},          // PL2
-	{"S_UART_RX", "", "", "", "S_PL_EINT3"},          // PL3
-	{"S_JTAG_MS", "", "", "", "S_PL_EINT4"},          // PL4
-	{"S_JTAG_CK", "", "", "", "S_PL_EINT5"},          // PL5
-	{"S_JTAG_DO", "", "", "", "S_PL_EINT6"},          // PL6
-	{"S_JTAG_DI", "", "", "", "S_PL_EINT7"},          // PL7
-	{"S_I2C_CSK", "", "", "", "S_PL_EINT8"},          // PL8
-	{"S_I2C_SDA", "", "", "", "S_PL_EINT9"},          // PL9
-	{"S_PWM", "", "", "", "S_PL_EINT10"},             // PL10
-	{"S_CIR_RX", "", "", "", "S_PL_EINT11"},          // PL11
-	{"", "", "", "", "S_PL_EINT12"},                  // PL12
+	{"RSB_SCK", "I2C_SCL", "", "", "PL_EINT0"}, // PL0
+	{"RSB_SDA", "I2C_SDA", "", "", "PL_EINT1"}, // PL1
+	{"UART_TX", "", "", "", "PL_EINT2"},        // PL2
+	{"UART_RX", "", "", "", "PL_EINT3"},        // PL3
+	{"JTAG_MS", "", "", "", "PL_EINT4"},        // PL4
+	{"JTAG_CK", "", "", "", "PL_EINT5"},        // PL5
+	{"JTAG_DO", "", "", "", "PL_EINT6"},        // PL6
+	{"JTAG_DI", "", "", "", "PL_EINT7"},        // PL7
+	{"I2C_CSK", "", "", "", "PL_EINT8"},        // PL8
+	{"I2C_SDA", "", "", "", "PL_EINT9"},        // PL9
+	{"PWM0", "", "", "", "PL_EINT10"},          // PL10
+	{"CIR_RX", "", "", "", "PL_EINT11"},        // PL11
+	{"", "", "", "", "PL_EINT12"},              // PL12
 }
 
 func init() {

--- a/host/allwinner/r8.go
+++ b/host/allwinner/r8.go
@@ -7,7 +7,11 @@
 
 package allwinner
 
-import "github.com/google/periph/conn/pins"
+import (
+	"strings"
+
+	"github.com/google/periph/conn/pins"
+)
 
 // R8 specific pins.
 var (
@@ -36,8 +40,11 @@ func init() {
 	Y2 = &pins.BasicPin{N: "Y2"}
 }
 
-// mappingR8 describes the mapping of each processor pin to its alternate
-// functions. It omits the in & out functions which are available on all pins.
+// mappingR8 describes the mapping of each R8 processor gpio to their alternate
+// functions.
+//
+// It omits the in & out functions which are available on all pins.
+//
 // The mapping comes from the datasheet page 18:
 // https://github.com/NextThingCo/CHIP-Hardware/raw/master/CHIP%5Bv1_0%5D/CHIPv1_0-BOM-Datasheets/Allwinner%20R8%20Datasheet%20V1.2.pdf
 //
@@ -45,7 +52,7 @@ func init() {
 var mappingR8 = map[string][5]string{
 	"PB0":  {"I2C0_SCL"},
 	"PB1":  {"I2C0_SDA"},
-	"PB2":  {"PWM", "", "", "", "EINT16"},
+	"PB2":  {"PWM0", "", "", "", "EINT16"},
 	"PB3":  {"IR_TX", "", "", "", "EINT17"},
 	"PB4":  {"IR_RX", "", "", "", "EINT18"},
 	"PB10": {"SPI2_CS1"},
@@ -69,6 +76,7 @@ var mappingR8 = map[string][5]string{
 	"PC13": {"NAND_DQ5", "SDC2_D5"},
 	"PC14": {"NAND_DQ6", "SDC2_D6"},
 	"PC15": {"NAND_DQ7", "SDC2_D7"},
+	"PC19": {""},
 	"PD2":  {"LCD_D2", "UART2_TX"},
 	"PD3":  {"LCD_D3", "UART2_RX"},
 	"PD4":  {"LCD_D4", "UART2_CTX"},
@@ -114,20 +122,23 @@ var mappingR8 = map[string][5]string{
 	"PG2":  {"GPS_MAG", "", "", "", "EINT2"},
 	"PG3":  {"", "", "UART1_TX", "", "EINT3"},
 	"PG4":  {"", "", "UART1_RX", "", "EINT4"},
-	"PG9":  {"SPI1_CS0", "UART3_TX", "", "", "PG_EINT9"},
-	"PG10": {"SPI1_CLK", "UART3_RX", "", "", "PG_EINT10"},
-	"PG11": {"SPI1_MOSI", "UART3_CTS", "", "", "PG_EINT11"},
-	"PG12": {"SPI1_MISO", "UART3_RTS", "", "", "PG_EINT12"},
+	"PG9":  {"SPI1_CS0", "UART3_TX", "", "", "EINT9"},
+	"PG10": {"SPI1_CLK", "UART3_RX", "", "", "EINT10"},
+	"PG11": {"SPI1_MOSI", "UART3_CTS", "", "", "EINT11"},
+	"PG12": {"SPI1_MISO", "UART3_RTS", "", "", "EINT12"},
 }
 
-// mapR8Pins uses mappingR8 to actually set the altFunc fields of all pins. It
-// is called by the generic allwinner processor code if an R8 is indeed
-// detected.
+// mapR8Pins uses mappingR8 to actually set the altFunc fields of all gpio and
+// mark them as available.
+//
+// It is called by the generic allwinner processor code if a R8 is detected.
 func mapR8Pins() {
-	// Set the altFunc fields of all pins that are on the R8.
 	for name, altFuncs := range mappingR8 {
-		if pin := cpupins[name]; pin != nil {
-			pin.altFunc = altFuncs
+		pin := cpupins[name]
+		pin.altFunc = altFuncs
+		pin.available = true
+		if strings.Contains(altFuncs[4], "EINT") {
+			pin.supportEdge = true
 		}
 	}
 }

--- a/host/bcm283x/doc.go
+++ b/host/bcm283x/doc.go
@@ -10,4 +10,9 @@
 // Datasheet
 //
 // https://www.raspberrypi.org/wp-content/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
+//
+// Its crowd-sourced errata: http://elinux.org/BCM2835_datasheet_errata
+//
+// Another doc about PCM and PWM:
+// https://fr.scribd.com/doc/127599939/BCM2835-Audio-clocks
 package bcm283x

--- a/host/bcm283x/gpio.go
+++ b/host/bcm283x/gpio.go
@@ -187,9 +187,7 @@ func (p *Pin) In(pull gpio.Pull, edge gpio.Edge) error {
 	if gpioMemory == nil {
 		return p.wrap(errors.New("subsystem not initialized"))
 	}
-	if !p.setFunction(in) {
-		return p.wrap(errors.New("failed to set pin as input"))
-	}
+	p.setFunction(in)
 	if pull != gpio.PullNoChange {
 		// Changing pull resistor requires a specific dance as described at
 		// https://www.raspberrypi.org/wp-content/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
@@ -282,9 +280,7 @@ func (p *Pin) Out(l gpio.Level) error {
 	} else {
 		gpioMemory.outputSet[offset] = 1 << uint(p.number&31)
 	}
-	if !p.setFunction(out) {
-		return p.wrap(errors.New("failed to set pin as output"))
-	}
+	p.setFunction(out)
 	return nil
 }
 
@@ -313,19 +309,10 @@ func (p *Pin) function() function {
 }
 
 // setFunction changes the GPIO pin function.
-//
-// Returns false if the pin was in AltN. Only accepts in and out
-func (p *Pin) setFunction(f function) bool {
-	if f != in && f != out {
-		return false
-	}
-	if actual := p.function(); actual != in && actual != out {
-		return false
-	}
+func (p *Pin) setFunction(f function) {
 	off := p.number / 10
 	shift := uint(p.number%10) * 3
 	gpioMemory.functionSelect[off] = (gpioMemory.functionSelect[off] &^ (7 << shift)) | (uint32(f) << shift)
-	return true
 }
 
 func (p *Pin) wrap(err error) error {
@@ -471,64 +458,64 @@ type gpioMap struct {
 	// 0x0C    RW   GPIO Function Select 3 (GPIO30-39)
 	// 0x10    RW   GPIO Function Select 4 (GPIO40-49)
 	// 0x14    RW   GPIO Function Select 5 (GPIO50-53)
-	functionSelect [6]uint32
+	functionSelect [6]uint32 // GPFSEL0~GPFSEL5
 	// 0x18    -    Reserved
 	dummy0 uint32
 	// 0x1C    W    GPIO Pin Output Set 0 (GPIO0-31)
 	// 0x20    W    GPIO Pin Output Set 1 (GPIO32-53)
-	outputSet [2]uint32
+	outputSet [2]uint32 // GPSET0-GPSET1
 	// 0x24    -    Reserved
 	dummy1 uint32
 	// 0x28    W    GPIO Pin Output Clear 0 (GPIO0-31)
 	// 0x2C    W    GPIO Pin Output Clear 1 (GPIO32-53)
-	outputClear [2]uint32
+	outputClear [2]uint32 // GPCLR0-GPCLR1
 	// 0x30    -    Reserved
 	dummy2 uint32
 	// 0x34    R    GPIO Pin Level 0 (GPIO0-31)
 	// 0x38    R    GPIO Pin Level 1 (GPIO32-53)
-	level [2]uint32
+	level [2]uint32 // GPLEV0-GPLEV1
 	// 0x3C    -    Reserved
 	dummy3 uint32
 	// 0x40    RW   GPIO Pin Event Detect Status 0 (GPIO0-31)
 	// 0x44    RW   GPIO Pin Event Detect Status 1 (GPIO32-53)
-	eventDetectStatus [2]uint32
+	eventDetectStatus [2]uint32 // GPEDS0-GPEDS1
 	// 0x48    -    Reserved
 	dummy4 uint32
 	// 0x4C    RW   GPIO Pin Rising Edge Detect Enable 0 (GPIO0-31)
 	// 0x50    RW   GPIO Pin Rising Edge Detect Enable 1 (GPIO32-53)
-	risingEdgeDetectEnable [2]uint32
+	risingEdgeDetectEnable [2]uint32 // GPREN0-GPREN1
 	// 0x54    -    Reserved
 	dummy5 uint32
 	// 0x58    RW   GPIO Pin Falling Edge Detect Enable 0 (GPIO0-31)
 	// 0x5C    RW   GPIO Pin Falling Edge Detect Enable 1 (GPIO32-53)
-	fallingEdgeDetectEnable [2]uint32
+	fallingEdgeDetectEnable [2]uint32 // GPFEN0-GPFEN1
 	// 0x60    -    Reserved
 	dummy6 uint32
 	// 0x64    RW   GPIO Pin High Detect Enable 0 (GPIO0-31)
 	// 0x68    RW   GPIO Pin High Detect Enable 1 (GPIO32-53)
-	highDetectEnable [2]uint32
+	highDetectEnable [2]uint32 // GPHEN0-GPHEN1
 	// 0x6C    -    Reserved
 	dummy7 uint32
 	// 0x70    RW   GPIO Pin Low Detect Enable 0 (GPIO0-31)
 	// 0x74    RW   GPIO Pin Low Detect Enable 1 (GPIO32-53)
-	lowDetectEnable [2]uint32
+	lowDetectEnable [2]uint32 // GPLEN0-GPLEN1
 	// 0x78    -    Reserved
 	dummy8 uint32
 	// 0x7C    RW   GPIO Pin Async Rising Edge Detect 0 (GPIO0-31)
 	// 0x80    RW   GPIO Pin Async Rising Edge Detect 1 (GPIO32-53)
-	asyncRisingEdgeDetectEnable [2]uint32
+	asyncRisingEdgeDetectEnable [2]uint32 // GPAREN0-GPAREN1
 	// 0x84    -    Reserved
 	dummy9 uint32
 	// 0x88    RW   GPIO Pin Async Falling Edge Detect 0 (GPIO0-31)
 	// 0x8C    RW   GPIO Pin Async Falling Edge Detect 1 (GPIO32-53)
-	asyncFallingEdgeDetectEnable [2]uint32
+	asyncFallingEdgeDetectEnable [2]uint32 // GPAFEN0-GPAFEN1
 	// 0x90    -    Reserved
 	dummy10 uint32
 	// 0x94    RW   GPIO Pin Pull-up/down Enable (00=Float, 01=Down, 10=Up)
-	pullEnable uint32
+	pullEnable uint32 // GPPUD
 	// 0x98    RW   GPIO Pin Pull-up/down Enable Clock 0 (GPIO0-31)
 	// 0x9C    RW   GPIO Pin Pull-up/down Enable Clock 1 (GPIO32-53)
-	pullEnableClock [2]uint32
+	pullEnableClock [2]uint32 // GPPUDCLK0-GPPUDCLK1
 	// 0xA0    -    Reserved
 	dummy uint32
 	// 0xB0    -    Test (byte)


### PR DESCRIPTION
- Add missing GPIO PC17, PC18 and PC19.
- Fix altfun which was incorrectly initialized for pins PE16. This fix a crah in
  allwinner driver.
- Make detection code do the detection only once, yet still lazily done.
- Make it clear to the user which pins actually exist based on the running CPU.
  The unavailable pin will behave in an expected way, will never crash.
- Mark explicitly which pins support edge based triggering from the CPU
  datasheets instead of the previous guessing, which was incorrect. It leverages
  the "EINT" string in the altfunc map.
- Stop limiting the user from changing a pin to an alternate functionality. This
  will be necessary for the follow up PWM support. This means users have more
  chance of shooting in their foot.
- Wrap some comments to 80 cols.

There'll be more CPU specific supports (DMA, PWM, clock, etc). To reduce
confusion, rename the files to gpio.go right away.