### PR TITLE
allow large SPI bus numbers for CHIP

### DIFF
--- a/host/sysfs/spi.go
+++ b/host/sysfs/spi.go
@@ -46,7 +46,7 @@ type SPI struct {
 }
 
 func newSPI(busNumber, chipSelect int) (*SPI, error) {
-	if busNumber < 0 || busNumber > 255 {
+	if busNumber < 0 || busNumber >= 1<<16 {
 		return nil, fmt.Errorf("sysfs-spi: invalid bus %d", busNumber)
 	}
 	if chipSelect < 0 || chipSelect > 255 {


### PR DESCRIPTION
CHIP's spi bus device likes to be `/dev/spidev32766.0`, and that should be fine...