### PR TITLE
set SPI speed and mode in spi smoketest

### DIFF
--- a/conn/spi/spismoketest/spismoketest.go
+++ b/conn/spi/spismoketest/spismoketest.go
@@ -44,13 +44,17 @@ func (s *SmokeTest) Run(args []string) error {
 	// Open the bus.
 	spiDev, err := spi.New(*busNum, *csNum)
 	if err != nil {
-		return fmt.Errorf("spi-smoke: %s", err)
+		return fmt.Errorf("spi-smoke: %v", err)
 	}
 	defer spiDev.Close()
 
 	// Set SPI parameters.
-	spiDev.Speed(4 * 1000 * 1000) // 4Mhz
-	spiDev.Configure(spi.Mode0, 8)
+	if err := spiDev.Speed(4 * 1000 * 1000 * 1000); err != nil {
+		return fmt.Errorf("spi-smoke: cannot set speed, %v", err)
+	}
+	if err := spiDev.Configure(spi.Mode0, 8); err != nil {
+		return fmt.Errorf("spi-smoke: cannot set mode, %v", err)
+	}
 
 	// Open the WC pin.
 	var wpPin gpio.PinIO


### PR DESCRIPTION
The SPI smoketest for periph-tester was not setting the mode & speed explicitly leading to strange issues. See also #101