### PR TITLE
Replace github.com/google with periph.io/x

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 * [doc/users/](doc/users/) for ready-to-use tools.
 * [doc/apps/](doc/apps/) to use `periph` as a library. The complete API
   documentation, including examples, is at
-  [![GoDoc](https://godoc.org/github.com/google/periph?status.svg)](https://godoc.org/github.com/google/periph).
+  [![GoDoc](https://godoc.org/periph.io/x/periph?status.svg)](https://godoc.org/periph.io/x/periph).
 * [doc/drivers/](doc/drivers/) to expand the list of supported hardware.
 
 
@@ -27,7 +27,7 @@ for more info on configuring the host and using the included tools.
 
 ```bash
 # Retrieve and install all the commands at once:
-go get github.com/google/periph/cmd/...
+go get periph.io/x/periph/cmd/...
 # List the host drivers registered and/or initialized:
 periph-info
 # List the known headers:
@@ -49,8 +49,8 @@ package main
 
 import (
     "time"
-    "github.com/google/periph/conn/gpio"
-    "github.com/google/periph/host"
+    "periph.io/x/periph/conn/gpio"
+    "periph.io/x/periph/host"
 )
 
 func main() {
@@ -64,11 +64,11 @@ func main() {
 
 The following are synonyms, use the form you prefer:
 * Runtime discovery:
-  * [`gpio.ByNumber(13)`](https://godoc.org/github.com/google/periph/conn/gpio/#ByNumber) or [`gpio.ByName("13")`](https://godoc.org/github.com/google/periph/conn/gpio/#ByName)
-  *  [`gpio.ByName("GPIO13")`](https://godoc.org/github.com/google/periph/conn/gpio/#ByName)
+  * [`gpio.ByNumber(13)`](https://godoc.org/periph.io/x/periph/conn/gpio/#ByNumber) or [`gpio.ByName("13")`](https://godoc.org/periph.io/x/periph/conn/gpio/#ByName)
+  *  [`gpio.ByName("GPIO13")`](https://godoc.org/periph.io/x/periph/conn/gpio/#ByName)
 * Using global variables:
-  * [`rpi.P1_33`](https://godoc.org/github.com/google/periph/host/rpi#/P1_33) to select the pin via its position on the board
-  * [`bcm283x.GPIO13`](https://godoc.org/github.com/google/periph/host/bcm283x/#GPIO13)
+  * [`rpi.P1_33`](https://godoc.org/periph.io/x/periph/host/rpi#/P1_33) to select the pin via its position on the board
+  * [`bcm283x.GPIO13`](https://godoc.org/periph.io/x/periph/host/bcm283x/#GPIO13)
 
 This example uses basically no CPU: the `Out()` call doesn't call into the
 kernel. Instead it directly changes the GPIO memory mapped register.
@@ -108,12 +108,12 @@ Google Contributor License. Please see
      on each platform.
 3. ... yet doesn't get in the way of platform specific code.
    * e.g. A user can use statically typed global variables
-     [rpi.P1_3](https://godoc.org/github.com/google/periph/host/rpi#pkg-variables),
-     [bcm283x.GPIO2](https://godoc.org/github.com/google/periph/host/bcm283x#Pin)
+     [rpi.P1_3](https://godoc.org/periph.io/x/periph/host/rpi#pkg-variables),
+     [bcm283x.GPIO2](https://godoc.org/periph.io/x/periph/host/bcm283x#Pin)
      to refer to the exact same pin on a Raspberry Pi.
 3. The user can chose to optimize for performance instead of usability.
    * e.g.
-     [apa102.Dev](https://godoc.org/github.com/google/periph/devices/apa102#Dev)
+     [apa102.Dev](https://godoc.org/periph.io/x/periph/devices/apa102#Dev)
      exposes both high level
      [draw.Image](https://golang.org/pkg/image/draw/#Image) to draw an image and
      low level [io.Writer](https://golang.org/pkg/io/#Writer) to write raw RGB
@@ -124,15 +124,15 @@ Google Contributor License. Please see
      "component": one for the CPU, one for the board headers, one for each
      bus and sensor, etc.
 5. Extensible via a [driver
-   registry](https://godoc.org/github.com/google/periph#Register).
+   registry](https://godoc.org/periph.io/x/periph#Register).
    * e.g. a user can inject a custom driver to expose more pins, headers, etc.
      A USB device (like an FT232H) can expose headers _in addition_ to the
      headers found on the host.
 6. The drivers must use the fastest possible implementation.
    * e.g. both
-     [allwinner](https://godoc.org/github.com/google/periph/host/allwinner)
+     [allwinner](https://godoc.org/periph.io/x/periph/host/allwinner)
      and
-     [bcm283x](https://godoc.org/github.com/google/periph/host/bcm283x)
+     [bcm283x](https://godoc.org/periph.io/x/periph/host/bcm283x)
      leverage sysfs gpio to expose interrupt driven edge detection, yet use
      memory mapped GPIO registers to perform single-cycle reads and writes.
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,7 +1,7 @@
 # periph/cmd - read-to-use executables
 
 This directory contains directly usable tools installable via `go get
-github.com/google/periph/cmd/...`.
+periph.io/x/periph/cmd/...`.
 
 
 ## Recommended first use

--- a/cmd/apa102/main.go
+++ b/cmd/apa102/main.go
@@ -21,10 +21,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/devices"
-	"github.com/google/periph/devices/apa102"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/devices"
+	"periph.io/x/periph/devices/apa102"
+	"periph.io/x/periph/host"
 )
 
 func access(name string) bool {
@@ -38,7 +38,7 @@ func findFile(name string) string {
 	}
 	for _, p := range strings.Split(os.Getenv("GOPATH"), ":") {
 		if len(p) != 0 {
-			if p2 := filepath.Join(p, "src/github.com/google/periph/cmd/apa102", name); access(p2) {
+			if p2 := filepath.Join(p, "src/periph.io/x/periph/cmd/apa102", name); access(p2) {
 				return p2
 			}
 		}

--- a/cmd/bme280/main.go
+++ b/cmd/bme280/main.go
@@ -13,14 +13,14 @@ import (
 	"os"
 	"time"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/i2c/i2ctest"
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/devices"
-	"github.com/google/periph/devices/bme280"
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/devices"
+	"periph.io/x/periph/devices/bme280"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/headers"
 )
 
 func printPin(fn string, p pins.Pin) {

--- a/cmd/gpio-list/README.md
+++ b/cmd/gpio-list/README.md
@@ -29,7 +29,7 @@ then running:
     sudo systemctl disable hciuart
 
 For more information for enabling functional pins, see
-[![GoDoc](https://godoc.org/github.com/google/periph/host/rpi?status.svg)](https://godoc.org/github.com/google/periph/host/rpi).
+[![GoDoc](https://godoc.org/periph.io/x/periph/host/rpi?status.svg)](https://godoc.org/periph.io/x/periph/host/rpi).
 
 
 ### Aliases

--- a/cmd/gpio-list/main.go
+++ b/cmd/gpio-list/main.go
@@ -13,9 +13,9 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/headers"
 )
 
 func printAliases(invalid bool) {

--- a/cmd/gpio-read/main.go
+++ b/cmd/gpio-read/main.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host"
 )
 
 func printLevel(l gpio.Level) error {

--- a/cmd/gpio-write/main.go
+++ b/cmd/gpio-write/main.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host"
 )
 
 func mainImpl() error {

--- a/cmd/headers-list/main.go
+++ b/cmd/headers-list/main.go
@@ -15,10 +15,10 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/headers"
 )
 
 func printFailures(state *periph.State) {

--- a/cmd/i2c-list/main.go
+++ b/cmd/i2c-list/main.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/headers"
 )
 
 func printPin(fn string, p pins.Pin) {

--- a/cmd/i2c/main.go
+++ b/cmd/i2c/main.go
@@ -15,8 +15,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/host"
 )
 
 func mainImpl() error {

--- a/cmd/ir/main.go
+++ b/cmd/ir/main.go
@@ -17,8 +17,8 @@ import (
 	"os"
 	"os/signal"
 
-	"github.com/google/periph/devices/lirc"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/devices/lirc"
+	"periph.io/x/periph/host"
 )
 
 func mainImpl() error {

--- a/cmd/led/main.go
+++ b/cmd/led/main.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/sysfs"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/sysfs"
 )
 
 func mainImpl() error {

--- a/cmd/periph-info/main.go
+++ b/cmd/periph-info/main.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/periph"
-	"github.com/google/periph/host"
+	"periph.io/x/periph"
+	"periph.io/x/periph/host"
 )
 
 func printDrivers(drivers []periph.DriverFailure) {

--- a/cmd/periph-smoketest/main.go
+++ b/cmd/periph-smoketest/main.go
@@ -15,13 +15,13 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/periph/conn/gpio/gpiosmoketest"
-	"github.com/google/periph/conn/i2c/i2csmoketest"
-	"github.com/google/periph/conn/spi/spismoketest"
-	"github.com/google/periph/experimental/conn/onewire/onewiresmoketest"
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/chip/chipsmoketest"
-	"github.com/google/periph/host/odroid_c1/odroidc1smoketest"
+	"periph.io/x/periph/conn/gpio/gpiosmoketest"
+	"periph.io/x/periph/conn/i2c/i2csmoketest"
+	"periph.io/x/periph/conn/spi/spismoketest"
+	"periph.io/x/periph/experimental/conn/onewire/onewiresmoketest"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/chip/chipsmoketest"
+	"periph.io/x/periph/host/odroid_c1/odroidc1smoketest"
 )
 
 // SmokeTest must be implemented by a smoke test. It will be run by this

--- a/cmd/spi-list/main.go
+++ b/cmd/spi-list/main.go
@@ -10,10 +10,10 @@ import (
 	"os"
 	"sort"
 
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/headers"
 )
 
 func printPin(fn string, p pins.Pin) {

--- a/cmd/ssd1306/main.go
+++ b/cmd/ssd1306/main.go
@@ -24,11 +24,11 @@ import (
 	"golang.org/x/image/font/basicfont"
 	"golang.org/x/image/math/fixed"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/devices/ssd1306"
-	"github.com/google/periph/devices/ssd1306/image1bit"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/devices/ssd1306"
+	"periph.io/x/periph/devices/ssd1306/image1bit"
+	"periph.io/x/periph/host"
 )
 
 func access(name string) bool {
@@ -42,7 +42,7 @@ func findFile(name string) string {
 	}
 	for _, p := range strings.Split(os.Getenv("GOPATH"), ":") {
 		if len(p) != 0 {
-			if p2 := filepath.Join(p, "src/github.com/google/periph/cmd/ssd1306", name); access(p2) {
+			if p2 := filepath.Join(p, "src/periph.io/x/periph/cmd/ssd1306", name); access(p2) {
 				return p2
 			}
 		}

--- a/cmd/thermal/main.go
+++ b/cmd/thermal/main.go
@@ -10,9 +10,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/periph/devices"
-	"github.com/google/periph/host"
-	"github.com/google/periph/host/sysfs"
+	"periph.io/x/periph/devices"
+	"periph.io/x/periph/host"
+	"periph.io/x/periph/host/sysfs"
 )
 
 func mainImpl() error {

--- a/cmd/tm1637/main.go
+++ b/cmd/tm1637/main.go
@@ -14,9 +14,9 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/devices/tm1637"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/devices/tm1637"
+	"periph.io/x/periph/host"
 )
 
 func mainImpl() error {

--- a/conn/conntest/conntest.go
+++ b/conn/conntest/conntest.go
@@ -12,7 +12,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn"
+	"periph.io/x/periph/conn"
 )
 
 // RecordRaw implements conn.Conn. It sends everything written to it to W.

--- a/conn/gpio/gpio.go
+++ b/conn/gpio/gpio.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/periph/conn/pins"
+	"periph.io/x/periph/conn/pins"
 )
 
 // Level is the level of the pin: Low or High.

--- a/conn/gpio/gpiosmoketest/gpiosmoketest.go
+++ b/conn/gpio/gpiosmoketest/gpiosmoketest.go
@@ -12,10 +12,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/allwinner"
-	"github.com/google/periph/host/bcm283x"
-	"github.com/google/periph/host/sysfs"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/allwinner"
+	"periph.io/x/periph/host/bcm283x"
+	"periph.io/x/periph/host/sysfs"
 )
 
 type SmokeTest struct {
@@ -85,7 +85,7 @@ func (s *SmokeTest) Run(args []string) error {
 	}
 	if allwinner.IsA64() {
 		// For now, skip edge testing on the Allwinner A64 (pine64).
-		// https://github.com/google/periph/issues/54
+		// https://periph.io/x/periph/issues/54
 		s.noEdge = true
 	}
 	// On certain Allwinner CPUs, it's a good idea to test specifically the PLx

--- a/conn/gpio/gpiotest/gpio_test.go
+++ b/conn/gpio/gpiotest/gpio_test.go
@@ -7,7 +7,7 @@ package gpiotest
 import (
 	"testing"
 
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio"
 )
 
 func TestAll(t *testing.T) {

--- a/conn/gpio/gpiotest/gpiotest.go
+++ b/conn/gpio/gpiotest/gpiotest.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // Pin implements gpio.Pin.

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -15,7 +15,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // Bus defines the interface a concrete I²C driver must implement.

--- a/conn/i2c/i2csmoketest/i2csmoketest.go
+++ b/conn/i2c/i2csmoketest/i2csmoketest.go
@@ -17,8 +17,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/i2c"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/i2c"
 )
 
 type SmokeTest struct {

--- a/conn/i2c/i2ctest/i2c_test.go
+++ b/conn/i2c/i2ctest/i2c_test.go
@@ -7,7 +7,7 @@ package i2ctest
 import (
 	"testing"
 
-	"github.com/google/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c"
 )
 
 func TestDev(t *testing.T) {

--- a/conn/i2c/i2ctest/i2ctest.go
+++ b/conn/i2c/i2ctest/i2ctest.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/i2c"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/i2c"
 )
 
 // IO registers the I/O that happened on either a real or fake I²C bus.

--- a/conn/spi/spi.go
+++ b/conn/spi/spi.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // Mode determines how communication is done. The bits can be OR'ed to change

--- a/conn/spi/spismoketest/spismoketest.go
+++ b/conn/spi/spismoketest/spismoketest.go
@@ -17,8 +17,8 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/spi"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/spi"
 )
 
 type SmokeTest struct {

--- a/conn/spi/spitest/spi_test.go
+++ b/conn/spi/spitest/spi_test.go
@@ -7,7 +7,7 @@ package spitest
 import (
 	"testing"
 
-	"github.com/google/periph/conn/conntest"
+	"periph.io/x/periph/conn/conntest"
 )
 
 func TestBasic(t *testing.T) {

--- a/conn/spi/spitest/spitest.go
+++ b/conn/spi/spitest/spitest.go
@@ -10,9 +10,9 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn/conntest"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/spi"
+	"periph.io/x/periph/conn/conntest"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/spi"
 )
 
 // RecordRaw implements spi.Conn. It sends everything written to it to W.

--- a/devices/apa102/apa102.go
+++ b/devices/apa102/apa102.go
@@ -9,8 +9,8 @@ import (
 	"image"
 	"image/color"
 
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/devices"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/devices"
 )
 
 // maxOut is the maximum intensity of each channel on a APA102 LED.

--- a/devices/apa102/apa102_test.go
+++ b/devices/apa102/apa102_test.go
@@ -13,8 +13,8 @@ import (
 	"log"
 	"testing"
 
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/conn/spi/spitest"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/conn/spi/spitest"
 )
 
 func TestRamp(t *testing.T) {

--- a/devices/bme280/bme280.go
+++ b/devices/bme280/bme280.go
@@ -12,10 +12,10 @@ package bme280
 import (
 	"errors"
 
-	"github.com/google/periph/conn"
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/devices"
+	"periph.io/x/periph/conn"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/devices"
 )
 
 // Oversampling affects how much time is taken to measure each of temperature,

--- a/devices/bme280/bme280_test.go
+++ b/devices/bme280/bme280_test.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/i2c/i2ctest"
-	"github.com/google/periph/devices"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/devices"
 )
 
 // Real data extracted from a device.

--- a/devices/devicestest/display.go
+++ b/devices/devicestest/display.go
@@ -10,7 +10,7 @@ import (
 	"image/color"
 	"image/draw"
 
-	"github.com/google/periph/devices"
+	"periph.io/x/periph/devices"
 )
 
 // Display is a fake devices.Display.

--- a/devices/lirc/lirc.go
+++ b/devices/lirc/lirc.go
@@ -14,8 +14,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/ir"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/ir"
 )
 
 // Conn is an open port to lirc.

--- a/devices/ssd1306/ssd1306.go
+++ b/devices/ssd1306/ssd1306.go
@@ -41,10 +41,10 @@ import (
 	"io"
 	"log"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/devices"
-	"github.com/google/periph/devices/ssd1306/image1bit"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/devices"
+	"periph.io/x/periph/devices/ssd1306/image1bit"
 )
 
 // FrameRate determines scrolling speed.

--- a/devices/ssd1306/ssd1306_test.go
+++ b/devices/ssd1306/ssd1306_test.go
@@ -14,9 +14,9 @@ import (
 	"golang.org/x/image/font/basicfont"
 	"golang.org/x/image/math/fixed"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/i2c/i2ctest"
-	"github.com/google/periph/devices/ssd1306/image1bit"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/devices/ssd1306/image1bit"
 )
 
 func TestDrawGray(t *testing.T) {

--- a/devices/tm1637/tm1637.go
+++ b/devices/tm1637/tm1637.go
@@ -14,8 +14,8 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/cpu"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/cpu"
 )
 
 // Clock converts time to a slice of bytes as segments.

--- a/devices/tm1637/tm1637_test.go
+++ b/devices/tm1637/tm1637_test.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/gpio/gpiotest"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpiotest"
+	"periph.io/x/periph/host"
 )
 
 func TestNew(t *testing.T) {

--- a/doc/README.md
+++ b/doc/README.md
@@ -8,5 +8,5 @@ The documentation is split into 4 sections:
   * No Go programming skill is required at all. `go get` and run.
 * [apps/](apps/) to use `periph` as a library.
   * The complete API documentation, including examples, is at
-    [![GoDoc](https://godoc.org/github.com/google/periph?status.svg)](https://godoc.org/github.com/google/periph).
+    [![GoDoc](https://godoc.org/periph.io/x/periph?status.svg)](https://godoc.org/periph.io/x/periph).
 * [drivers/](drivers/) to expand the list of supported hardware.

--- a/doc/apps/README.md
+++ b/doc/apps/README.md
@@ -4,7 +4,7 @@ Documentation for _application developers_ who want to write Go applications
 leveraging `periph`.
 
 The complete API documentation, including examples, is at
-[![GoDoc](https://godoc.org/github.com/google/periph?status.svg)](https://godoc.org/github.com/google/periph).
+[![GoDoc](https://godoc.org/periph.io/x/periph?status.svg)](https://godoc.org/periph.io/x/periph).
 
 
 ## Introduction
@@ -14,13 +14,13 @@ host it is running on. It differentiates between drivers that _enable_
 functionality on the host and drivers for devices connected _to_ the host.
 
 Most micro computers expose at least some of the following:
-[I²C bus](https://godoc.org/github.com/google/periph/conn/i2c#Bus),
-[SPI bus](https://godoc.org/github.com/google/periph/conn/spi#Conn),
+[I²C bus](https://godoc.org/periph.io/x/periph/conn/i2c#Bus),
+[SPI bus](https://godoc.org/periph.io/x/periph/conn/spi#Conn),
 [gpio
-pins](https://godoc.org/github.com/google/periph/conn/gpio#PinIO),
+pins](https://godoc.org/periph.io/x/periph/conn/gpio#PinIO),
 [analog
-pins](https://godoc.org/github.com/google/periph/experimental/conn/analog),
-[UART](https://godoc.org/github.com/google/periph/experimental/conn/uart), I2S
+pins](https://godoc.org/periph.io/x/periph/experimental/conn/analog),
+[UART](https://godoc.org/periph.io/x/periph/experimental/conn/uart), I2S
 and PWM.
 
 Note: not all of the above is implemented yet!
@@ -47,15 +47,15 @@ frequently.
 ## Initialization
 
 The function to initialize the drivers registered by default is
-[host.Init()](https://godoc.org/github.com/google/periph/host#Init). It
+[host.Init()](https://godoc.org/periph.io/x/periph/host#Init). It
 returns a
-[periph.State](https://godoc.org/github.com/google/periph#State):
+[periph.State](https://godoc.org/periph.io/x/periph#State):
 
 ```go
 state, err := host.Init()
 ```
 
-[periph.State](https://godoc.org/github.com/google/periph#State) contains
+[periph.State](https://godoc.org/periph.io/x/periph#State) contains
 information about:
 
 * The drivers loaded and active.
@@ -64,22 +64,22 @@ information about:
   these drivers.
 
 In addition,
-[host.Init()](https://godoc.org/github.com/google/periph/host#Init) may
+[host.Init()](https://godoc.org/periph.io/x/periph/host#Init) may
 return an error when there's a structural issue, for example two drivers with
 the same name were registered. This is a fatal failure. The package
-[host](https://godoc.org/github.com/google/periph/host) registers all the
+[host](https://godoc.org/periph.io/x/periph/host) registers all the
 drivers under [host/](../../host/).
 
 
 ## Connection
 
 A connection
-[conn.Conn](https://godoc.org/github.com/google/periph/conn#Conn)
+[conn.Conn](https://godoc.org/periph.io/x/periph/conn#Conn)
 is a **point-to-point** connection between the host and a device where the
 application is the master driving the I/O.
 
 A `Conn` can be multiplexed over the underlying bus. For example an I²C bus
-[i2c.Bus](https://godoc.org/github.com/google/periph/conn/i2c#Bus) may have
+[i2c.Bus](https://godoc.org/periph.io/x/periph/conn/i2c#Bus) may have
 multiple connections (slaves) to the master, each addressed by the device
 address.
 
@@ -87,20 +87,20 @@ address.
 ### SPI connection
 
 An
-[spi.Conn](https://godoc.org/github.com/google/periph/conn/spi#Conn)
+[spi.Conn](https://godoc.org/periph.io/x/periph/conn/spi#Conn)
 **is** a
-[conn.Conn](https://godoc.org/github.com/google/periph/conn#Conn).
+[conn.Conn](https://godoc.org/periph.io/x/periph/conn#Conn).
 
 
 ### I²C connection
 
-An [i2c.Bus](https://godoc.org/github.com/google/periph/conn/i2c#Bus) is **not**
-a [conn.Conn](https://godoc.org/github.com/google/periph/conn#Conn).
+An [i2c.Bus](https://godoc.org/periph.io/x/periph/conn/i2c#Bus) is **not**
+a [conn.Conn](https://godoc.org/periph.io/x/periph/conn#Conn).
 This is because an I²C bus is **not** a point-to-point connection but instead is
 a real bus where multiple devices can be connected simultaneously, like a USB
 bus. To create a point-to-point connection to a device which does implement
-[conn.Conn](https://godoc.org/github.com/google/periph/conn#Conn) use
-[i2c.Dev](https://godoc.org/github.com/google/periph/conn/i2c#Dev), which embeds
+[conn.Conn](https://godoc.org/periph.io/x/periph/conn#Conn) use
+[i2c.Dev](https://godoc.org/periph.io/x/periph/conn/i2c#Dev), which embeds
 the device's address:
 
 ```go
@@ -118,7 +118,7 @@ specify the address.
 
 ### GPIO
 
-[gpio pins](https://godoc.org/github.com/google/periph/conn/gpio#PinIO)
+[gpio pins](https://godoc.org/periph.io/x/periph/conn/gpio#PinIO)
 can be leveraged for arbitrary uses, such as buttons, LEDs, relays, etc. 
 
 
@@ -142,9 +142,9 @@ import (
     "log"
 
     "github.com/example/virtual_i2c"
-    "github.com/google/periph"
-    "github.com/google/periph/host"
-    "github.com/google/periph/conn/i2c"
+    "periph.io/x/periph"
+    "periph.io/x/periph/host"
+    "periph.io/x/periph/conn/i2c"
 )
 
 type driver struct{}

--- a/doc/apps/SAMPLES.md
+++ b/doc/apps/SAMPLES.md
@@ -2,7 +2,7 @@
 
 [README.md](README.md) contains general information for application developpers.
 The complete API documentation, including examples, is at
-[![GoDoc](https://godoc.org/github.com/google/periph?status.svg)](https://godoc.org/github.com/google/periph).
+[![GoDoc](https://godoc.org/periph.io/x/periph?status.svg)](https://godoc.org/periph.io/x/periph).
 
 You are encouraged to look at tools in [cmd/](cmd/). These can be used as the
 basis of your projects.
@@ -26,9 +26,9 @@ import (
     "log"
     "time"
 
-    "github.com/google/periph/conn/gpio"
-    "github.com/google/periph/host"
-    "github.com/google/periph/host/rpi"
+    "periph.io/x/periph/conn/gpio"
+    "periph.io/x/periph/host"
+    "periph.io/x/periph/host/rpi"
 )
 
 func main() {
@@ -56,7 +56,7 @@ _Purpose:_ display IR remote keys.
 
 This sample uses lirc (http://www.lirc.org/). This assumes you installed lirc
 and configured it. See
-[devices/lirc](https://godoc.org/github.com/google/periph/devices/lirc)
+[devices/lirc](https://godoc.org/periph.io/x/periph/devices/lirc)
 for more information.
 
 ```go
@@ -66,8 +66,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/google/periph/devices/lirc"
-    "github.com/google/periph/host"
+    "periph.io/x/periph/devices/lirc"
+    "periph.io/x/periph/host"
 )
 
 func main() {
@@ -98,7 +98,7 @@ func main() {
 _Purpose:_ display an animated GIF.
 
 This sample uses a
-[ssd1306](https://godoc.org/github.com/google/periph/devices/ssd1306).
+[ssd1306](https://godoc.org/periph.io/x/periph/devices/ssd1306).
 The frames in the GIF are resized and centered first to reduce the CPU overhead.
 
 ```go
@@ -112,8 +112,8 @@ import (
     "os"
     "time"
 
-    "github.com/google/periph/devices/ssd1306"
-    "github.com/google/periph/host"
+    "periph.io/x/periph/devices/ssd1306"
+    "periph.io/x/periph/host"
     "github.com/nfnt/resize"
 )
 
@@ -183,7 +183,7 @@ _Purpose:_ Signals when a button was pressed or a motion detector detected a
 movement.
 
 The
-[gpio.PinIn.Edge()](https://godoc.org/github.com/google/periph/conn/gpio#PinIn)
+[gpio.PinIn.Edge()](https://godoc.org/periph.io/x/periph/conn/gpio#PinIn)
 function permits a edge detection without a busy loop. This is useful for
 **motion detectors**, **buttons** and other kinds of inputs where a busy loop
 would burn CPU for no reason.
@@ -195,8 +195,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/google/periph/host"
-    "github.com/google/periph/conn/gpio"
+    "periph.io/x/periph/host"
+    "periph.io/x/periph/conn/gpio"
 )
 
 func main() {
@@ -231,7 +231,7 @@ func main() {
 _Purpose:_ gather temperature, pressure and relative humidity.
 
 This sample uses a
-[bme280](https://godoc.org/github.com/google/periph/devices/bme280).
+[bme280](https://godoc.org/periph.io/x/periph/devices/bme280).
 
 ```go
 package main
@@ -240,9 +240,9 @@ import (
     "fmt"
     "log"
 
-    "github.com/google/periph/devices"
-    "github.com/google/periph/devices/bme280"
-    "github.com/google/periph/host"
+    "periph.io/x/periph/devices"
+    "periph.io/x/periph/devices/bme280"
+    "periph.io/x/periph/host"
 )
 
 func main() {

--- a/doc/drivers/DESIGN.md
+++ b/doc/drivers/DESIGN.md
@@ -10,7 +10,7 @@ This document dives into some of the designs. Read more about the goals at
 The core of extensibility is implemented as an in-process driver registry. The
 things that make it work are:
 * Clear priority classes via
-  [periph.Type](https://godoc.org/github.com/google/periph#Type).
+  [periph.Type](https://godoc.org/periph.io/x/periph#Type).
   Each category is loaded one after the other so a driver of a type can assume
   that all relevant drivers of lower level types were fully loaded.
 * Native way to skip a driver on unrelated platform.
@@ -19,9 +19,9 @@ things that make it work are:
 * Native way to return the state of all registered drivers. The ones loaded, the
   ones skipped and the ones that failed.
 * Native way to declare inter-driver dependency. A specialized
-  [Processor](https://godoc.org/github.com/google/periph#Type)
+  [Processor](https://godoc.org/periph.io/x/periph#Type)
   driver may dependent on generic
-  [Processor](https://godoc.org/github.com/google/periph#Type)
+  [Processor](https://godoc.org/periph.io/x/periph#Type)
   driver and the drivers will be loaded sequentially.
 * In another other case, the drivers are loaded in parallel for minimum total
   latency.
@@ -30,12 +30,12 @@ things that make it work are:
 ### Other registries
 
 Many packages under
-[conn](https://godoc.org/github.com/google/periph/conn) and
-[host/headers](https://godoc.org/github.com/google/periph/host/headers)
+[conn](https://godoc.org/periph.io/x/periph/conn) and
+[host/headers](https://godoc.org/periph.io/x/periph/host/headers)
 contains small focused registries. The goal is to not have a one-size-fits-all
 approach that would require broad generalization; when a user needs an I²C bus
 handle, the user knows they can find it in
-[conn/i2c](https://godoc.org/github.com/google/periph/conn/i2c). It's is
+[conn/i2c](https://godoc.org/periph.io/x/periph/conn/i2c). It's is
 assumed the user knows what bus to use in the first place. Strict type typing
 guides the user towards providing the right object.
 
@@ -49,14 +49,14 @@ twice is an error. This helps reducing ambiguity for the users.
 ## pins
 
 There's a strict separation between
-[analog](https://godoc.org/github.com/google/periph/experimental/conn/analog#PinIO),
+[analog](https://godoc.org/periph.io/x/periph/experimental/conn/analog#PinIO),
 [digital
-(gpio)](https://godoc.org/github.com/google/periph/conn/gpio#PinIO)
+(gpio)](https://godoc.org/periph.io/x/periph/conn/gpio#PinIO)
 and [generic
-pins](https://godoc.org/github.com/google/periph/conn/pins#Pin).
+pins](https://godoc.org/periph.io/x/periph/conn/pins#Pin).
 
 The common base is
-[pins.Pin](https://godoc.org/github.com/google/periph/conn/pins#Pin),
+[pins.Pin](https://godoc.org/periph.io/x/periph/conn/pins#Pin),
 which is a purely generic pin. This describes GROUND,
 VCC, etc. Each pin is registered by the relevant device driver at initialization
 time and has a unique name. The same pin may be present multiple times on a
@@ -64,11 +64,11 @@ header.
 
 The only pins not registered are the INVALID ones. There's one generic
 at
-[pins.INVALID](https://godoc.org/github.com/google/periph/conn/pins#INVALID)
+[pins.INVALID](https://godoc.org/periph.io/x/periph/conn/pins#INVALID)
 and two specialized,
-[analog.INVALID](https://godoc.org/github.com/google/periph/experimental/conn/analog#INVALID)
+[analog.INVALID](https://godoc.org/periph.io/x/periph/experimental/conn/analog#INVALID)
 and
-[gpio.INVALID](https://godoc.org/github.com/google/periph/conn/gpio#INVALID).
+[gpio.INVALID](https://godoc.org/periph.io/x/periph/conn/gpio#INVALID).
 
 *Warning:* analog is not yet implemented.
 

--- a/doc/drivers/GOALS.md
+++ b/doc/drivers/GOALS.md
@@ -41,7 +41,7 @@ maintenance.
     whenever possible, etc.
 * Coverage:
   * Be as OS agnostic as possible. Abstract OS specific concepts like
-    [sysfs](https://godoc.org/github.com/google/periph/host/sysfs).
+    [sysfs](https://godoc.org/periph.io/x/periph/host/sysfs).
   * Each driver implements and exposes as much of the underlying device
     capability as possible and relevant.
   * [cmd/](../../cmd/) implements useful directly usable tool.
@@ -59,7 +59,7 @@ maintenance.
   * Breakage in the API should happen at a yearly parce at most once the library
     got to a stable state.
 * Strong distinction about the driver (as a user of a
-  [conn.Conn](https://godoc.org/github.com/google/periph/conn#Conn)
+  [conn.Conn](https://godoc.org/periph.io/x/periph/conn#Conn)
   instance) and an application writer (as a user of a device driver). It's the
   _application_ that controls the objects' lifetime.
 * Strong distinction between _enablers_ and _devices_. See
@@ -94,9 +94,9 @@ HAL -> the right hardware abstraction layer (not too deep, not too light) is the
 core here.
 
 Devices need common interfaces to help with application developers (like
-[devices.Display](https://godoc.org/github.com/google/periph/devices#Display)
+[devices.Display](https://godoc.org/periph.io/x/periph/devices#Display)
 and
-[devices.Environmental](https://godoc.org/github.com/google/periph/devices#Environmental))
+[devices.Environmental](https://godoc.org/periph.io/x/periph/devices#Environmental))
 but the lack of core repository and coherency is less dramatic.
 
 

--- a/doc/drivers/README.md
+++ b/doc/drivers/README.md
@@ -55,7 +55,7 @@ followed:
   [experimental/](../../experimental/) and respond to the code review.
 
 At this point, it is available for use to everyone but it is not loaded by
-default by [host.Init()](https://godoc.org/github.com/google/periph/host#Init).
+default by [host.Init()](https://godoc.org/periph.io/x/periph/host#Init).
 
 There is no API compatibility guarantee for drivers under
 [experimental/](../../experimental/).
@@ -115,7 +115,7 @@ experience.
   * Minimal use of factories except for protocol level registries.
   * No `init()` code that accesses peripherals on process startup. These belong
     to
-    [Driver.Init()](https://godoc.org/github.com/google/periph#Driver).
+    [Driver.Init()](https://godoc.org/periph.io/x/periph#Driver).
 * Exact naming
   * Driver for a chipset must have the name of the chipset or the chipset
     family. Don't use `oleddisplay`, use `ssd1306`.
@@ -149,7 +149,7 @@ experience.
   * Floating point arithmetic should only be used when absolutely necesary in
     the driver code. Most of the cases can be replaced by fixed point
     arithmetic, for example
-    [devices.Milli](https://godoc.org/github.com/google/periph/devices#Milli).
+    [devices.Milli](https://godoc.org/periph.io/x/periph/devices#Milli).
     Floating point arithmetic is acceptable in the unit tests and tools in
     [cmd/](../../cmd/) but should not be abused.
   * Drivers must be implemented with performance in mind. For example I²C
@@ -174,4 +174,4 @@ experience.
   should be wrapped at reasonable width.
 * Comments should start with a capitalized letter and end with a period.
 * Markdown tries to follow [Google Markdown
-  style](https://github.com/google/styleguide/blob/gh-pages/docguide/style.md)
+  style](https://periph.io/x/styleguide/blob/gh-pages/docguide/style.md)

--- a/doc/users/README.md
+++ b/doc/users/README.md
@@ -28,7 +28,7 @@ run `sudo apt-get install golang` to get the Go toolchain installed.
 It is as simple as:
 
 ```bash
-go get -u github.com/google/periph/cmd/...
+go get -u periph.io/x/periph/cmd/...
 ```
 
 On many platforms, many tools requires running as root (via _sudo_) to have
@@ -39,11 +39,11 @@ access to the necessary CPU GPIO registers or even just kernel exposed APIs.
 
 To have faster builds, you may wish to build on a desktop and send the
 executables to your ARM based micro computer (e.g.  Raspberry Pi).
-[push.sh](https://github.com/google/periph/blob/master/cmd/push.sh) is included
+[push.sh](https://periph.io/x/periph/blob/master/cmd/push.sh) is included
 to wrap this:
 
 ```bash
-cd $GOPATH/src/github.com/google/periph/cmd
+cd $GOPATH/src/periph.io/x/periph/cmd
 ./push.sh raspberrypi bme280
 ```
 

--- a/experimental/cmd/lsusb/main.go
+++ b/experimental/cmd/lsusb/main.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/google/periph/experimental/host/usbbus"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/experimental/host/usbbus"
+	"periph.io/x/periph/host"
 )
 
 func mainImpl() error {

--- a/experimental/conn/analog/analog.go
+++ b/experimental/conn/analog/analog.go
@@ -8,7 +8,7 @@ package analog
 import (
 	"errors"
 
-	"github.com/google/periph/conn/pins"
+	"periph.io/x/periph/conn/pins"
 )
 
 // ADC is an analog-to-digital-conversion input.

--- a/experimental/conn/onewire/onewire.go
+++ b/experimental/conn/onewire/onewire.go
@@ -22,8 +22,8 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn"
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // Bus defines the function a concrete driver for a 1-wire bus must implement.

--- a/experimental/conn/onewire/onewiresmoketest/onewiresmoketest.go
+++ b/experimental/conn/onewire/onewiresmoketest/onewiresmoketest.go
@@ -16,10 +16,10 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/experimental/conn/onewire"
-	"github.com/google/periph/experimental/devices/ds18b20"
-	"github.com/google/periph/experimental/devices/ds248x"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/experimental/conn/onewire"
+	"periph.io/x/periph/experimental/devices/ds18b20"
+	"periph.io/x/periph/experimental/devices/ds248x"
 )
 
 type SmokeTest struct {

--- a/experimental/conn/onewire/onewiretest/onewire_test.go
+++ b/experimental/conn/onewire/onewiretest/onewire_test.go
@@ -7,7 +7,7 @@ package onewiretest
 import (
 	"testing"
 
-	"github.com/google/periph/experimental/conn/onewire"
+	"periph.io/x/periph/experimental/conn/onewire"
 )
 
 // TestDevTx tests the onewire.Dev implementation using the Playback bus impl.

--- a/experimental/conn/onewire/onewiretest/onewiretest.go
+++ b/experimental/conn/onewire/onewiretest/onewiretest.go
@@ -11,8 +11,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/experimental/conn/onewire"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/experimental/conn/onewire"
 )
 
 // IO registers the I/O that happened on either a real or fake 1-wire bus.

--- a/experimental/conn/onewire/onewiretest/search_test.go
+++ b/experimental/conn/onewire/onewiretest/search_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"testing"
 
-	"github.com/google/periph/experimental/conn/onewire"
+	"periph.io/x/periph/experimental/conn/onewire"
 )
 
 // TestSearch tests the onewire.Search function using the Playback bus preloaded

--- a/experimental/conn/uart/uart.go
+++ b/experimental/conn/uart/uart.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // Parity determines the parity bit when transmitting, if any.

--- a/experimental/conn/usb/usb.go
+++ b/experimental/conn/usb/usb.go
@@ -10,7 +10,7 @@ import (
 	"io"
 	"sync"
 
-	"github.com/google/periph/conn"
+	"periph.io/x/periph/conn"
 )
 
 // Conn represents a connection to an USB device.

--- a/experimental/devices/bitbang/i2c.go
+++ b/experimental/devices/bitbang/i2c.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/host/cpu"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/host/cpu"
 )
 
 // Use SkipAddr to skip the address from being sent.

--- a/experimental/devices/bitbang/spi.go
+++ b/experimental/devices/bitbang/spi.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/spi"
-	"github.com/google/periph/host/cpu"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/host/cpu"
 )
 
 // SPI represents a SPI master implemented as bit-banging on 3 or 4 GPIO pins.

--- a/experimental/devices/ds18b20/ds18b20.go
+++ b/experimental/devices/ds18b20/ds18b20.go
@@ -25,8 +25,8 @@ import (
 	"errors"
 	"time"
 
-	"github.com/google/periph/devices"
-	"github.com/google/periph/experimental/conn/onewire"
+	"periph.io/x/periph/devices"
+	"periph.io/x/periph/experimental/conn/onewire"
 )
 
 // New returns an object that communicates over 1-wire to the DS18B20 sensor with the

--- a/experimental/devices/ds18b20/ds18b20_test.go
+++ b/experimental/devices/ds18b20/ds18b20_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/periph/devices"
-	"github.com/google/periph/experimental/conn/onewire"
-	"github.com/google/periph/experimental/conn/onewire/onewiretest"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/devices"
+	"periph.io/x/periph/experimental/conn/onewire"
+	"periph.io/x/periph/experimental/conn/onewire/onewiretest"
+	"periph.io/x/periph/host"
 )
 
 // TestMain lets periph load all drivers and then runs the tests.

--- a/experimental/devices/ds248x/dev.go
+++ b/experimental/devices/ds248x/dev.go
@@ -9,8 +9,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/periph/conn"
-	"github.com/google/periph/experimental/conn/onewire"
+	"periph.io/x/periph/conn"
+	"periph.io/x/periph/experimental/conn/onewire"
 )
 
 // Dev is a handle to a ds248x device and it implements the onewire.Bus interface.

--- a/experimental/devices/ds248x/ds248x.go
+++ b/experimental/devices/ds248x/ds248x.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c"
 )
 
 // PupOhm controls the strength of the passive pull-up resistor

--- a/experimental/devices/ds248x/ds248x_test.go
+++ b/experimental/devices/ds248x/ds248x_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2ctest"
 )
 
 // TestInit tests the initialization of a ds2483 using a recording.

--- a/experimental/devices/piblaster/piblaster.go
+++ b/experimental/devices/piblaster/piblaster.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // SetPWM enables and sets the PWM duty on a GPIO output pin via piblaster.

--- a/experimental/driver_skeleton/driver_skeleton.go
+++ b/experimental/driver_skeleton/driver_skeleton.go
@@ -7,13 +7,13 @@ package driver_skeleton
 import (
 	"errors"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn"
-	"github.com/google/periph/conn/i2c"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn"
+	"periph.io/x/periph/conn/i2c"
 )
 
 // FIXME: Expose public symbols as relevant. Do not export more than needed!
-// See https://github.com/google/periph/tree/master/doc/drivers#requirements
+// See https://periph.io/x/periph/tree/master/doc/drivers#requirements
 // for the expectations.
 
 // Dev is a handle to the device. FIXME.

--- a/experimental/driver_skeleton/driver_skeleton_test.go
+++ b/experimental/driver_skeleton/driver_skeleton_test.go
@@ -9,9 +9,9 @@ import (
 	"log"
 	"testing"
 
-	"github.com/google/periph/conn/i2c"
-	"github.com/google/periph/conn/i2c/i2ctest"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/host"
 )
 
 func Example() {

--- a/experimental/host/sysfs/uart.go
+++ b/experimental/host/sysfs/uart.go
@@ -11,8 +11,8 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/experimental/conn/uart"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/experimental/conn/uart"
 )
 
 // EnumerateUART returns the available serial buses.

--- a/experimental/host/usbbus/usbbus.go
+++ b/experimental/host/usbbus/usbbus.go
@@ -11,9 +11,9 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/google/periph"
-	"github.com/google/periph/experimental/conn/usb"
 	gousb "github.com/kylelemons/gousb/usb"
+	"periph.io/x/periph"
+	"periph.io/x/periph/experimental/conn/usb"
 )
 
 // Desc represents the description of an USB device on an USB bus.

--- a/experimental/host/usbbus/usbbus_test.go
+++ b/experimental/host/usbbus/usbbus_test.go
@@ -11,8 +11,8 @@ import (
 	"log"
 	"testing"
 
-	"github.com/google/periph/experimental/conn/usb"
-	"github.com/google/periph/host"
+	"periph.io/x/periph/experimental/conn/usb"
+	"periph.io/x/periph/host"
 )
 
 func Example() {

--- a/host/allwinner/a64.go
+++ b/host/allwinner/a64.go
@@ -10,7 +10,7 @@ package allwinner
 import (
 	"strings"
 
-	"github.com/google/periph/conn/pins"
+	"periph.io/x/periph/conn/pins"
 )
 
 // A64 specific pins.

--- a/host/allwinner/detect.go
+++ b/host/allwinner/detect.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/google/periph/host/distro"
+	"periph.io/x/periph/host/distro"
 )
 
 // Present detects whether the host CPU is an Allwinner CPU.

--- a/host/allwinner/driver.go
+++ b/host/allwinner/driver.go
@@ -16,9 +16,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/pmem"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/pmem"
 )
 
 // driverGPIO implements periph.Driver.

--- a/host/allwinner/gpio.go
+++ b/host/allwinner/gpio.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/sysfs"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/sysfs"
 )
 
 // List of all known pins. These global variables can be used directly.

--- a/host/allwinner/gpio_pl.go
+++ b/host/allwinner/gpio_pl.go
@@ -14,10 +14,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/pmem"
-	"github.com/google/periph/host/sysfs"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/pmem"
+	"periph.io/x/periph/host/sysfs"
 )
 
 // All the pins in the PL group.

--- a/host/allwinner/r8.go
+++ b/host/allwinner/r8.go
@@ -10,7 +10,7 @@ package allwinner
 import (
 	"strings"
 
-	"github.com/google/periph/conn/pins"
+	"periph.io/x/periph/conn/pins"
 )
 
 // R8 specific pins.

--- a/host/bcm283x/gpio.go
+++ b/host/bcm283x/gpio.go
@@ -15,11 +15,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/distro"
-	"github.com/google/periph/host/pmem"
-	"github.com/google/periph/host/sysfs"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/distro"
+	"periph.io/x/periph/host/pmem"
+	"periph.io/x/periph/host/sysfs"
 )
 
 // All the pins supported by the CPU.

--- a/host/chip/chip.go
+++ b/host/chip/chip.go
@@ -12,12 +12,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/host/allwinner"
-	"github.com/google/periph/host/distro"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/host/allwinner"
+	"periph.io/x/periph/host/distro"
+	"periph.io/x/periph/host/headers"
 )
 
 // C.H.I.P. hardware pins.

--- a/host/chip/chipsmoketest/chipsmoketest.go
+++ b/host/chip/chipsmoketest/chipsmoketest.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/allwinner"
-	"github.com/google/periph/host/chip"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/allwinner"
+	"periph.io/x/periph/host/chip"
+	"periph.io/x/periph/host/headers"
 )
 
 // testChipPresent verifies that CHIP and Allwinner are indeed detected.

--- a/host/headers/headers.go
+++ b/host/headers/headers.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/pins"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/pins"
 )
 
 // All contains all the on-board headers on a micro computer.

--- a/host/headers/headers_test.go
+++ b/host/headers/headers_test.go
@@ -7,8 +7,8 @@ package headers
 import (
 	"testing"
 
-	"github.com/google/periph/conn/gpio/gpiotest"
-	"github.com/google/periph/conn/pins"
+	"periph.io/x/periph/conn/gpio/gpiotest"
+	"periph.io/x/periph/conn/pins"
 )
 
 func TestAll(t *testing.T) {

--- a/host/host.go
+++ b/host/host.go
@@ -4,7 +4,7 @@
 
 package host
 
-import "github.com/google/periph"
+import "periph.io/x/periph"
 
 // Init calls periph.Init() and returns it as-is.
 //

--- a/host/host_arm.go
+++ b/host/host_arm.go
@@ -6,12 +6,12 @@ package host
 
 import (
 	// Make sure CPU and board drivers are registered.
-	_ "github.com/google/periph/host/allwinner"
-	_ "github.com/google/periph/host/bcm283x"
-	_ "github.com/google/periph/host/chip"
-	_ "github.com/google/periph/host/odroid_c1"
+	_ "periph.io/x/periph/host/allwinner"
+	_ "periph.io/x/periph/host/bcm283x"
+	_ "periph.io/x/periph/host/chip"
+	_ "periph.io/x/periph/host/odroid_c1"
 	// While this board is ARM64, it may run ARM 32 bits binaries so load it on
 	// 32 bits builds too.
-	_ "github.com/google/periph/host/pine64"
-	_ "github.com/google/periph/host/rpi"
+	_ "periph.io/x/periph/host/pine64"
+	_ "periph.io/x/periph/host/rpi"
 )

--- a/host/host_arm64.go
+++ b/host/host_arm64.go
@@ -6,6 +6,6 @@ package host
 
 import (
 	// Make sure CPU and board drivers are registered.
-	_ "github.com/google/periph/host/allwinner"
-	_ "github.com/google/periph/host/pine64"
+	_ "periph.io/x/periph/host/allwinner"
+	_ "periph.io/x/periph/host/pine64"
 )

--- a/host/host_linux.go
+++ b/host/host_linux.go
@@ -6,5 +6,5 @@ package host
 
 import (
 	// Make sure sysfs drivers are registered.
-	_ "github.com/google/periph/host/sysfs"
+	_ "periph.io/x/periph/host/sysfs"
 )

--- a/host/odroid_c1/c1.go
+++ b/host/odroid_c1/c1.go
@@ -8,12 +8,12 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/host/distro"
-	"github.com/google/periph/host/headers"
-	"github.com/google/periph/host/sysfs"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/host/distro"
+	"periph.io/x/periph/host/headers"
+	"periph.io/x/periph/host/sysfs"
 )
 
 // The J2 header is rPi compatible, except for the two analog pins and the 1.8V

--- a/host/odroid_c1/odroidc1smoketest/odroidc1smoketest.go
+++ b/host/odroid_c1/odroidc1smoketest/odroidc1smoketest.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/host/headers"
-	"github.com/google/periph/host/odroid_c1"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/headers"
+	"periph.io/x/periph/host/odroid_c1"
 )
 
 // testOdroidC1Present verifies that odroid_c1 is indeed detected.

--- a/host/pine64/pine64.go
+++ b/host/pine64/pine64.go
@@ -8,10 +8,10 @@ import (
 	"errors"
 	"os"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/host/allwinner"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/host/allwinner"
+	"periph.io/x/periph/host/headers"
 )
 
 // Present returns true if running on a Pine64 board.

--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -12,12 +12,12 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/pins"
-	"github.com/google/periph/host/bcm283x"
-	"github.com/google/periph/host/distro"
-	"github.com/google/periph/host/headers"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/pins"
+	"periph.io/x/periph/host/bcm283x"
+	"periph.io/x/periph/host/distro"
+	"periph.io/x/periph/host/headers"
 )
 
 // Present returns true if running on a Raspberry Pi board.

--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // Pins is all the pins exported by GPIO sysfs.

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/i2c"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/i2c"
 )
 
 // I2C is an open I²C bus via sysfs.

--- a/host/sysfs/led.go
+++ b/host/sysfs/led.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
 )
 
 // LEDs is all the leds discovered on this host via sysfs.

--- a/host/sysfs/led_test.go
+++ b/host/sysfs/led_test.go
@@ -9,7 +9,7 @@ import (
 	"log"
 	"testing"
 
-	"github.com/google/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio"
 )
 
 func ExampleLEDByName() {

--- a/host/sysfs/spi.go
+++ b/host/sysfs/spi.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/google/periph"
-	"github.com/google/periph/conn/gpio"
-	"github.com/google/periph/conn/spi"
+	"periph.io/x/periph"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/spi"
 )
 
 // NewSPI opens a SPI bus via its devfs interface as described at

--- a/host/sysfs/thermal_sensor.go
+++ b/host/sysfs/thermal_sensor.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/google/periph"
-	"github.com/google/periph/devices"
+	"periph.io/x/periph"
+	"periph.io/x/periph/devices"
 )
 
 // ThermalSensors is all the sensors discovered on this host via sysfs.

--- a/host/videocore/videocore.go
+++ b/host/videocore/videocore.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/google/periph/host/pmem"
+	"periph.io/x/periph/host/pmem"
 )
 
 // Mem represents contiguous physically locked memory that was allocated by

--- a/periph.go
+++ b/periph.go
@@ -35,7 +35,7 @@
 //     CPU and buses that are exposed by the host onto which devices can be
 //     connected, i.e. I²C, SPI, GPIO, etc. 'host' contains the interfaces
 //     and subpackages contain contain concrete types.
-package periph
+package periph // import "periph.io/x/periph"
 
 import (
 	"errors"


### PR DESCRIPTION
This makes periph.io/x/periph the repository root so it is not tied to the
Google organisation anymore.