### PR TITLE
Make markdown files more compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 * Continuously tested on [Raspberry Pi](https://raspberrypi.org),
   [C.H.I.P.](https://getchip.com/) and Windows 10 via
-  [gohci](https://github.com/maruel/gohci).
+  [gohci](https://github.com/periph/gohci).
 * Interfaces: I²C, SPI, gpio (both low latency memory mapped registers and
   zero-CPU edge detection), 1-wire and more.
 * Devices: apa102, bme280, ds18b20, ssd1306, tm1637, and more coming.
@@ -63,6 +63,7 @@ func main() {
 ```
 
 The following are synonyms, use the form you prefer:
+
 * Runtime discovery:
   * [`gpio.ByNumber(13)`](https://godoc.org/periph.io/x/periph/conn/gpio/#ByNumber) or [`gpio.ByName("13")`](https://godoc.org/periph.io/x/periph/conn/gpio/#ByName)
   *  [`gpio.ByName("GPIO13")`](https://godoc.org/periph.io/x/periph/conn/gpio/#ByName)
@@ -88,7 +89,7 @@ not _required_ to fork the periph repository to load out-of-tree drivers for
 your platform.
 
 **Every commit is [tested on real hardware](doc/drivers/CONTRIBUTING.md#testing)
-via [gohci](https://github.com/maruel/gohci) workers.**
+via [gohci](https://github.com/periph/gohci) workers.**
 
 We gladly accept contributions for documentation improvements and from device
 driver developers via GitHub pull requests, as long as the author has signed the

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,6 +3,7 @@
 periph is a Peripheral I/O library in Go.
 
 The documentation is split into 4 sections:
+
 * [host/](host/) describes periph on each supported platform.
 * [users/](users/) for ready-to-use tools.
   * No Go programming skill is required at all. `go get` and run.

--- a/doc/drivers/CONTRIBUTING.md
+++ b/doc/drivers/CONTRIBUTING.md
@@ -37,11 +37,12 @@ device support.
 
 ## Testing
 
-We use [gohci](https://github.com/maruel/gohci) for automated testing on
+We use [gohci](https://github.com/periph/gohci) for automated testing on
 devices. The devices run unit tests, `go vet` and
 [periph-smoketest](../../cmd/periph-smoketest).
 
 The fleet currently is currently hosted by [maruel](https://github.com/maruel):
+
 - [Raspberry Pi 3](https://www.raspberrypi.org/) running [Raspbian Jessie
   Lite](https://www.raspberrypi.org/downloads/raspbian/)
 - [C.H.I.P.](https://getchip.com/pages/chip) running Debian headless image

--- a/doc/drivers/DESIGN.md
+++ b/doc/drivers/DESIGN.md
@@ -9,6 +9,7 @@ This document dives into some of the designs. Read more about the goals at
 
 The core of extensibility is implemented as an in-process driver registry. The
 things that make it work are:
+
 * Clear priority classes via
   [periph.Type](https://godoc.org/periph.io/x/periph#Type).
   Each category is loaded one after the other so a driver of a type can assume

--- a/doc/drivers/README.md
+++ b/doc/drivers/README.md
@@ -47,6 +47,7 @@ that must be asserted.
 Any driver can be requested to be added to the library under the
 [experimental/](../../experimental/) directory. The following process must be
 followed:
+
 * Create a driver out of tree an make it work.
 * Improve the driver so it meets a minimal quality bar under the promise of
   being improved. See [Requirements](#requirements) for the extensive list.
@@ -66,6 +67,7 @@ There is no API compatibility guarantee for drivers under
 A driver in [experimental/](../../experimental/) can be promoted to stable in
 either [devices/](../../devices/) or [host/](../../host/) as appropriate. The
 following process must be followed:
+
 * Declare at least one (or multiple) owners that are responsive to
   feature requests and bug reports.
   * There could be a threshold, > _TO BE DETERMINED_ lines, where more than one

--- a/doc/host/CHIP.md
+++ b/doc/host/CHIP.md
@@ -3,6 +3,7 @@
 The NextThing Co's C.H.I.P. board is supported by periph using sysfs drivers
 as well as using memory-mapped I/O for gpio pins. The CHIPs use an
 Allwinner R8 processor. The following functionality is supported:
+
 - 3x I²C buses
 - 1x SPI bus with 1x chip-enable
 - 8x GPIO pins via pcf8574 I²C I/O extender ("XIO" pins)
@@ -31,6 +32,7 @@ is required in order to create the /dev/spi32766.0 device and connect it
 to the pins.
 
 Buses cheat sheet:
+
 - i2c0: not available on the headers but has axp209 power control chip
 - i2c1: U13 pins 9 & 11
 - i2c2: U14 pins 25 & 26, has pcf8574 I/O extender

--- a/doc/host/ODROID-C1.md
+++ b/doc/host/ODROID-C1.md
@@ -5,6 +5,7 @@ using the sysfs drivers.  These boards use an Amlogic S805 processor (called
 "meson_8b" in the linux kernel).  Currently no package for memory-mapped I/O
 has been written for this processor, thus all gpio functions are implemented
 via sysfs. The functionality supported is:
+
 - 2x I²C buses
 - 1x SPI bus with 1x chip-enable
 - 25x GPIO pins on the main J2 header
@@ -32,6 +33,7 @@ drivers and some of their peculiarities are described in the Ubuntu section of t
 [wiki page](http://odroid.com/dokuwiki/doku.php?id=en:odroid-c1#ubuntu).
 
 Driver cheat sheet:
+
 - For I²C: `modprobe aml_i2c`, buses: i2c1 on pins 3&5, i2c2 on pins 27&28.
 - For SPI: `modprobe spicc`, bus on pins 19, 21, 23 and chip enable pin 24.
 - To free up gpio83 from 1-wire: `rmmod w1-gpio`

--- a/doc/host/README.md
+++ b/doc/host/README.md
@@ -10,6 +10,7 @@ Pine64, the additional support means that in addition to the above high-speed
 memory-mapped I/O has been implemented.
 
 Current platforms:
+
 - Raspberry Pi
 - [NextThing C.H.I.P.](CHIP.md)
 - Pine 64


### PR DESCRIPTION
Certain parser requires empty line above the first list item to be recognized as
a list.

Update gohci URL.