### PR TITLE
i2c: convert from "number only" to named buses plus aliases

### DIFF
--- a/cmd/bme280/main.go
+++ b/cmd/bme280/main.go
@@ -48,7 +48,7 @@ func read(e devices.Environmental, loop bool) error {
 }
 
 func mainImpl() error {
-	i2cID := flag.Int("i", -1, "I²C bus to use")
+	i2cID := flag.String("i", "", "I²C bus to use")
 	i2cADDR := flag.Uint("ia", 0, "I²C bus address to use")
 	spiID := flag.Int("s", -1, "SPI bus to use")
 	cs := flag.Int("cs", -1, "SPI chip select (CS) line to use")
@@ -122,7 +122,7 @@ func mainImpl() error {
 			return err
 		}
 	} else {
-		bus, err := i2c.New(*i2cID)
+		bus, err := i2c.OpenByName(*i2cID)
 		if err != nil {
 			return err
 		}

--- a/cmd/i2c-list/main.go
+++ b/cmd/i2c-list/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"periph.io/x/periph/conn/i2c"
 	"periph.io/x/periph/conn/pins"
@@ -29,15 +28,9 @@ func mainImpl() error {
 	if _, err := host.Init(); err != nil {
 		return err
 	}
-	all := i2c.All()
-	names := make([]string, 0, len(all))
-	for name := range all {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		fmt.Printf("%s:\n", name)
-		bus, err := all[name]()
+	for _, ref := range i2c.All() {
+		fmt.Printf("%s:\n", ref.Name)
+		bus, err := ref.Open()
 		if err != nil {
 			fmt.Printf("  Failed to open: %v\n", err)
 			continue
@@ -46,7 +39,9 @@ func mainImpl() error {
 			printPin("SCL", p.SCL())
 			printPin("SDA", p.SDA())
 		}
-		bus.Close()
+		if err := bus.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/i2c/main.go
+++ b/cmd/i2c/main.go
@@ -21,7 +21,7 @@ import (
 
 func mainImpl() error {
 	addr := flag.Int("a", -1, "I²C device address to query")
-	busNumber := flag.Int("b", -1, "I²C bus to use")
+	busName := flag.String("b", "", "I²C bus to use")
 	verbose := flag.Bool("v", false, "verbose mode")
 	write := flag.Bool("w", false, "write instead of reading")
 	reg := flag.Int("r", -1, "register to address")
@@ -69,7 +69,7 @@ func mainImpl() error {
 		buf = make([]byte, *l)
 	}
 
-	bus, err := i2c.New(*busNumber)
+	bus, err := i2c.OpenByName(*busName)
 	if err != nil {
 		return err
 	}

--- a/cmd/ssd1306/main.go
+++ b/cmd/ssd1306/main.go
@@ -238,7 +238,7 @@ func patterns(s *ssd1306.Dev) error {
 }
 
 func mainImpl() error {
-	i2cID := flag.Int("i2c", -1, "specify I²C bus to use")
+	i2cID := flag.String("i2c", "", "I²C bus to use")
 	spiID := flag.Int("spi", -1, "specify SPI bus to use")
 	csID := flag.Int("cs", 0, "specify SPI chip select (CS) to use")
 	speed := flag.Int("speed", 0, "specify SPI speed in Hz to use")
@@ -285,7 +285,7 @@ func mainImpl() error {
 			return err
 		}
 	} else {
-		bus, err := i2c.New(*i2cID)
+		bus, err := i2c.OpenByName(*i2cID)
 		if err != nil {
 			return err
 		}

--- a/conn/gpio/gpio.go
+++ b/conn/gpio/gpio.go
@@ -19,6 +19,8 @@ import (
 	"periph.io/x/periph/conn/pins"
 )
 
+// Interfaces
+
 // Level is the level of the pin: Low or High.
 type Level bool
 
@@ -182,7 +184,7 @@ type RealPin interface {
 	Real() PinIO // Real returns the real pin behind an Alias
 }
 
-//
+// Registry
 
 // ByNumber returns a GPIO pin from its number.
 //
@@ -323,12 +325,12 @@ func Register(p PinIO, preferred bool) error {
 //
 // It is possible to register an alias for a pin number that itself has not
 // been registered yet.
-func RegisterAlias(name string, number int) error {
-	if len(name) == 0 {
+func RegisterAlias(alias string, number int) error {
+	if len(alias) == 0 {
 		return errors.New("gpio: can't register an alias with no name")
 	}
-	if _, err := strconv.Atoi(name); err == nil {
-		return fmt.Errorf("gpio: can't register an alias with a name being only a number %q", name)
+	if _, err := strconv.Atoi(alias); err == nil {
+		return fmt.Errorf("gpio: can't register an alias being only a number %q", alias)
 	}
 	if number < 0 {
 		return fmt.Errorf("gpio: can't register an alias to a pin with a negative number %d", number)
@@ -336,10 +338,10 @@ func RegisterAlias(name string, number int) error {
 
 	mu.Lock()
 	defer mu.Unlock()
-	if orig, ok := byAlias[name]; ok {
-		return fmt.Errorf("gpio: can't register alias %q for pin %d: it is already aliased to %q", name, number, orig)
+	if orig := byAlias[alias]; orig != nil {
+		return fmt.Errorf("gpio: can't register alias %q for pin %d: it is already aliased to %q", alias, number, orig)
 	}
-	byAlias[name] = &pinAlias{name: name, number: number}
+	byAlias[alias] = &pinAlias{name: alias, number: number}
 	return nil
 }
 

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -2,9 +2,10 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// Package i2c defines an I²C bus.
+// Package i2c defines interface to an I²C bus, an I²C device and a registry to
+// list buses present on the host.
 //
-// It includes an adapter to directly address an I²C device on a I²C bus
+// It includes the adapter Dev to directly address an I²C device on a I²C bus
 // without having to continuously specify the address when doing I/O. This
 // enables the support of conn.Conn.
 package i2c
@@ -13,11 +14,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
+	"strconv"
 	"sync"
 
 	"periph.io/x/periph/conn"
 	"periph.io/x/periph/conn/gpio"
 )
+
+// Interfaces
 
 // Bus defines the interface a concrete I²C driver must implement.
 //
@@ -27,7 +32,6 @@ import (
 // specified. Use i2cdev.Dev as an adapter to get a conn.Conn compatible
 // object.
 type Bus interface {
-	fmt.Stringer
 	Tx(addr uint16, w, r []byte) error
 	// Speed changes the bus speed, if supported.
 	Speed(hz int64) error
@@ -35,7 +39,9 @@ type Bus interface {
 
 // BusCloser is an I²C bus that can be closed.
 //
-// This interface is meant to be handled by the application.
+// This interface is meant to be handled by the application and not the device
+// driver. A device driver doesn't "own" a bus, hence it must operate on a Bus,
+// not a BusCloser.
 type BusCloser interface {
 	io.Closer
 	Bus
@@ -88,58 +94,192 @@ func (d *Dev) Duplex() conn.Duplex {
 	return conn.Half
 }
 
-//
+// Registry
 
-// All returns all the I²C buses available on this host.
-func All() map[string]Opener {
-	mu.Lock()
-	defer mu.Unlock()
-	out := make(map[string]Opener, len(byName))
-	for k, v := range byName {
-		out[k] = v
-	}
-	return out
+// Open opens an handle to a bus.
+type Opener func() (BusCloser, error)
+
+// Ref references an I²C bus.
+type Ref struct {
+	// Name of the bus.
+	//
+	// It must not be a sole number. It must be unique across the host.
+	Name string
+	// Aliases are the alternative names that can be used to reference this bus.
+	Aliases []string
+	// Number of the bus or -1 if the bus doesn't have any "native" number.
+	//
+	// Buses provided by the CPU normally have a 0 based number. Buses provided
+	// via an addon (like over USB) generally are not numbered.
+	Number int
+	// Open is the factory to open an handle to this I²C bus.
+	Open Opener
 }
 
-// New returns an open handle to the first available I²C bus.
+// OpenByNumber opens an I²C bus by its "bus number" and returns an handle to
+// it.
 //
 // Specify busNumber -1 to get the first available bus. This is the recommended
-// value.
-func New(busNumber int) (BusCloser, error) {
-	opener, err := find(busNumber)
+// default value unless an application knows the exact bus to use.
+//
+// "Bus number" is a generic concept that is highly dependent on the platform
+// and OS. On some platform, the first bus may have the number 0, 1 or as high
+// as 32766. Bus numbers are not necessarily continuous and may not start at 0.
+// It was observed that the bus number as reported by the OS may change across
+// OS revisions.
+//
+// When the I²C bus is provided by an off board plug and play bus like USB via
+// an FT232H USB device, there can be no associated number.
+func OpenByNumber(busNumber int) (BusCloser, error) {
+	var r *Ref
+	var err error
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(byName) == 0 {
+			err = errors.New("i2c: no bus found; did you forget to call Init()?")
+			return
+		}
+		if busNumber == -1 {
+			// Asking for the default bus.
+			r = defaultBus()
+			return
+		}
+		r = byNumber[busNumber]
+	}()
 	if err != nil {
 		return nil, err
 	}
-	return opener()
+	if r == nil {
+		return nil, fmt.Errorf("i2c: unknown bus %d", busNumber)
+	}
+	return r.Open()
 }
 
-// Opener opens an I²C bus.
-type Opener func() (BusCloser, error)
+// OpenByName opens an I²C bus by its name or an alias and returns an handle to
+// it.
+//
+// Specify the empty string "" to get the first available bus. This is the
+// recommended default value unless an application knows the exact bus to use.
+//
+// Each bus can register multiple aliases, each leading to the same bus handle.
+// The aliases can be retrieved with Aliases(). For example, "/dev/i2c-0",
+// "I2C0" and "0" are likely valid ways to access the same bus on linux.
+func OpenByName(name string) (BusCloser, error) {
+	var r *Ref
+	var err error
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(byName) == 0 {
+			err = errors.New("i2c: no bus found; did you forget to call Init()?")
+			return
+		}
+		if len(name) == 0 {
+			// Asking for the default bus.
+			r = defaultBus()
+			return
+		}
+		// Try by name, by alias, by number.
+		if r = byName[name]; r == nil {
+			if r = byAlias[name]; r == nil {
+				if i, err2 := strconv.Atoi(name); err2 == nil {
+					r = byNumber[i]
+				}
+			}
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, fmt.Errorf("i2c: unknown bus %q", name)
+	}
+	return r.Open()
+}
+
+// All returns a copy of all the registered references to all know I²C buses
+// available on this host.
+//
+// The list is sorted by the bus name.
+func All() []*Ref {
+	var out refList
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+		out = make(refList, 0, len(byName))
+		for _, v := range byName {
+			r := &Ref{Name: v.Name, Aliases: make([]string, len(v.Aliases)), Number: v.Number, Open: v.Open}
+			copy(r.Aliases, v.Aliases)
+			out = append(out, r)
+		}
+	}()
+	sort.Sort(out)
+	return out
+}
 
 // Register registers an I²C bus.
 //
-// Registering the same bus name twice is an error.
-func Register(name string, busNumber int, opener Opener) error {
-	if opener == nil {
-		return errors.New("i2c: nil opener")
+// Registering the same bus name twice is an error, e.g. o.Name(). o.Number()
+// can be -1 to signify that the bus doesn't have an inherent "bus number". A
+// good example is a bus provided over a FT232H device connected on an USB bus.
+// In this case, the bus name should be created from the serial number of the
+// device for unique identification.
+func Register(name string, aliases []string, number int, o Opener) error {
+	if o == nil {
+		return errors.New("i2c: nil Opener")
+	}
+	if number < -1 {
+		return errors.New("i2c: invalid bus number")
 	}
 	if len(name) == 0 {
 		return errors.New("i2c: empty name")
 	}
-	mu.Lock()
-	defer mu.Unlock()
-	if _, ok := byName[name]; ok {
-		return fmt.Errorf("i2c: registering the same bus %s twice", name)
+	if _, err := strconv.Atoi(name); err == nil {
+		return fmt.Errorf("i2c: can't register an alias being only a number %q", name)
 	}
-	if busNumber != -1 {
-		if _, ok := byNumber[busNumber]; ok {
-			return fmt.Errorf("i2c: registering the same bus %d twice", busNumber)
+	for _, alias := range aliases {
+		if len(alias) == 0 {
+			return errors.New("i2c: empty alias")
+		}
+		if name == alias {
+			return errors.New("i2c: alias of the same name than the bus itself")
+		}
+		if _, err := strconv.Atoi(alias); err == nil {
+			return fmt.Errorf("i2c: can't register an alias being only a number %q", alias)
 		}
 	}
 
-	byName[name] = opener
-	if busNumber != -1 {
-		byNumber[busNumber] = opener
+	mu.Lock()
+	defer mu.Unlock()
+	if _, ok := byName[name]; ok {
+		return fmt.Errorf("i2c: registering the same bus %q twice", name)
+	}
+	if _, ok := byAlias[name]; ok {
+		return fmt.Errorf("i2c: registering the same bus %q twice", name)
+	}
+	if number != -1 {
+		if _, ok := byNumber[number]; ok {
+			return fmt.Errorf("i2c: registering the same bus %d twice", number)
+		}
+	}
+	for _, alias := range aliases {
+		if _, ok := byName[alias]; ok {
+			return fmt.Errorf("i2c: registering the same bus %q twice", alias)
+		}
+		if _, ok := byAlias[alias]; ok {
+			return fmt.Errorf("i2c: registering the same bus %q twice", alias)
+		}
+	}
+
+	r := &Ref{Name: name, Aliases: make([]string, len(aliases)), Number: number, Open: o}
+	copy(r.Aliases, aliases)
+	byName[name] = r
+	if number != -1 {
+		byNumber[number] = r
+	}
+	for _, alias := range aliases {
+		byAlias[alias] = r
 	}
 	return nil
 }
@@ -148,48 +288,58 @@ func Register(name string, busNumber int, opener Opener) error {
 //
 // This can happen when an I²C bus is exposed via an USB device and the device
 // is unplugged.
-func Unregister(name string, busNumber int) error {
+func Unregister(name string) error {
 	mu.Lock()
 	defer mu.Unlock()
-	if _, ok := byName[name]; !ok {
+	r := byName[name]
+	if r == nil {
 		return fmt.Errorf("i2c: unknown bus name %q", name)
 	}
-	if _, ok := byNumber[busNumber]; !ok {
-		return fmt.Errorf("i2c: unknown bus number %d", busNumber)
-	}
-
 	delete(byName, name)
-	delete(byNumber, busNumber)
+	delete(byNumber, r.Number)
+	for _, alias := range r.Aliases {
+		delete(byAlias, alias)
+	}
 	return nil
 }
 
 //
 
-func find(busNumber int) (Opener, error) {
-	mu.Lock()
-	defer mu.Unlock()
+var (
+	mu     sync.Mutex
+	byName = map[string]*Ref{}
+	// Caches
+	byNumber = map[int]*Ref{}
+	byAlias  = map[string]*Ref{}
+)
+
+func defaultBus() *Ref {
+	var o *Ref
 	if len(byNumber) == 0 {
-		return nil, errors.New("i2c: no bus found; did you forget to call Init()?")
-	}
-	if busNumber == -1 {
-		busNumber = int((^uint(0)) >> 1)
-		for n := range byNumber {
-			if busNumber > n {
-				busNumber = n
+		// Fallback to use byName using a lexical sort.
+		name := ""
+		for n, o2 := range byName {
+			if len(name) == 0 || n < name {
+				o = o2
+				name = n
 			}
 		}
+		return o
 	}
-	bus, ok := byNumber[busNumber]
-	if !ok {
-		return nil, fmt.Errorf("i2c: no bus %d", busNumber)
+	busNumber := int((^uint(0)) >> 1)
+	for n, o2 := range byNumber {
+		if busNumber > n {
+			busNumber = n
+			o = o2
+		}
 	}
-	return bus, nil
+	return o
 }
 
-var (
-	mu       sync.Mutex
-	byName   = map[string]Opener{}
-	byNumber = map[int]Opener{}
-)
+type refList []*Ref
+
+func (r refList) Len() int           { return len(r) }
+func (r refList) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r refList) Less(i, j int) bool { return r[i].Name < r[j].Name }
 
 var _ conn.Conn = &Dev{}

--- a/conn/i2c/i2csmoketest/i2csmoketest.go
+++ b/conn/i2c/i2csmoketest/i2csmoketest.go
@@ -40,13 +40,13 @@ func (s *SmokeTest) Description() string {
 // Run implements the SmokeTest interface.
 func (s *SmokeTest) Run(args []string) error {
 	f := flag.NewFlagSet("i2c", flag.ExitOnError)
-	busNum := f.Int("bus", -1, "bus number, -1 for lowest numbered bus")
+	busName := f.String("bus", "", "I²C bus to use")
 	wc := f.String("wc", "", "gpio pin for EEPROM write-control pin")
 	seed := f.Int64("seed", 0, "random number seed, default is to use the time")
 	f.Parse(args)
 
 	// Open the bus.
-	i2cBus, err := i2c.New(*busNum)
+	i2cBus, err := i2c.OpenByName(*busName)
 	if err != nil {
 		return fmt.Errorf("i2c-smoke: %s", err)
 	}

--- a/conn/i2c/i2ctest/i2ctest_test.go
+++ b/conn/i2c/i2ctest/i2ctest_test.go
@@ -7,10 +7,74 @@ package i2ctest
 import (
 	"testing"
 
-	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpiotest"
 )
 
-func TestDev(t *testing.T) {
+func TestRecord_empty(t *testing.T) {
+	r := Record{}
+	if s := r.String(); s != "record" {
+		t.Fatal(s)
+	}
+	if err := r.Speed(-100); err != nil {
+		t.Fatal(err)
+	}
+	if r.Tx(1, nil, []byte{'a'}) == nil {
+		t.Fatal("Bus is nil")
+	}
+	if s := r.SCL(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if s := r.SDA(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+}
+
+func TestRecord_empty_tx(t *testing.T) {
+	r := Record{}
+	if err := r.Tx(1, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Ops) != 1 {
+		t.Fatal(r.Ops)
+	}
+	if err := r.Tx(1, []byte{'a', 'b'}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Ops) != 2 {
+		t.Fatal(r.Ops)
+	}
+	if r.Tx(1, []byte{'a', 'b'}, []byte{'d'}) == nil {
+		t.Fatal("Bus is nil")
+	}
+	if len(r.Ops) != 2 {
+		t.Fatal(r.Ops)
+	}
+}
+
+func TestPlayback(t *testing.T) {
+	p := Playback{
+		SDAPin: &gpiotest.Pin{N: "DA"},
+		SCLPin: &gpiotest.Pin{N: "CL"},
+	}
+	if s := p.String(); s != "playback" {
+		t.Fatal(s)
+	}
+	if err := p.Speed(-100); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if n := p.SDA().Name(); n != "DA" {
+		t.Fatal(n)
+	}
+	if n := p.SCL().Name(); n != "CL" {
+		t.Fatal(n)
+	}
+}
+
+func TestPlayback_tx(t *testing.T) {
 	p := Playback{
 		Ops: []IO{
 			{
@@ -20,12 +84,65 @@ func TestDev(t *testing.T) {
 			},
 		},
 	}
-	d := i2c.Dev{Bus: &p, Addr: 23}
+	if p.Tx(23, nil, nil) == nil {
+		t.Fatal("missing read and write")
+	}
+	if p.Close() == nil {
+		t.Fatal("Ops is not empty")
+	}
 	v := [1]byte{}
-	if err := d.Tx([]byte{10}, v[:]); err != nil {
+	if p.Tx(42, []byte{10}, v[:]) == nil {
+		t.Fatal("invalid address")
+	}
+	if p.Tx(23, []byte{10}, make([]byte, 2)) == nil {
+		t.Fatal("invalid read size")
+	}
+	if err := p.Tx(23, []byte{10}, v[:]); err != nil {
 		t.Fatal(err)
 	}
 	if v[0] != 12 {
-		t.Fail()
+		t.Fatalf("expected 12, got %v", v)
+	}
+	if err := p.Tx(23, []byte{10}, v[:]); err == nil {
+		t.Fatal("Playback.Ops is empty")
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecord_Playback(t *testing.T) {
+	r := Record{
+		Bus: &Playback{
+			Ops: []IO{
+				{
+					Addr:  23,
+					Write: []byte{10},
+					Read:  []byte{12},
+				},
+			},
+			SDAPin: &gpiotest.Pin{N: "DA"},
+			SCLPin: &gpiotest.Pin{N: "CL"},
+		},
+	}
+	if err := r.Speed(-100); err != nil {
+		t.Fatal(err)
+	}
+	if n := r.SDA().Name(); n != "DA" {
+		t.Fatal(n)
+	}
+	if n := r.SCL().Name(); n != "CL" {
+		t.Fatal(n)
+	}
+
+	v := [1]byte{}
+	if err := r.Tx(23, []byte{10}, v[:]); err != nil {
+		t.Fatal(err)
+	}
+	if v[0] != 12 {
+		t.Fatalf("expected 12, got %v", v)
+	}
+	if r.Tx(23, []byte{10}, v[:]) == nil {
+		t.Fatal("Playback.Ops is empty")
 	}
 }

--- a/conn/onewire/onewiresmoketest/onewiresmoketest.go
+++ b/conn/onewire/onewiresmoketest/onewiresmoketest.go
@@ -40,12 +40,12 @@ func (s *SmokeTest) Description() string {
 // Run implements the SmokeTest interface.
 func (s *SmokeTest) Run(args []string) error {
 	f := flag.NewFlagSet("onewire", flag.ExitOnError)
-	busNum := f.Int("i2cbus", -1, "bus number for the DS2483 1-wire interface chip, -1 for lowest numbered bus")
+	busName := f.String("i2cbus", "", "I²C bus name for the DS2483 1-wire interface chip")
 	seed := f.Int64("seed", 0, "random number seed, default is to use the time")
 	f.Parse(args)
 
 	// Open the i2c bus where the DS2483 is located.
-	i2cBus, err := i2c.New(*busNum)
+	i2cBus, err := i2c.OpenByName(*busName)
 	if err != nil {
 		return fmt.Errorf("onewire-smoke: cannot open i2c bus: %v", err)
 	}

--- a/conn/reg/reg_test.go
+++ b/conn/reg/reg_test.go
@@ -21,7 +21,7 @@ import (
 
 func ExampleDev8() {
 	// Open a connection, using I²C as an example:
-	bus, err := i2c.New(-1)
+	bus, err := i2c.OpenByName("")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -40,7 +40,7 @@ func ExampleDev8() {
 
 func ExampleDev8_ReadStruct() {
 	// Open a connection, using I²C as an example:
-	bus, err := i2c.New(-1)
+	bus, err := i2c.OpenByName("")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/devices/bme280/bme280_test.go
+++ b/devices/bme280/bme280_test.go
@@ -140,7 +140,7 @@ func TestCalibrationInt(t *testing.T) {
 //
 
 func Example() {
-	bus, err := i2c.New(-1)
+	bus, err := i2c.OpenByName("")
 	if err != nil {
 		log.Fatalf("failed to open I²C: %v", err)
 	}

--- a/devices/ds248x/ds248x_test.go
+++ b/devices/ds248x/ds248x_test.go
@@ -32,7 +32,7 @@ func TestInit(t *testing.T) {
 
 func Example() {
 	// Open the I²C bus to which the DS248x is connected.
-	i2cBus, err := i2c.New(-1)
+	i2cBus, err := i2c.OpenByName("")
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -72,7 +72,7 @@ func TestRecordInit(t *testing.T) {
 	}
 	host.Init()
 
-	i2cReal, err := i2c.New(-1)
+	i2cReal, err := i2c.OpenByName("")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/devices/ssd1306/ssd1306_test.go
+++ b/devices/ssd1306/ssd1306_test.go
@@ -77,7 +77,7 @@ func TestDraw1D(t *testing.T) {
 //
 
 func Example() {
-	bus, err := i2c.New(-1)
+	bus, err := i2c.OpenByName("")
 	if err != nil {
 		log.Fatalf("failed to open I²C: %v", err)
 	}

--- a/experimental/driverskeleton/driverskeleton_test.go
+++ b/experimental/driverskeleton/driverskeleton_test.go
@@ -19,7 +19,7 @@ func Example() {
 	if _, err := host.Init(); err != nil {
 		log.Fatalf("failed to initialize periph: %v", err)
 	}
-	bus, err := i2c.New(-1)
+	bus, err := i2c.OpenByName("")
 	if err != nil {
 		log.Fatalf("failed to open I²C: %v", err)
 	}

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -331,13 +331,19 @@ func (d *driverI2C) Init() (bool, error) {
 		if err != nil {
 			continue
 		}
-		if err := i2c.Register(fmt.Sprintf("I2C%d", bus), bus, func() (i2c.BusCloser, error) {
-			return NewI2C(bus)
-		}); err != nil {
+		name := fmt.Sprintf("/dev/i2c-%d", bus)
+		aliases := []string{fmt.Sprintf("I2C%d", bus)}
+		if err := i2c.Register(name, aliases, bus, opener(bus).Open); err != nil {
 			return true, err
 		}
 	}
 	return true, nil
+}
+
+type opener int
+
+func (o opener) Open() (i2c.BusCloser, error) {
+	return NewI2C(int(o))
 }
 
 func init() {


### PR DESCRIPTION
This is a breaking change.

This is closer to how gpio behaves yet different in practice because of the
different challenges.

spi will be updated later to behave the same. Add support for aliases, which is
very useful, and it permits the CLI tools to accept a free form string to
specify the bus name.

- Increase test coverage of i2c and i2ctest to 100%.
- Add i2c.Pins implementation to i2ctest.Playback.