### PR TITLE
spi: Rewrite similar to how i2c was refactored

### DIFF
--- a/cmd/apa102/main.go
+++ b/cmd/apa102/main.go
@@ -109,7 +109,7 @@ func showImage(display devices.Display, img image.Image, sleep time.Duration, lo
 
 func mainImpl() error {
 	verbose := flag.Bool("v", false, "verbose mode")
-	busNumber := flag.Int("b", -1, "SPI bus to use")
+	spiName := flag.String("spi", "", "SPI bus to use")
 
 	numLights := flag.Int("n", 150, "number of lights on the strip")
 	intensity := flag.Int("l", 127, "light intensity [1-255]")
@@ -139,7 +139,7 @@ func mainImpl() error {
 	}
 
 	// Open the display device.
-	bus, err := spi.New(*busNumber, 0)
+	bus, err := spi.OpenByName(*spiName)
 	if err != nil {
 		return err
 	}

--- a/cmd/bme280/main.go
+++ b/cmd/bme280/main.go
@@ -48,10 +48,9 @@ func read(e devices.Environmental, loop bool) error {
 }
 
 func mainImpl() error {
-	i2cID := flag.String("i", "", "I²C bus to use")
+	i2cID := flag.String("i2c", "", "I²C bus to use")
 	i2cADDR := flag.Uint("ia", 0, "I²C bus address to use")
-	spiID := flag.Int("s", -1, "SPI bus to use")
-	cs := flag.Int("cs", -1, "SPI chip select (CS) line to use")
+	spiID := flag.String("spi", "", "SPI bus to use")
 	sample1x := flag.Bool("s1", false, "sample at 1x")
 	sample2x := flag.Bool("s2", false, "sample at 2x")
 	sample4x := flag.Bool("s4", false, "sample at 4x")
@@ -105,9 +104,9 @@ func mainImpl() error {
 
 	var dev *bme280.Dev
 	var recorder i2ctest.Record
-	if *spiID != -1 && *cs != -1 {
+	if *spiID != "" {
 		// Spec calls for max 10Mhz. In practice so little data is used.
-		bus, err := spi.New(*spiID, *cs)
+		bus, err := spi.OpenByName(*spiID)
 		if err != nil {
 			return err
 		}

--- a/cmd/spi-list/main.go
+++ b/cmd/spi-list/main.go
@@ -8,7 +8,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"sort"
 
 	"periph.io/x/periph/conn/pins"
 	"periph.io/x/periph/conn/spi"
@@ -29,15 +28,9 @@ func mainImpl() error {
 	if _, err := host.Init(); err != nil {
 		return err
 	}
-	all := spi.All()
-	names := make([]string, 0, len(all))
-	for name := range all {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
-		fmt.Printf("%s:\n", name)
-		bus, err := all[name]()
+	for _, ref := range spi.All() {
+		fmt.Printf("%s:\n", ref)
+		bus, err := ref.Open()
 		if err != nil {
 			fmt.Printf("  Failed to open: %v\n", err)
 			continue
@@ -48,7 +41,9 @@ func mainImpl() error {
 			printPin("MISO", pins.MISO())
 			printPin("CS", pins.CS())
 		}
-		bus.Close()
+		if err := bus.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/ssd1306/main.go
+++ b/cmd/ssd1306/main.go
@@ -239,8 +239,7 @@ func patterns(s *ssd1306.Dev) error {
 
 func mainImpl() error {
 	i2cID := flag.String("i2c", "", "I²C bus to use")
-	spiID := flag.Int("spi", -1, "specify SPI bus to use")
-	csID := flag.Int("cs", 0, "specify SPI chip select (CS) to use")
+	spiID := flag.String("spi", "", "SPI bus to use")
 	speed := flag.Int("speed", 0, "specify SPI speed in Hz to use")
 	h := flag.Int("h", 64, "display height")
 	imgName := flag.String("i", "ballerine.gif", "image to load; try bunny.gif")
@@ -265,8 +264,8 @@ func mainImpl() error {
 
 	// Open the device on the right bus.
 	var s *ssd1306.Dev
-	if *spiID >= 0 {
-		bus, err := spi.New(*spiID, *csID)
+	if *spiID != "" {
+		bus, err := spi.OpenByName(*spiID)
 		if err != nil {
 			return err
 		}

--- a/conn/spi/spi.go
+++ b/conn/spi/spi.go
@@ -9,11 +9,15 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
+	"strconv"
 	"sync"
 
 	"periph.io/x/periph/conn"
 	"periph.io/x/periph/conn/gpio"
 )
+
+// Interfaces
 
 // Mode determines how communication is done. The bits can be OR'ed to change
 // the polarity and phase used for communication.
@@ -66,114 +70,252 @@ type Pins interface {
 	CS() gpio.PinOut
 }
 
-// All returns all the SPI buses available on this host.
-func All() map[string]Opener {
-	mu.Lock()
-	defer mu.Unlock()
-	out := make(map[string]Opener, len(byName))
-	for k, v := range byName {
-		out[k] = v
-	}
-	return out
+// Registry
+
+// Open opens an handle to a bus.
+type Opener func() (ConnCloser, error)
+
+// Ref references an SPI bus.
+//
+// It is returned by All() to enumerate all registered buses.
+type Ref struct {
+	// Name of the bus.
+	//
+	// It must not be a sole number. It must be unique across the host.
+	Name string
+	// Aliases are the alternative names that can be used to reference this bus.
+	Aliases []string
+	// Number of the bus or -1 if the bus doesn't have any "native" number.
+	//
+	// Buses provided by the CPU normally have a 0 based number. Buses provided
+	// via an addon (like over USB) generally are not numbered.
+	Number int
+	// Open is the factory to open an handle to this SPI bus.
+	Open Opener
 }
 
-// New returns an open handle to the bus and CS line.
+// OpenByNumber opens an SPI bus by its "bus number" and returns an handle to
+// it.
 //
-// Specify busNumber -1 to get the first available bus and its first CS line.
-// This is the recommended value.
-func New(busNumber, cs int) (ConnCloser, error) {
-	opener, err := find(busNumber, cs)
+// Specify busNumber -1 to get the first available bus. This is the recommended
+// default value unless an application knows the exact bus to use.
+//
+// "Bus number" is a generic concept that is highly dependent on the platform
+// and OS. On some platform, the first bus may have the number 0, 1 or as high
+// as 32766. Bus numbers are not necessarily continuous and may not start at 0.
+// It was observed that the bus number as reported by the OS may change across
+// OS revisions.
+//
+// When the SPI bus is provided by an off board plug and play bus like USB via
+// an FT232H USB device, there can be no associated number.
+func OpenByNumber(busNumber int) (ConnCloser, error) {
+	var r *Ref
+	var err error
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(byName) == 0 {
+			err = errors.New("spi: no bus found; did you forget to call Init()?")
+			return
+		}
+		if busNumber == -1 {
+			// Asking for the default bus.
+			r = defaultBus()
+			return
+		}
+		r = byNumber[busNumber]
+	}()
 	if err != nil {
 		return nil, err
 	}
-	return opener()
+	if r == nil {
+		return nil, fmt.Errorf("spi: unknown bus %d", busNumber)
+	}
+	return r.Open()
 }
 
-// Opener opens an SPI bus.
-type Opener func() (ConnCloser, error)
-
-// Register registers a SPI bus.
+// OpenByName opens an SPI bus by its name or an alias and returns an handle to
+// it.
 //
-// Registering the same bus name twice is an error.
-func Register(name string, busNumber, cs int, opener Opener) error {
+// Specify the empty string "" to get the first available bus. This is the
+// recommended default value unless an application knows the exact bus to use.
+//
+// Each bus can register multiple aliases, each leading to the same bus handle.
+func OpenByName(name string) (ConnCloser, error) {
+	var r *Ref
+	var err error
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+		if len(byName) == 0 {
+			err = errors.New("spi: no bus found; did you forget to call Init()?")
+			return
+		}
+		if len(name) == 0 {
+			// Asking for the default bus.
+			r = defaultBus()
+			return
+		}
+		// Try by name, by alias, by number.
+		if r = byName[name]; r == nil {
+			if r = byAlias[name]; r == nil {
+				if i, err2 := strconv.Atoi(name); err2 == nil {
+					r = byNumber[i]
+				}
+			}
+		}
+	}()
+	if err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, fmt.Errorf("spi: unknown bus %q", name)
+	}
+	return r.Open()
+}
+
+// All returns a copy of all the registered references to all know SPI buses
+// available on this host.
+//
+// The list is sorted by the bus name.
+func All() []*Ref {
+	var out refList
+	func() {
+		mu.Lock()
+		defer mu.Unlock()
+		out = make(refList, 0, len(byName))
+		for _, v := range byName {
+			r := &Ref{Name: v.Name, Aliases: make([]string, len(v.Aliases)), Number: v.Number, Open: v.Open}
+			copy(r.Aliases, v.Aliases)
+			out = append(out, r)
+		}
+	}()
+	sort.Sort(out)
+	return out
+}
+
+// Register registers an SPI bus.
+//
+// Registering the same bus name twice is an error, e.g. o.Name(). o.Number()
+// can be -1 to signify that the bus doesn't have an inherent "bus number". A
+// good example is a bus provided over a FT232H device connected on an USB bus.
+// In this case, the bus name should be created from the serial number of the
+// device for unique identification.
+func Register(name string, aliases []string, number int, o Opener) error {
+	if o == nil {
+		return errors.New("spi: nil Opener")
+	}
+	if number < -1 {
+		return errors.New("spi: invalid bus number")
+	}
 	if len(name) == 0 {
-		return errors.New("spi: trying to register an unamed bus")
+		return errors.New("spi: empty name")
 	}
-	if opener == nil {
-		return errors.New("spi: trying to register a nil opener")
+	if _, err := strconv.Atoi(name); err == nil {
+		return fmt.Errorf("spi: can't register an alias being only a number %q", name)
 	}
+	for _, alias := range aliases {
+		if len(alias) == 0 {
+			return errors.New("spi: empty alias")
+		}
+		if name == alias {
+			return errors.New("spi: alias of the same name than the bus itself")
+		}
+		if _, err := strconv.Atoi(alias); err == nil {
+			return fmt.Errorf("spi: can't register an alias being only a number %q", alias)
+		}
+	}
+
 	mu.Lock()
 	defer mu.Unlock()
 	if _, ok := byName[name]; ok {
-		return fmt.Errorf("spi: registering the same bus %s twice", name)
+		return fmt.Errorf("spi: registering the same bus %q twice", name)
 	}
-	if busNumber != -1 {
-		if _, ok := byNumber[busNumber]; !ok {
-			byNumber[busNumber] = map[int]Opener{}
+	if _, ok := byAlias[name]; ok {
+		return fmt.Errorf("spi: registering the same bus %q twice", name)
+	}
+	if number != -1 {
+		if _, ok := byNumber[number]; ok {
+			return fmt.Errorf("spi: registering the same bus %d twice", number)
 		}
-		if _, ok := byNumber[busNumber][cs]; ok {
-			return fmt.Errorf("spi: registering the same bus %d.%d twice", busNumber, cs)
+	}
+	for _, alias := range aliases {
+		if _, ok := byName[alias]; ok {
+			return fmt.Errorf("spi: registering the same bus %q twice", alias)
+		}
+		if _, ok := byAlias[alias]; ok {
+			return fmt.Errorf("spi: registering the same bus %q twice", alias)
 		}
 	}
 
-	byName[name] = opener
-	if busNumber != -1 {
-		byNumber[busNumber][cs] = opener
+	r := &Ref{Name: name, Aliases: make([]string, len(aliases)), Number: number, Open: o}
+	copy(r.Aliases, aliases)
+	byName[name] = r
+	if number != -1 {
+		byNumber[number] = r
+	}
+	for _, alias := range aliases {
+		byAlias[alias] = r
 	}
 	return nil
 }
 
 // Unregister removes a previously registered SPI bus.
 //
-// This can happen when a SPI bus is exposed via an USB device and the device is
-// unplugged.
-func Unregister(name string, busNumber int) error {
+// This can happen when an SPI bus is exposed via an USB device and the device
+// is unplugged.
+func Unregister(name string) error {
 	mu.Lock()
 	defer mu.Unlock()
-	_, ok := byName[name]
-	if !ok {
+	r := byName[name]
+	if r == nil {
 		return fmt.Errorf("spi: unknown bus name %q", name)
 	}
-	if _, ok := byNumber[busNumber]; !ok {
-		return fmt.Errorf("spi: unknown bus number %d", busNumber)
-	}
-
 	delete(byName, name)
-	delete(byNumber, busNumber)
+	delete(byNumber, r.Number)
+	for _, alias := range r.Aliases {
+		delete(byAlias, alias)
+	}
 	return nil
 }
 
 //
 
-func find(busNumber, cs int) (Opener, error) {
-	mu.Lock()
-	defer mu.Unlock()
+var (
+	mu     sync.Mutex
+	byName = map[string]*Ref{}
+	// Caches
+	byNumber = map[int]*Ref{}
+	byAlias  = map[string]*Ref{}
+)
+
+func defaultBus() *Ref {
+	var o *Ref
 	if len(byNumber) == 0 {
-		return nil, errors.New("no SPI bus found; did you forget to call Init()?")
-	}
-	if busNumber == -1 {
-		busNumber = int((^uint(0)) >> 1)
-		for n := range byNumber {
-			if busNumber > n {
-				busNumber = n
+		// Fallback to use byName using a lexical sort.
+		name := ""
+		for n, o2 := range byName {
+			if len(name) == 0 || n < name {
+				o = o2
+				name = n
 			}
 		}
+		return o
 	}
-	bus, ok := byNumber[busNumber]
-	if !ok {
-		return nil, fmt.Errorf("spi: no bus %d found", busNumber)
+	busNumber := int((^uint(0)) >> 1)
+	for n, o2 := range byNumber {
+		if busNumber > n {
+			busNumber = n
+			o = o2
+		}
 	}
-	opener, ok := bus[cs]
-	if !ok {
-		return nil, fmt.Errorf("spi: no bus %d.%d found", busNumber, cs)
-	}
-	return opener, nil
+	return o
 }
 
-var (
-	mu       sync.Mutex
-	byName   = map[string]Opener{}
-	byNumber = map[int]map[int]Opener{}
-)
+type refList []*Ref
+
+func (r refList) Len() int           { return len(r) }
+func (r refList) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+func (r refList) Less(i, j int) bool { return r[i].Name < r[j].Name }
 
 var _ conn.Conn = Conn(nil)

--- a/conn/spi/spi_test.go
+++ b/conn/spi/spi_test.go
@@ -6,121 +6,267 @@ package spi
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 	"testing"
 
 	"periph.io/x/periph/conn"
 )
 
 func ExampleAll() {
+	// Enumerate all SPI buses available and the corresponding pins.
 	fmt.Print("SPI buses available:\n")
-	for name := range All() {
-		fmt.Printf("- %s\n", name)
-	}
-}
+	for _, ref := range All() {
+		fmt.Printf("- %s\n", ref.Name)
+		if ref.Number != -1 {
+			fmt.Printf("  %d\n", ref.Number)
+		}
+		if len(ref.Aliases) != 0 {
+			fmt.Printf("  %s\n", strings.Join(ref.Aliases, " "))
+		}
 
-func Example() {
-	// Find a specific device on all available SPI buses:
-	for _, opener := range All() {
-		bus, err := opener()
+		b, err := ref.Open()
 		if err != nil {
-			log.Fatal(err)
+			fmt.Printf("  Failed to open: %v", err)
 		}
-		w := []byte("command to device")
-		r := make([]byte, 16)
-		if err := bus.Tx(w, r); err != nil {
-			log.Fatal(err)
+		if p, ok := b.(Pins); ok {
+			fmt.Printf("  CLK : %s", p.CLK())
+			fmt.Printf("  MOSI: %s", p.MOSI())
+			fmt.Printf("  MISO: %s", p.MISO())
+			fmt.Printf("  CS  : %s", p.CS())
 		}
-		// Handle 'r'.
-		bus.Close()
+		if err := b.Close(); err != nil {
+			fmt.Printf("  Failed to close: %v", err)
+		}
 	}
 }
 
-func TestInvalid(t *testing.T) {
-	defer reset()
-	if _, err := New(-1, -1); err == nil {
-		t.FailNow()
+func ExampleOpenByName() {
+	// On linux, the following calls will likely open the same bus.
+	OpenByName("/dev/spidev1.0")
+	OpenByName("SPI1.0")
+	OpenByName("1")
+
+	// How a command line tool may let the user choose an I²C, yet default to the
+	// first bus known.
+	name := flag.String("spi", "", "SPI bus to use")
+	flag.Parse()
+	b, err := OpenByName(*name)
+	if err != nil {
+		log.Fatal(err)
 	}
+	defer b.Close()
+	// Use b...
+	b.Tx([]byte("cmd"), nil)
 }
 
-func TestAll(t *testing.T) {
-	defer reset()
-	if len(All()) != 0 {
-		t.FailNow()
-	}
-	if err := Register("a", 0, 0, op); err != nil {
-		t.Fatal(err)
-	}
-	if len(All()) != 1 {
-		t.FailNow()
-	}
-	if b, err := New(0, 0); b == nil || err != nil {
-		t.Fatal(b, err)
-	}
+func ExampleOpenByNumber() {
+	// Open bus the bus number 1.
+	OpenByNumber(1)
+	// Open the first bus known.
+	OpenByNumber(-1)
 }
 
-func TestRegister_fail(t *testing.T) {
-	if err := Register("", 0, 0, op); err == nil {
-		t.FailNow()
+func ExamplePins() {
+	b, err := OpenByName("")
+	if err != nil {
+		log.Fatal(err)
 	}
-	if err := Register("a", 0, 0, nil); err == nil {
-		t.FailNow()
-	}
-}
+	defer b.Close()
 
-func TestUnregister_fail(t *testing.T) {
-	if Unregister("", -1) == nil {
-		t.FailNow()
-	}
-	if err := Register("a", 0, 0, op); err != nil {
-		t.Fatal(err)
-	}
-	if Unregister("a", 1) == nil {
-		t.FailNow()
+	// Prints out the gpio pin used.
+	if p, ok := b.(Pins); ok {
+		fmt.Printf("  CLK : %s", p.CLK())
+		fmt.Printf("  MOSI: %s", p.MOSI())
+		fmt.Printf("  MISO: %s", p.MISO())
+		fmt.Printf("  CS  : %s", p.CS())
 	}
 }
 
 //
 
-type basicSPI struct {
+func TestOpenByNumber(t *testing.T) {
+	defer reset()
+	if _, err := OpenByNumber(-1); err == nil {
+		t.Fatal("no bus registered")
+	}
+
+	if err := Register("a", nil, 42, fakeBuser); err != nil {
+		t.Fatal(err)
+	}
+	if v, err := OpenByNumber(-1); err != nil || v == nil {
+		t.Fatal(v, err)
+	}
+	if v, err := OpenByNumber(42); err != nil || v == nil {
+		t.Fatal(v, err)
+	}
+	if v, err := OpenByNumber(1); err == nil || v != nil {
+		t.Fatal(v, err)
+	}
 }
 
-func (b *basicSPI) String() string {
-	return "basicSPI"
+func TestOpenByName(t *testing.T) {
+	defer reset()
+	if _, err := OpenByName(""); err == nil {
+		t.Fatal("no bus registered")
+	}
+	if err := Register("a", []string{"x"}, 1, fakeBuser); err != nil {
+		t.Fatal(err)
+	}
+	if o, err := OpenByName(""); o == nil || err != nil {
+		t.Fatal(o, err)
+	}
+	if o, err := OpenByName("1"); o == nil || err != nil {
+		t.Fatal(o, err)
+	}
+	if o, err := OpenByName("x"); o == nil || err != nil {
+		t.Fatal(o, err)
+	}
+	if o, err := OpenByName("y"); o != nil || err == nil {
+		t.Fatal(o, err)
+	}
 }
 
-func (b *basicSPI) Close() error {
+func TestDefault_NoNumber(t *testing.T) {
+	defer reset()
+	if err := Register("a", nil, -1, fakeBuser); err != nil {
+		t.Fatal(err)
+	}
+	if o, err := OpenByName(""); o == nil || err != nil {
+		t.Fatal(o, err)
+	}
+}
+
+func TestAll(t *testing.T) {
+	defer reset()
+	if a := All(); len(a) != 0 {
+		t.Fatal(a)
+	}
+	if err := Register("a", nil, 1, fakeBuser); err != nil {
+		t.Fatal(err)
+	}
+	if err := Register("b", nil, 2, fakeBuser); err != nil {
+		t.Fatal(err)
+	}
+	if a := All(); len(a) != 2 {
+		t.Fatal(a)
+	}
+}
+
+func TestRefList(t *testing.T) {
+	l := refList{&Ref{Name: "b"}, &Ref{Name: "a"}}
+	sort.Sort(l)
+	if l[0].Name != "a" || l[1].Name != "b" {
+		t.Fatal(l)
+	}
+}
+
+func TestRegister(t *testing.T) {
+	defer reset()
+	if err := Register("a", []string{"b"}, 42, fakeBuser); err != nil {
+		t.Fatal(err)
+	}
+	if Register("a", nil, -1, fakeBuser) == nil {
+		t.Fatal("same bus name")
+	}
+	if Register("b", nil, -1, fakeBuser) == nil {
+		t.Fatal("same bus alias name")
+	}
+	if Register("c", nil, 42, fakeBuser) == nil {
+		t.Fatal("same bus number")
+	}
+	if Register("c", []string{"a"}, -1, fakeBuser) == nil {
+		t.Fatal("same bus alias")
+	}
+	if Register("c", []string{"b"}, -1, fakeBuser) == nil {
+		t.Fatal("same bus alias")
+	}
+}
+
+func TestRegister_fail(t *testing.T) {
+	defer reset()
+	if Register("a", nil, -1, nil) == nil {
+		t.Fatal("missing Opener")
+	}
+	if Register("a", nil, -2, fakeBuser) == nil {
+		t.Fatal("bad bus number")
+	}
+	if Register("", nil, 42, fakeBuser) == nil {
+		t.Fatal("missing name")
+	}
+	if Register("1", nil, 42, fakeBuser) == nil {
+		t.Fatal("numeric name")
+	}
+	if Register("a", []string{"a"}, 0, fakeBuser) == nil {
+		t.Fatal("\"a\" is already registered")
+	}
+	if Register("a", []string{""}, 0, fakeBuser) == nil {
+		t.Fatal("empty alias")
+	}
+	if Register("a", []string{"1"}, 0, fakeBuser) == nil {
+		t.Fatal("numeric alias")
+	}
+	if a := All(); len(a) != 0 {
+		t.Fatal(a)
+	}
+}
+
+func TestUnregister(t *testing.T) {
+	defer reset()
+	if Unregister("") == nil {
+		t.Fatal("unregister empty")
+	}
+	if Unregister("a") == nil {
+		t.Fatal("unregister non-existing")
+	}
+	if err := Register("a", []string{"b"}, 0, fakeBuser); err != nil {
+		t.Fatal(err)
+	}
+	if err := Unregister("a"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+//
+
+func fakeBuser() (ConnCloser, error) {
+	return &fakeBus{}, nil
+}
+
+type fakeBus struct {
+}
+
+func (f *fakeBus) String() string {
+	return "fake"
+}
+
+func (f *fakeBus) Close() error {
 	return errors.New("not implemented")
 }
 
-func (b *basicSPI) Tx(w, r []byte) error {
+func (f *fakeBus) Tx(w, r []byte) error {
 	return errors.New("not implemented")
 }
 
-func (b *basicSPI) Write(w []byte) (int, error) {
-	return 0, errors.New("not implemented")
-}
-
-func (b *basicSPI) Duplex() conn.Duplex {
+func (f *fakeBus) Duplex() conn.Duplex {
 	return conn.DuplexUnknown
 }
 
-func (b *basicSPI) Speed(hz int64) error {
+func (f *fakeBus) Speed(hz int64) error {
 	return errors.New("not implemented")
 }
 
-func (b *basicSPI) Configure(mode Mode, bits int) error {
+func (f *fakeBus) Configure(mode Mode, bits int) error {
 	return errors.New("not implemented")
-}
-
-func op() (ConnCloser, error) {
-	return &basicSPI{}, nil
 }
 
 func reset() {
 	mu.Lock()
 	defer mu.Unlock()
-	byNumber = map[int]map[int]Opener{}
-	byName = map[string]Opener{}
+	byName = map[string]*Ref{}
+	byNumber = map[int]*Ref{}
+	byAlias = map[string]*Ref{}
 }

--- a/conn/spi/spismoketest/spismoketest.go
+++ b/conn/spi/spismoketest/spismoketest.go
@@ -38,14 +38,13 @@ func (s *SmokeTest) Description() string {
 // Run implements the SmokeTest interface.
 func (s *SmokeTest) Run(args []string) error {
 	f := flag.NewFlagSet("spi", flag.ExitOnError)
-	busNum := f.Int("bus", -1, "bus number, -1 for lowest numbered bus")
-	csNum := f.Int("cs", 0, "chip select number")
+	bus := f.String("spi", "", "SPI bus to use")
 	wp := f.String("wp", "", "gpio pin for EEPROM write-protect")
 	seed := f.Int64("seed", 0, "random number seed, default is to use the time")
 	f.Parse(args)
 
 	// Open the bus.
-	spiDev, err := spi.New(*busNum, *csNum)
+	spiDev, err := spi.OpenByName(*bus)
 	if err != nil {
 		return fmt.Errorf("spi-smoke: opening SPI: %v", err)
 	}

--- a/conn/spi/spitest/spitest_test.go
+++ b/conn/spi/spitest/spitest_test.go
@@ -5,27 +5,181 @@
 package spitest
 
 import (
+	"bytes"
 	"testing"
 
+	"periph.io/x/periph/conn"
 	"periph.io/x/periph/conn/conntest"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpiotest"
 )
 
-func TestBasic(t *testing.T) {
+func TestRecordRaw(t *testing.T) {
+	b := bytes.Buffer{}
+	r := NewRecordRaw(&b)
+	if err := r.Speed(-100); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Configure(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRecord_empty(t *testing.T) {
+	r := Record{}
+	if s := r.String(); s != "record" {
+		t.Fatal(s)
+	}
+	if err := r.Speed(-100); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Configure(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if r.Tx(nil, []byte{'a'}) == nil {
+		t.Fatal("Bus is nil")
+	}
+	if s := r.CLK(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if s := r.MOSI(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if s := r.MISO(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if s := r.CS(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if d := r.Duplex(); d != conn.DuplexUnknown {
+		t.Fatal(d)
+	}
+}
+
+func TestRecord_empty_tx(t *testing.T) {
+	r := Record{}
+	if err := r.Tx(nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Ops) != 1 {
+		t.Fatal(r.Ops)
+	}
+	if err := r.Tx([]byte{'a', 'b'}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Ops) != 2 {
+		t.Fatal(r.Ops)
+	}
+	if r.Tx([]byte{'a', 'b'}, []byte{'d'}) == nil {
+		t.Fatal("Bus is nil")
+	}
+	if len(r.Ops) != 2 {
+		t.Fatal(r.Ops)
+	}
+}
+
+func TestPlayback(t *testing.T) {
 	p := Playback{}
-	p.Ops = []conntest.IO{
-		{
-			Write: []byte{10},
-			Read:  []byte{12},
+	if s := p.String(); s != "playback" {
+		t.Fatal(s)
+	}
+	if err := p.Speed(-100); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Configure(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPlayback_tx(t *testing.T) {
+	p := Playback{
+		Playback: conntest.Playback{
+			Ops: []conntest.IO{
+				{
+					Write: []byte{10},
+					Read:  []byte{12},
+				},
+			},
 		},
 	}
-	r := make([]byte, 1)
-	if err := p.Tx([]byte{10}, r); err != nil {
+	if p.Tx(nil, nil) == nil {
+		t.Fatal("missing read and write")
+	}
+	if p.Close() == nil {
+		t.Fatal("Ops is not empty")
+	}
+	v := [1]byte{}
+	if p.Tx([]byte{10}, make([]byte, 2)) == nil {
+		t.Fatal("invalid read size")
+	}
+	if err := p.Tx([]byte{10}, v[:]); err != nil {
 		t.Fatal(err)
 	}
-	if r[0] != 12 {
-		t.Fail()
+	if v[0] != 12 {
+		t.Fatalf("expected 12, got %v", v)
 	}
-	if err := p.Speed(0); err != nil {
+	if err := p.Tx([]byte{10}, v[:]); err == nil {
+		t.Fatal("Playback.Ops is empty")
+	}
+	if err := p.Close(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestRecord_Playback(t *testing.T) {
+	r := Record{
+		Conn: &Playback{
+			Playback: conntest.Playback{
+				Ops: []conntest.IO{
+					{
+						Write: []byte{10},
+						Read:  []byte{12},
+					},
+				},
+				D: conn.Full,
+			},
+			CLKPin:  &gpiotest.Pin{N: "CLK"},
+			MOSIPin: &gpiotest.Pin{N: "MOSI"},
+			MISOPin: &gpiotest.Pin{N: "MISO"},
+			CSPin:   &gpiotest.Pin{N: "CS"},
+		},
+	}
+	if err := r.Speed(-100); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Configure(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if n := r.CLK().Name(); n != "CLK" {
+		t.Fatal(n)
+	}
+	if n := r.MOSI().Name(); n != "MOSI" {
+		t.Fatal(n)
+	}
+	if n := r.MISO().Name(); n != "MISO" {
+		t.Fatal(n)
+	}
+	if n := r.CS().Name(); n != "CS" {
+		t.Fatal(n)
+	}
+	if d := r.Duplex(); d != conn.Full {
+		t.Fatal(d)
+	}
+
+	v := [1]byte{}
+	if err := r.Tx([]byte{10}, v[:]); err != nil {
+		t.Fatal(err)
+	}
+	if v[0] != 12 {
+		t.Fatalf("expected 12, got %v", v)
+	}
+	if r.Tx([]byte{10}, v[:]) == nil {
+		t.Fatal("Playback.Ops is empty")
 	}
 }

--- a/devices/apa102/apa102_test.go
+++ b/devices/apa102/apa102_test.go
@@ -509,7 +509,7 @@ func TestDrawRGBA(t *testing.T) {
 //
 
 func Example() {
-	bus, err := spi.New(-1, -1)
+	bus, err := spi.OpenByName("")
 	if err != nil {
 		log.Fatalf("failed to open SPI: %v", err)
 	}

--- a/host/sysfs/i2c.go
+++ b/host/sysfs/i2c.go
@@ -333,16 +333,16 @@ func (d *driverI2C) Init() (bool, error) {
 		}
 		name := fmt.Sprintf("/dev/i2c-%d", bus)
 		aliases := []string{fmt.Sprintf("I2C%d", bus)}
-		if err := i2c.Register(name, aliases, bus, opener(bus).Open); err != nil {
+		if err := i2c.Register(name, aliases, bus, openerI2C(bus).Open); err != nil {
 			return true, err
 		}
 	}
 	return true, nil
 }
 
-type opener int
+type openerI2C int
 
-func (o opener) Open() (i2c.BusCloser, error) {
+func (o openerI2C) Open() (i2c.BusCloser, error) {
 	return NewI2C(int(o))
 }
 


### PR DESCRIPTION
Because of the way the SPI bus is exposed via sysfs, do not use the same pattern
as i2c. This may change as more OSes are supported.

Increase test coverage for spi and spitest to 100%.