### PR TITLE
spi: Update spi.Conn to separate app and device configuration.

### DIFF
--- a/conn/spi/spi.go
+++ b/conn/spi/spi.go
@@ -12,8 +12,6 @@ import (
 	"periph.io/x/periph/conn/gpio"
 )
 
-// Interfaces
-
 // Mode determines how communication is done. The bits can be OR'ed to change
 // the polarity and phase used for communication.
 //
@@ -36,10 +34,14 @@ const (
 // io.Reader.
 type Conn interface {
 	conn.Conn
-	// Speed changes the bus speed.
-	Speed(hz int64) error
-	// Configure changes the communication parameters of the bus.
-	Configure(mode Mode, bits int) error
+	// DevParams sets the communication parameters of the connection for use by a
+	// device.
+	//
+	// The device driver calls this function exactly once. It must specify the
+	// maximum rated speed by the device's spec. The lowest speed between the bus
+	// speed and the device speed is selected. Use 0 for maxHz if there is no
+	// known maximum value for this device.
+	DevParams(maxHz int64, mode Mode, bits int) error
 }
 
 // ConnCloser is a SPI bus that can be closed.
@@ -48,12 +50,22 @@ type Conn interface {
 type ConnCloser interface {
 	io.Closer
 	Conn
+	// Speed sets the maximum bus speed.
+	//
+	// It lets an application use a device at a lower speed than the maximum
+	// speed as rated by the device driver. This is useful for example when the
+	// wires are long or the connection is of poor quality.
+	//
+	// This function can be called multiple times and resets the previous value.
+	// 0 is not a value value for maxHz. The lowest speed between the bus speed
+	// and the device speed is selected.
+	Speed(maxHz int64) error
 }
 
 // Pins defines the pins that a SPI bus interconnect is using on the host.
 //
-// It is expected that a implementer of Conn also implement Pins but this is
-// not a requirement.
+// It is expected that a implementer of ConnCloser or Conn also implement Pins
+// but this is not a requirement.
 type Pins interface {
 	// CLK returns the SCK (clock) pin.
 	CLK() gpio.PinOut
@@ -64,5 +76,3 @@ type Pins interface {
 	// CS returns the CSN (chip select) pin.
 	CS() gpio.PinOut
 }
-
-var _ conn.Conn = Conn(nil)

--- a/conn/spi/spireg/spireg_test.go
+++ b/conn/spi/spireg/spireg_test.go
@@ -213,11 +213,11 @@ func (f *fakeBus) Duplex() conn.Duplex {
 	return conn.DuplexUnknown
 }
 
-func (f *fakeBus) Speed(hz int64) error {
+func (f *fakeBus) Speed(maxHz int64) error {
 	return errors.New("not implemented")
 }
 
-func (f *fakeBus) Configure(mode spi.Mode, bits int) error {
+func (f *fakeBus) DevParams(maxHz int64, mode spi.Mode, bits int) error {
 	return errors.New("not implemented")
 }
 

--- a/conn/spi/spismoketest/spismoketest.go
+++ b/conn/spi/spismoketest/spismoketest.go
@@ -53,11 +53,8 @@ func (s *SmokeTest) Run(args []string) error {
 	defer spiDev.Close()
 
 	// Set SPI parameters.
-	if err := spiDev.Configure(spi.Mode0, 8); err != nil {
+	if err := spiDev.DevParams(4000000, spi.Mode0, 8); err != nil {
 		return fmt.Errorf("spi-smoke: cannot set mode, %v", err)
-	}
-	if err := spiDev.Speed(4 * 1000 * 1000); err != nil {
-		return fmt.Errorf("spi-smoke: cannot set speed, %v", err)
 	}
 
 	// Open the WC pin.

--- a/conn/spi/spitest/spitest.go
+++ b/conn/spi/spitest/spitest.go
@@ -35,12 +35,12 @@ func (r *RecordRaw) Close() error {
 }
 
 // Speed is a no-op.
-func (r *RecordRaw) Speed(hz int64) error {
+func (r *RecordRaw) Speed(maxHz int64) error {
 	return nil
 }
 
-// Configure is a no-op.
-func (r *RecordRaw) Configure(mode spi.Mode, bits int) error {
+// DevParams is a no-op.
+func (r *RecordRaw) DevParams(maxHz int64, mode spi.Mode, bits int) error {
 	return nil
 }
 
@@ -49,7 +49,7 @@ func (r *RecordRaw) Configure(mode spi.Mode, bits int) error {
 // This can then be used to feed to Playback to do "replay" based unit tests.
 type Record struct {
 	sync.Mutex
-	Conn spi.Conn // Conn can be nil if only writes are being recorded.
+	Conn spi.ConnCloser // Conn can be nil if only writes are being recorded.
 	Ops  []conntest.IO
 }
 
@@ -88,18 +88,18 @@ func (r *Record) Duplex() conn.Duplex {
 	return conn.DuplexUnknown
 }
 
-// Speed implements spi.Conn.
-func (r *Record) Speed(hz int64) error {
+// Speed implements spi.ConnCloser.
+func (r *Record) Speed(maxHz int64) error {
 	if r.Conn != nil {
-		return r.Conn.Speed(hz)
+		return r.Conn.Speed(maxHz)
 	}
 	return nil
 }
 
-// Configure implements spi.Conn.
-func (r *Record) Configure(mode spi.Mode, bits int) error {
+// DevParams implements spi.Conn.
+func (r *Record) DevParams(maxHz int64, mode spi.Mode, bits int) error {
 	if r.Conn != nil {
-		return r.Conn.Configure(mode, bits)
+		return r.Conn.DevParams(maxHz, mode, bits)
 	}
 	return nil
 }
@@ -161,12 +161,12 @@ func (p *Playback) Close() error {
 }
 
 // Speed implements spi.Conn.
-func (p *Playback) Speed(hz int64) error {
+func (p *Playback) Speed(maxHz int64) error {
 	return nil
 }
 
-// Configure implements spi.Conn.
-func (p *Playback) Configure(mode spi.Mode, bits int) error {
+// DevParams implements spi.Conn.
+func (p *Playback) DevParams(maxHz int64, mode spi.Mode, bits int) error {
 	return nil
 }
 

--- a/conn/spi/spitest/spitest_test.go
+++ b/conn/spi/spitest/spitest_test.go
@@ -12,6 +12,7 @@ import (
 	"periph.io/x/periph/conn/conntest"
 	"periph.io/x/periph/conn/gpio"
 	"periph.io/x/periph/conn/gpio/gpiotest"
+	"periph.io/x/periph/conn/spi"
 )
 
 func TestRecordRaw(t *testing.T) {
@@ -20,7 +21,7 @@ func TestRecordRaw(t *testing.T) {
 	if err := r.Speed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Configure(0, 0); err != nil {
+	if err := r.DevParams(0, spi.Mode0, 0); err != nil {
 		t.Fatal(err)
 	}
 	if err := r.Close(); err != nil {
@@ -36,7 +37,7 @@ func TestRecord_empty(t *testing.T) {
 	if err := r.Speed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Configure(0, 0); err != nil {
+	if err := r.DevParams(0, spi.Mode0, 0); err != nil {
 		t.Fatal(err)
 	}
 	if r.Tx(nil, []byte{'a'}) == nil {
@@ -89,7 +90,7 @@ func TestPlayback(t *testing.T) {
 	if err := p.Speed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := p.Configure(0, 0); err != nil {
+	if err := p.DevParams(0, spi.Mode0, 0); err != nil {
 		t.Fatal(err)
 	}
 	if err := p.Close(); err != nil {
@@ -153,7 +154,7 @@ func TestRecord_Playback(t *testing.T) {
 	if err := r.Speed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.Configure(0, 0); err != nil {
+	if err := r.DevParams(0, spi.Mode0, 0); err != nil {
 		t.Fatal(err)
 	}
 	if n := r.CLK().Name(); n != "CLK" {

--- a/devices/apa102/apa102.go
+++ b/devices/apa102/apa102.go
@@ -283,7 +283,7 @@ func (d *Dev) Write(pixels []byte) (int, error) {
 // https://en.wikipedia.org/wiki/Flicker_fusion_threshold is a recommended
 // reading.
 func New(s spi.Conn, numLights int, intensity uint8, temperature uint16) (*Dev, error) {
-	if err := s.Configure(spi.Mode3, 8); err != nil {
+	if err := s.DevParams(20000000, spi.Mode3, 8); err != nil {
 		return nil, err
 	}
 	// End frames are needed to be able to push enough SPI clock signals due to

--- a/devices/apa102/apa102_test.go
+++ b/devices/apa102/apa102_test.go
@@ -336,9 +336,9 @@ func TestDevEmpty(t *testing.T) {
 	}
 }
 
-func TestConfigureFail(t *testing.T) {
+func TestDevParamsFail(t *testing.T) {
 	if d, err := New(&configFail{}, 150, 255, 6500); d != nil || err == nil {
-		t.Fatal("Configure() call have failed")
+		t.Fatal("DevParams() call have failed")
 	}
 }
 
@@ -682,7 +682,7 @@ type configFail struct {
 	spitest.Record
 }
 
-func (c *configFail) Configure(mode spi.Mode, bits int) error {
+func (c *configFail) DevParams(maxHz int64, mode spi.Mode, bits int) error {
 	return errors.New("injected error")
 }
 

--- a/devices/bme280/bme280.go
+++ b/devices/bme280/bme280.go
@@ -6,7 +6,7 @@
 //
 // Datasheet
 //
-// https://cdn-shop.adafruit.com/datasheets/BST-BME280_DS001-10.pdf
+// https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280_DS001-11.pdf
 package bme280
 
 import (
@@ -172,7 +172,7 @@ func NewI2C(b i2c.Bus, opts *Opts) (*Dev, error) {
 // device in the mail.
 func NewSPI(s spi.Conn, opts *Opts) (*Dev, error) {
 	// It works both in Mode0 and Mode3.
-	if err := s.Configure(spi.Mode3, 8); err != nil {
+	if err := s.DevParams(10000000, spi.Mode3, 8); err != nil {
 		return nil, err
 	}
 	d := &Dev{d: s, isSPI: true}

--- a/devices/ssd1306/ssd1306.go
+++ b/devices/ssd1306/ssd1306.go
@@ -89,9 +89,8 @@ type Dev struct {
 // connection is to connect RES and DC to ground, CS to 3.3v, SDA to MOSI, SCK
 // to SCLK.
 //
-// As per datasheet, maximum clock speed is 1/100ns = 10MHz.
 func NewSPI(s spi.Conn, w, h int, rotated bool) (*Dev, error) {
-	if err := s.Configure(spi.Mode3, 8); err != nil {
+	if err := s.DevParams(3300000, spi.Mode3, 8); err != nil {
 		return nil, err
 	}
 	return newDev(s, w, h, rotated)
@@ -101,10 +100,8 @@ func NewSPI(s spi.Conn, w, h int, rotated bool) (*Dev, error) {
 // controler.
 //
 // If rotated, turns the display by 180°
-//
-// As per datasheet, maximum clock speed is 1/2.5µs = 400KHz. It's worth
-// bumping up from default bus speed of 100KHz if possible.
 func NewI2C(i i2c.Bus, w, h int, rotated bool) (*Dev, error) {
+	// Maximum clock speed is 1/2.5µs = 400KHz.
 	return newDev(&i2c.Dev{Bus: i, Addr: 0x3C}, w, h, rotated)
 }
 


### PR DESCRIPTION
- Allow both app and device drive set max bus speed.
- Make DevParams callable only exactly once.
- sysfs: make SPI implement io.Reader.