### PR TITLE
spi: Refactor Conn and ConnCloser into Conn, Port and PortCloser

### DIFF
--- a/cmd/spi-io/main.go
+++ b/cmd/spi-io/main.go
@@ -127,15 +127,16 @@ func mainImpl() error {
 		return err
 	}
 	defer bus.Close()
-	if err = bus.DevParams(int64(*hz), m, *bits); err != nil {
+	c, err := bus.DevParams(int64(*hz), m, *bits)
+	if err != nil {
 		return err
 	}
 	if *verbose {
-		if p, ok := bus.(spi.Pins); ok {
+		if p, ok := c.(spi.Pins); ok {
 			log.Printf("Using pins CLK: %s  MOSI: %s  MISO:  %s", p.CLK(), p.MOSI(), p.MISO())
 		}
 	}
-	return runTx(bus, flag.Args())
+	return runTx(c, flag.Args())
 }
 
 func main() {

--- a/conn/spi/spireg/spireg.go
+++ b/conn/spi/spireg/spireg.go
@@ -18,7 +18,7 @@ import (
 // Opener opens an handle to a port.
 //
 // It is provided by the actual bus driver.
-type Opener func() (spi.ConnCloser, error)
+type Opener func() (spi.PortCloser, error)
 
 // Ref references a SPI port.
 //
@@ -58,7 +58,7 @@ type Ref struct {
 //
 // When the SPI port is provided by an off board plug and play bus like USB via
 // a FT232H USB device, there can be no associated number.
-func Open(name string) (spi.ConnCloser, error) {
+func Open(name string) (spi.PortCloser, error) {
 	var r *Ref
 	var err error
 	func() {

--- a/conn/spi/spireg/spireg_test.go
+++ b/conn/spi/spireg/spireg_test.go
@@ -60,8 +60,14 @@ func ExampleOpen() {
 		log.Fatal(err)
 	}
 	defer b.Close()
+
+	// Pass b to a device driver, or if using b directly, do:
+	c, err := b.DevParams(1000000, spi.Mode3, 8)
+	if err != nil {
+		log.Fatal(err)
+	}
 	// Use b...
-	b.Tx([]byte("cmd"), nil)
+	c.Tx([]byte("cmd"), nil)
 }
 
 //
@@ -196,7 +202,7 @@ func TestUnregister(t *testing.T) {
 
 //
 
-func fakeBuser() (spi.ConnCloser, error) {
+func fakeBuser() (spi.PortCloser, error) {
 	return &fakeBus{}, nil
 }
 
@@ -223,8 +229,8 @@ func (f *fakeBus) LimitSpeed(maxHz int64) error {
 	return errors.New("not implemented")
 }
 
-func (f *fakeBus) DevParams(maxHz int64, mode spi.Mode, bits int) error {
-	return errors.New("not implemented")
+func (f *fakeBus) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+	return f, errors.New("not implemented")
 }
 
 func (f *fakeBus) TxPackets(p []spi.Packet) error {

--- a/conn/spi/spismoketest/spismoketest.go
+++ b/conn/spi/spismoketest/spismoketest.go
@@ -57,7 +57,8 @@ func (s *SmokeTest) Run(args []string) error {
 	defer spiDev.Close()
 
 	// Set SPI parameters.
-	if err := spiDev.DevParams(4000000, spi.Mode0, 8); err != nil {
+	c, err := spiDev.DevParams(4000000, spi.Mode0, 8)
+	if err != nil {
 		return fmt.Errorf("error setting bus parameters: %v", err)
 	}
 
@@ -77,7 +78,7 @@ func (s *SmokeTest) Run(args []string) error {
 	log.Printf("%s: random number seed %d", s, *seed)
 
 	// Run the tests.
-	return s.eeprom(spiDev, wpPin)
+	return s.eeprom(c, wpPin)
 }
 
 // eeprom tests a 5080 8Kbit serial EEPROM attached to the SPI bus.

--- a/conn/spi/spitest/spitest_test.go
+++ b/conn/spi/spitest/spitest_test.go
@@ -23,10 +23,11 @@ func TestRecordRaw(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.DevParams(0, spi.Mode0, 0); err != nil {
+	c, err := r.DevParams(0, spi.Mode0, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.TxPackets(nil); err == nil {
+	if err := c.TxPackets(nil); err == nil {
 		t.Fatal("not yet implemented")
 	}
 	if err := r.Close(); err != nil {
@@ -42,29 +43,31 @@ func TestRecord_empty(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.DevParams(0, spi.Mode0, 0); err != nil {
+	c, err := r.DevParams(0, spi.Mode0, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if r.Tx(nil, []byte{'a'}) == nil {
+	if c.Tx(nil, []byte{'a'}) == nil {
 		t.Fatal("Bus is nil")
 	}
-	if err := r.TxPackets(nil); err == nil {
+	if err := c.TxPackets(nil); err == nil {
 		t.Fatal("not yet implemented")
 	}
-	if s := r.CLK(); s != gpio.INVALID {
-		t.Fatal(s)
-	}
-	if s := r.MOSI(); s != gpio.INVALID {
-		t.Fatal(s)
-	}
-	if s := r.MISO(); s != gpio.INVALID {
-		t.Fatal(s)
-	}
-	if s := r.CS(); s != gpio.INVALID {
-		t.Fatal(s)
-	}
-	if d := r.Duplex(); d != conn.DuplexUnknown {
+	if d := c.Duplex(); d != conn.DuplexUnknown {
 		t.Fatal(d)
+	}
+	p := c.(spi.Pins)
+	if s := p.CLK(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if s := p.MOSI(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if s := p.MISO(); s != gpio.INVALID {
+		t.Fatal(s)
+	}
+	if s := p.CS(); s != gpio.INVALID {
+		t.Fatal(s)
 	}
 	if err := r.Close(); err != nil {
 		t.Fatal(err)
@@ -73,19 +76,23 @@ func TestRecord_empty(t *testing.T) {
 
 func TestRecord_Tx_empty(t *testing.T) {
 	r := Record{}
-	if err := r.Tx(nil, nil); err != nil {
+	c, err := r.DevParams(0, spi.Mode0, 8)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := c.Tx(nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(r.Ops) != 1 {
 		t.Fatal(r.Ops)
 	}
-	if err := r.Tx([]byte{'a', 'b'}, nil); err != nil {
+	if err := c.Tx([]byte{'a', 'b'}, nil); err != nil {
 		t.Fatal(err)
 	}
 	if len(r.Ops) != 2 {
 		t.Fatal(r.Ops)
 	}
-	if r.Tx([]byte{'a', 'b'}, []byte{'d'}) == nil {
+	if c.Tx([]byte{'a', 'b'}, []byte{'d'}) == nil {
 		t.Fatal("Bus is nil")
 	}
 	if len(r.Ops) != 2 {
@@ -101,10 +108,11 @@ func TestPlayback(t *testing.T) {
 	if err := p.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := p.DevParams(0, spi.Mode0, 0); err != nil {
+	c, err := p.DevParams(0, spi.Mode0, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := p.TxPackets(nil); err == nil {
+	if err := c.TxPackets(nil); err == nil {
 		t.Fatal("not yet implemented")
 	}
 	if err := p.Close(); err != nil {
@@ -119,20 +127,28 @@ func TestPlayback_Tx_err(t *testing.T) {
 			DontPanic: true,
 		},
 	}
-	if p.Tx(nil, nil) == nil {
+	c, err := p.DevParams(0, spi.Mode0, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.Tx(nil, nil) == nil {
 		t.Fatal("missing read and write")
 	}
 	if p.Close() == nil {
 		t.Fatal("Ops is not empty")
 	}
-	if p.Tx([]byte{10}, make([]byte, 2)) == nil {
+	if c.Tx([]byte{10}, make([]byte, 2)) == nil {
 		t.Fatal("invalid read size")
 	}
 }
 
 func TestPlayback_Tx_empty(t *testing.T) {
 	p := Playback{Playback: conntest.Playback{DontPanic: true}}
-	if err := p.Tx([]byte{0}, []byte{0}); err == nil {
+	c, err := p.DevParams(0, spi.Mode0, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Tx([]byte{0}, []byte{0}); err == nil {
 		t.Fatal("Playback.Ops is empty")
 	}
 }
@@ -143,8 +159,12 @@ func TestPlayback_Tx(t *testing.T) {
 			Ops: []conntest.IO{{W: []byte{10}, R: []byte{12}}},
 		},
 	}
+	c, err := p.DevParams(0, spi.Mode0, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
 	v := [1]byte{}
-	if err := p.Tx([]byte{10}, v[:]); err != nil {
+	if err := c.Tx([]byte{10}, v[:]); err != nil {
 		t.Fatal(err)
 	}
 	if v[0] != 12 {
@@ -157,7 +177,7 @@ func TestPlayback_Tx(t *testing.T) {
 
 func TestRecord_Playback(t *testing.T) {
 	r := Record{
-		Conn: &Playback{
+		Port: &Playback{
 			Playback: conntest.Playback{
 				Ops:       []conntest.IO{{W: []byte{10}, R: []byte{12}}},
 				D:         conn.Full,
@@ -172,33 +192,35 @@ func TestRecord_Playback(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.DevParams(0, spi.Mode0, 0); err != nil {
+	c, err := r.DevParams(0, spi.Mode0, 8)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if n := r.CLK().Name(); n != "CLK" {
-		t.Fatal(n)
-	}
-	if n := r.MOSI().Name(); n != "MOSI" {
-		t.Fatal(n)
-	}
-	if n := r.MISO().Name(); n != "MISO" {
-		t.Fatal(n)
-	}
-	if n := r.CS().Name(); n != "CS" {
-		t.Fatal(n)
-	}
-	if d := r.Duplex(); d != conn.Full {
+	if d := c.Duplex(); d != conn.Full {
 		t.Fatal(d)
+	}
+	p := c.(spi.Pins)
+	if n := p.CLK().Name(); n != "CLK" {
+		t.Fatal(n)
+	}
+	if n := p.MOSI().Name(); n != "MOSI" {
+		t.Fatal(n)
+	}
+	if n := p.MISO().Name(); n != "MISO" {
+		t.Fatal(n)
+	}
+	if n := p.CS().Name(); n != "CS" {
+		t.Fatal(n)
 	}
 
 	v := [1]byte{}
-	if err := r.Tx([]byte{10}, v[:]); err != nil {
+	if err := c.Tx([]byte{10}, v[:]); err != nil {
 		t.Fatal(err)
 	}
 	if v[0] != 12 {
 		t.Fatalf("expected 12, got %v", v)
 	}
-	if r.Tx([]byte{10}, v[:]) == nil {
+	if c.Tx([]byte{10}, v[:]) == nil {
 		t.Fatal("Playback.Ops is empty")
 	}
 	if err := r.Close(); err != nil {
@@ -208,7 +230,7 @@ func TestRecord_Playback(t *testing.T) {
 
 func TestLog_Playback(t *testing.T) {
 	r := Log{
-		Conn: &Playback{
+		Port: &Playback{
 			Playback: conntest.Playback{
 				Ops:       []conntest.IO{{W: []byte{10}, R: []byte{12}}},
 				D:         conn.Full,
@@ -223,24 +245,25 @@ func TestLog_Playback(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	if err := r.DevParams(0, spi.Mode0, 0); err != nil {
+	c, err := r.DevParams(0, spi.Mode0, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := r.TxPackets(nil); err == nil {
+	if err := c.TxPackets(nil); err == nil {
 		t.Fatal("not yet implemented")
 	}
-	if d := r.Duplex(); d != conn.Full {
+	if d := c.Duplex(); d != conn.Full {
 		t.Fatal(d)
 	}
 
 	v := [1]byte{}
-	if err := r.Tx([]byte{10}, v[:]); err != nil {
+	if err := c.Tx([]byte{10}, v[:]); err != nil {
 		t.Fatal(err)
 	}
 	if v[0] != 12 {
 		t.Fatalf("expected 12, got %v", v)
 	}
-	if r.Tx([]byte{10}, v[:]) == nil {
+	if c.Tx([]byte{10}, v[:]) == nil {
 		t.Fatal("Playback.Ops is empty")
 	}
 	if err := r.Close(); err != nil {

--- a/devices/apa102/apa102.go
+++ b/devices/apa102/apa102.go
@@ -293,8 +293,9 @@ func (d *Dev) Halt() error {
 // As per APA102-C spec, the chip's max refresh rate is 400hz.
 // https://en.wikipedia.org/wiki/Flicker_fusion_threshold is a recommended
 // reading.
-func New(s spi.Conn, numLights int, intensity uint8, temperature uint16) (*Dev, error) {
-	if err := s.DevParams(20000000, spi.Mode3, 8); err != nil {
+func New(p spi.Port, numLights int, intensity uint8, temperature uint16) (*Dev, error) {
+	c, err := p.DevParams(20000000, spi.Mode3, 8)
+	if err != nil {
 		return nil, err
 	}
 	// End frames are needed to be able to push enough SPI clock signals due to
@@ -308,7 +309,7 @@ func New(s spi.Conn, numLights int, intensity uint8, temperature uint16) (*Dev, 
 	return &Dev{
 		Intensity:   intensity,
 		Temperature: temperature,
-		s:           s,
+		s:           c,
 		numLights:   numLights,
 		rawBuf:      buf,
 		pixels:      buf[4 : 4+4*numLights],

--- a/devices/apa102/apa102_test.go
+++ b/devices/apa102/apa102_test.go
@@ -703,8 +703,8 @@ type configFail struct {
 	spitest.Record
 }
 
-func (c *configFail) DevParams(maxHz int64, mode spi.Mode, bits int) error {
-	return errors.New("injected error")
+func (c *configFail) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+	return nil, errors.New("injected error")
 }
 
 func equalUint16(a, b []uint16) bool {

--- a/devices/bme280/bme280.go
+++ b/devices/bme280/bme280.go
@@ -176,12 +176,13 @@ func NewI2C(b i2c.Bus, opts *Opts) (*Dev, error) {
 //
 // BUG(maruel): This code was not tested yet, still waiting for a SPI enabled
 // device in the mail.
-func NewSPI(s spi.Conn, opts *Opts) (*Dev, error) {
+func NewSPI(p spi.Port, opts *Opts) (*Dev, error) {
 	// It works both in Mode0 and Mode3.
-	if err := s.DevParams(10000000, spi.Mode3, 8); err != nil {
+	c, err := p.DevParams(10000000, spi.Mode3, 8)
+	if err != nil {
 		return nil, err
 	}
-	d := &Dev{d: s, isSPI: true}
+	d := &Dev{d: c, isSPI: true}
 	if err := d.makeDev(opts); err != nil {
 		return nil, err
 	}

--- a/devices/bme280/bme280_test.go
+++ b/devices/bme280/bme280_test.go
@@ -545,6 +545,6 @@ type spiFail struct {
 	spitest.Playback
 }
 
-func (s *spiFail) DevParams(maxHz int64, mode spi.Mode, bits int) error {
-	return errors.New("failing")
+func (s *spiFail) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+	return nil, errors.New("failing")
 }

--- a/devices/bme280/bme280smoketest/bme280smoketest.go
+++ b/devices/bme280/bme280smoketest/bme280smoketest.go
@@ -67,7 +67,7 @@ func (s *SmokeTest) Run(args []string) (err error) {
 	}
 
 	i2cRecorder := i2ctest.Record{Bus: i2cBus}
-	spiRecorder := spitest.Record{Conn: spiBus}
+	spiRecorder := spitest.Record{Port: spiBus}
 	err = run(&i2cRecorder, &spiRecorder)
 	if len(i2cRecorder.Ops) != 0 {
 		fmt.Printf("I²C recorder Addr: 0x%02X\n", i2cRecorder.Ops[0].Addr)
@@ -119,7 +119,7 @@ func (s *SmokeTest) Run(args []string) (err error) {
 	return err
 }
 
-func run(i2cBus i2c.Bus, spiBus spi.ConnCloser) (err error) {
+func run(i2cBus i2c.Bus, spiBus spi.PortCloser) (err error) {
 	opts := &bme280.Opts{
 		Temperature: bme280.O16x,
 		Pressure:    bme280.O16x,

--- a/devices/lepton/lepton_test.go
+++ b/devices/lepton/lepton_test.go
@@ -370,7 +370,7 @@ type spiStream struct {
 	err    error
 }
 
-func (s *spiStream) DevParams(maxHz int64, mode spi.Mode, bits int) error {
+func (s *spiStream) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	if maxHz != 20000000 {
 		s.t.Fatal(maxHz)
 	}
@@ -380,7 +380,7 @@ func (s *spiStream) DevParams(maxHz int64, mode spi.Mode, bits int) error {
 	if bits != 8 {
 		s.t.Fatal(bits)
 	}
-	return s.err
+	return s, s.err
 }
 
 func (s *spiStream) Tx(w, r []byte) error {

--- a/devices/ssd1306/ssd1306.go
+++ b/devices/ssd1306/ssd1306.go
@@ -122,7 +122,7 @@ type Dev struct {
 // The RES (reset) pin can be used outside of this driver but is not supported
 // natively. In case of external reset via the RES pin, this device drive must
 // be reinstantiated.
-func NewSPI(s spi.Conn, dc gpio.PinOut, w, h int, rotated bool) (*Dev, error) {
+func NewSPI(p spi.Port, dc gpio.PinOut, w, h int, rotated bool) (*Dev, error) {
 	if dc == gpio.INVALID {
 		return nil, errors.New("ssd1306: use nil for dc to use 3-wire mode, do not use gpio.INVALID")
 	}
@@ -133,10 +133,11 @@ func NewSPI(s spi.Conn, dc gpio.PinOut, w, h int, rotated bool) (*Dev, error) {
 	} else if err := dc.Out(gpio.Low); err != nil {
 		return nil, err
 	}
-	if err := s.DevParams(3300000, spi.Mode0, bits); err != nil {
+	c, err := p.DevParams(3300000, spi.Mode0, bits)
+	if err != nil {
 		return nil, err
 	}
-	return newDev(s, w, h, rotated, true, dc)
+	return newDev(c, w, h, rotated, true, dc)
 }
 
 // NewI2C returns a Dev object that communicates over I²C to a SSD1306 display

--- a/devices/ssd1306/ssd1306_test.go
+++ b/devices/ssd1306/ssd1306_test.go
@@ -575,8 +575,8 @@ type configFail struct {
 	spitest.Record
 }
 
-func (c *configFail) DevParams(maxHz int64, mode spi.Mode, bits int) error {
-	return errors.New("injected error")
+func (c *configFail) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+	return nil, errors.New("injected error")
 }
 
 type failPin struct {

--- a/devices/ssd1306/ssd1306smoketest/ssd1306smoketest.go
+++ b/devices/ssd1306/ssd1306smoketest/ssd1306smoketest.go
@@ -97,7 +97,7 @@ func (s *SmokeTest) Run(args []string) (err error) {
 	}
 
 	i2cRecorder := i2ctest.Record{Bus: i2cBus}
-	spiRecorder := spitest.Record{Conn: spiBus}
+	spiRecorder := spitest.Record{Port: spiBus}
 	err = s.run(&i2cRecorder, &spiRecorder, dc, *w, *h, *rotated)
 	if len(i2cRecorder.Ops) != 0 {
 		fmt.Printf("I²C recorder Addr: 0x%02X\n", i2cRecorder.Ops[0].Addr)
@@ -149,7 +149,7 @@ func (s *SmokeTest) Run(args []string) (err error) {
 	return err
 }
 
-func (s *SmokeTest) run(i2cBus i2c.Bus, spiBus spi.ConnCloser, dc gpio.PinOut, w, h int, rotated bool) (err error) {
+func (s *SmokeTest) run(i2cBus i2c.Bus, spiBus spi.PortCloser, dc gpio.PinOut, w, h int, rotated bool) (err error) {
 	s.timings = make([]time.Duration, 2)
 	start := time.Now()
 	i2cDev, err2 := ssd1306.NewI2C(i2cBus, w, h, rotated)

--- a/host/sysfs/spi_test.go
+++ b/host/sysfs/spi_test.go
@@ -5,6 +5,7 @@
 package sysfs
 
 import (
+	"io"
 	"log"
 	"testing"
 
@@ -20,7 +21,12 @@ func ExampleNewSPI() {
 	}
 	defer b.Close()
 
-	if err := b.Tx([]byte{0x10}, nil); err != nil {
+	c, err := b.DevParams(1000000, spi.Mode3, 8)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := c.Tx([]byte{0x10}, nil); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -38,61 +44,62 @@ func TestNewSPI(t *testing.T) {
 
 func TestSPI_IO(t *testing.T) {
 	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	if err := bus.DevParams(1, spi.Mode3, 8); err != nil {
+	c, err := bus.DevParams(1, spi.Mode3, 8)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := bus.Tx(nil, nil); err == nil {
+	if err := c.Tx(nil, nil); err == nil {
 		t.Fatal("nil values")
 	}
-	if err := bus.Tx([]byte{0}, nil); err != nil {
+	if err := c.Tx([]byte{0}, nil); err != nil {
 		t.Fatal(err)
 	}
-	if err := bus.Tx(nil, []byte{0}); err != nil {
+	if err := c.Tx(nil, []byte{0}); err != nil {
 		t.Fatal(err)
 	}
-	if err := bus.Tx([]byte{0}, []byte{0}); err != nil {
+	if err := c.Tx([]byte{0}, []byte{0}); err != nil {
 		t.Fatal(err)
 	}
-	if err := bus.Tx([]byte{0}, []byte{0, 1}); err == nil {
+	if err := c.Tx([]byte{0}, []byte{0, 1}); err == nil {
 		t.Fatal("different lengths")
 	}
-	if err := bus.Tx(make([]byte, spiBufSize+1), nil); err == nil {
+	if err := c.Tx(make([]byte, spiBufSize+1), nil); err == nil {
 		t.Fatal("buffer too long")
 	}
-	if err := bus.TxPackets(nil); err == nil {
+	if err := c.TxPackets(nil); err == nil {
 		t.Fatal("empty TxPackets")
 	}
 	p := []spi.Packet{
 		{W: make([]byte, spiBufSize+1)},
 	}
-	if err := bus.TxPackets(p); err == nil {
+	if err := c.TxPackets(p); err == nil {
 		t.Fatal("buffer too long")
 	}
 	p = []spi.Packet{
 		{W: []byte{0}, R: []byte{0, 1}},
 	}
-	if err := bus.TxPackets(p); err == nil {
+	if err := c.TxPackets(p); err == nil {
 		t.Fatal("different lengths")
 	}
 	p = []spi.Packet{
 		{W: []byte{0}, R: []byte{0}},
 	}
-	if err := bus.TxPackets(p); err != nil {
+	if err := c.TxPackets(p); err != nil {
 		t.Fatal(err)
 	}
-	if n, err := bus.Read(nil); n != 0 || err == nil {
+	if n, err := c.(io.Reader).Read(nil); n != 0 || err == nil {
 		t.Fatal(n, err)
 	}
-	if n, err := bus.Read([]byte{0}); n != 1 || err != nil {
+	if n, err := c.(io.Reader).Read([]byte{0}); n != 1 || err != nil {
 		t.Fatal(n, err)
 	}
-	if n, err := bus.Write(nil); n != 0 || err == nil {
+	if n, err := c.(io.Writer).Write(nil); n != 0 || err == nil {
 		t.Fatal(n, err)
 	}
-	if n, err := bus.Write([]byte{0}); n != 1 || err != nil {
+	if n, err := c.(io.Writer).Write([]byte{0}); n != 1 || err != nil {
 		t.Fatal(n, err)
 	}
-	if d := bus.Duplex(); d != conn.Full {
+	if d := c.Duplex(); d != conn.Full {
 		t.Fatal(d)
 	}
 	if err := bus.Close(); err != nil {
@@ -102,10 +109,10 @@ func TestSPI_IO(t *testing.T) {
 
 func TestSPI_IO_not_initialized(t *testing.T) {
 	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	if err := bus.Tx([]byte{0}, []byte{0}); err == nil {
+	if _, err := bus.txInternal([]byte{0}, []byte{0}); err == nil {
 		t.Fatal("not initialized")
 	}
-	if err := bus.TxPackets([]spi.Packet{{W: []byte{0}}}); err == nil {
+	if bus.txPackets([]spi.Packet{{W: []byte{0}}}) == nil {
 		t.Fatal("not initialized")
 	}
 }
@@ -145,31 +152,32 @@ func TestSPI_other(t *testing.T) {
 func TestSPI_DevParams(t *testing.T) {
 	// Create a fake SPI to test methods.
 	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	if err := bus.DevParams(-1, spi.Mode0, 8); err == nil {
+	if _, err := bus.DevParams(-1, spi.Mode0, 8); err == nil {
 		t.Fatal("invalid speed")
 	}
-	if err := bus.DevParams(1, -1, 8); err == nil {
+	if _, err := bus.DevParams(1, -1, 8); err == nil {
 		t.Fatal("invalid mode")
 	}
-	if err := bus.DevParams(1, spi.Mode0, 0); err == nil {
+	if _, err := bus.DevParams(1, spi.Mode0, 0); err == nil {
 		t.Fatal("invalid bit")
 	}
-	if err := bus.DevParams(1, spi.Mode0|spi.HalfDuplex|spi.NoCS|spi.LSBFirst, 8); err != nil {
+	c, err := bus.DevParams(1, spi.Mode0|spi.HalfDuplex|spi.NoCS|spi.LSBFirst, 8)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := bus.DevParams(1, spi.Mode0, 8); err == nil {
+	if _, err := bus.DevParams(1, spi.Mode0, 8); err == nil {
 		t.Fatal("double initialization")
 	}
-	if d := bus.Duplex(); d != conn.Half {
+	if d := c.Duplex(); d != conn.Half {
 		t.Fatal(d)
 	}
-	if err := bus.Tx([]byte{0}, []byte{0}); err == nil {
+	if err := c.Tx([]byte{0}, []byte{0}); err == nil {
 		t.Fatal("half duplex")
 	}
 	p := []spi.Packet{
 		{W: []byte{0}, R: []byte{0}},
 	}
-	if err := bus.TxPackets(p); err == nil {
+	if err := c.TxPackets(p); err == nil {
 		t.Fatal("half duplex")
 	}
 }


### PR DESCRIPTION
This clarifies the difference on ownership and makes it clear that DevParams()
is essentially a 'connection factory'.

Doing this caught inconsistencies in the unit tests. Made the structs in spitest
enforce the fact that DevParams() can only be called once.