### PR TITLE
Set version of RPi for all known revisions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Google Inc.
 Stephan Sperber
 Thorsten von Eicken <tve@voneicken.com>
+Max Ekman <max@looplab.se>

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,6 @@
 # some cases, their employer may be the copyright holder.  To see the full list
 # of contributors, see the revision history in source control.
 Google Inc.
+Max Ekman <max@looplab.se>
 Stephan Sperber
 Thorsten von Eicken <tve@voneicken.com>
-Max Ekman <max@looplab.se>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -27,6 +27,7 @@
 # Please keep the list sorted.
 
 Marc-Antoine Ruel <maruel@chromium.org> <maruel@gmail.com>
+Max Ekman <max@looplab.se>
 Matias Insaurralde <matias@insaurral.de>
 Stephan Sperber <sperberstephan@googlemail.com>
 Thorsten von Eicken <tve@voneicken.com>

--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -197,27 +197,6 @@ func (d *driver) Init() (bool, error) {
 			return true, err
 		}
 
-		// Only the A and B v2 PCB has the P5 header.
-		if hasP5Header {
-			if err := pinreg.Register("P5", [][]pin.Pin{
-				{P5_1, P5_2},
-				{P5_3, P5_4},
-				{P5_5, P5_6},
-				{P5_7, P5_8},
-			}); err != nil {
-				return true, err
-			}
-		} else {
-			P5_1 = pin.INVALID
-			P5_2 = pin.INVALID
-			P5_3 = gpio.INVALID
-			P5_4 = gpio.INVALID
-			P5_5 = gpio.INVALID
-			P5_6 = gpio.INVALID
-			P5_7 = pin.INVALID
-			P5_8 = pin.INVALID
-		}
-
 		// TODO(maruel): Models from 2012 and earlier have P1_3=GPIO0, P1_5=GPIO1 and P1_13=GPIO21.
 		// P2 and P3 are not useful.
 		// P6 has a RUN pin for reset but it's not available after Pi version 1.
@@ -301,6 +280,27 @@ func (d *driver) Init() (bool, error) {
 		P1_38 = gpio.INVALID
 		P1_39 = pin.INVALID
 		P1_40 = gpio.INVALID
+	}
+
+	// Only the A and B v2 PCB has the P5 header.
+	if hasP5Header {
+		if err := pinreg.Register("P5", [][]pin.Pin{
+			{P5_1, P5_2},
+			{P5_3, P5_4},
+			{P5_5, P5_6},
+			{P5_7, P5_8},
+		}); err != nil {
+			return true, err
+		}
+	} else {
+		P5_1 = pin.INVALID
+		P5_2 = pin.INVALID
+		P5_3 = gpio.INVALID
+		P5_4 = gpio.INVALID
+		P5_5 = gpio.INVALID
+		P5_6 = gpio.INVALID
+		P5_7 = pin.INVALID
+		P5_8 = pin.INVALID
 	}
 
 	if hasAudio {

--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -128,17 +128,37 @@ func (d *driver) Init() (bool, error) {
 	//
 	// This code is not futureproof, it will error out on a Raspberry Pi 4
 	// whenever it comes out.
+	// Revision codes from: http://elinux.org/RPi_HardwareHistory
 	rev := distro.CPUInfo()["Revision"]
 	if i, err := strconv.ParseInt(rev, 16, 32); err == nil {
 		// Ignore the overclock bit.
 		i &= 0xFFFFFF
-		if i < 0x20 {
+		switch i {
+		case 0x0002, 0x0003, // B v1.0
+			0x0004, 0x0005, 0x0006, // B v2.0
+			0x0007, 0x0008, 0x0009, // A v2.0
+			0x000d, 0x000e, 0x000f, // B v2.0
+			0x0010,  // B+ v1.0
+			0x0011,  // Compute Module 1
+			0x0012,  // A+ v1.1
+			0x0013,  // B+ v1.2
+			0x0014,  // Compute Module 1
+			0x0015,  // A+ v1.1
+			0x90021, // A+ v1.1
+			0x90032: // B+ v1.2
 			Version = 1
-		} else if i == 0xa01041 || i == 0xa21041 {
+		case 0xa01040, // 2 Model B v1.0
+			0xa01041, 0xa21041, // 2 Model B v1.1
+			0xa22042, // 2 Model B v1.2
+			0x900092, // Zero v1.2
+			0x900093, // Zero v1.3
+			0x920093, // Zero v1.3
+			0x9000c1: // Zero W v1.1
 			Version = 2
-		} else if i == 0xa02082 || i == 0xa22082 {
+		case 0xa02082, 0xa22082, 0xa32082, // 3 Model B v1.2
+			0xa020a0: // Compute Module 3 v1.0
 			Version = 3
-		} else {
+		default:
 			return true, fmt.Errorf("rpi: unknown hardware version: 0x%x", i)
 		}
 	} else {

--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -155,13 +155,15 @@ func (d *driver) Init() (bool, error) {
 			0x90032,            // B+ v1.2
 			0xa01040,           // 2 Model B v1.0
 			0xa01041, 0xa21041, // 2 Model B v1.1
-			0xa22042, // 2 Model B v1.2
-			0x900092, // Zero v1.2
+			0xa22042: // 2 Model B v1.2
+			has40PinP1Header = true
+			hasAudio = true
+			hasHDMI = true
+		case 0x900092, // Zero v1.2
 			0x900093, // Zero v1.3
 			0x920093, // Zero v1.3
 			0x9000c1: // Zero W v1.1
 			has40PinP1Header = true
-			hasAudio = true
 			hasHDMI = true
 		case 0x0011, // Compute Module 1
 			0x0014,   // Compute Module 1


### PR DESCRIPTION
I needed to add support for the Raspberry Pi Zero W. I thought it would be wiser to specify revisions explicitly and I found a table [here](http://elinux.org/RPi_HardwareHistory) with an exhaustive list.