### PR TITLE
Don't error out when opening an already exported sysfs GPIO pin.

### DIFF
--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -263,8 +263,10 @@ func (p *Pin) open() error {
 	if exportHandle == nil {
 		return errors.New("sysfs gpio is not initialized")
 	}
-	_, p.err = exportHandle.Write([]byte(strconv.Itoa(p.number)))
+	var err error
+	_, err = exportHandle.Write([]byte(strconv.Itoa(p.number)))
 	if p.err != nil && !isErrBusy(p.err) {
+		p.err = err
 		if os.IsPermission(p.err) {
 			return fmt.Errorf("need more access, try as root or setup udev rules: %v", p.err)
 		}
@@ -276,7 +278,6 @@ func (p *Pin) open() error {
 	// It's simpler to just loop a little as if /export is accessible, it doesn't
 	// make sense that gpioN/value doesn't become accessible eventually.
 	timeout := 5 * time.Second
-	var err error
 	for start := time.Now(); time.Since(start) < timeout; {
 		p.fValue, err = fileIOOpen(p.root+"value", os.O_RDWR)
 		// The virtual file creation is synchronous when writing to /export for

--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -265,7 +265,7 @@ func (p *Pin) open() error {
 	}
 	var err error
 	_, err = exportHandle.Write([]byte(strconv.Itoa(p.number)))
-	if p.err != nil && !isErrBusy(p.err) {
+	if err != nil && !isErrBusy(err) {
 		p.err = err
 		if os.IsPermission(p.err) {
 			return fmt.Errorf("need more access, try as root or setup udev rules: %v", p.err)


### PR DESCRIPTION
The sysfs Pin.open function checked for the pin already being exported, but left p.err set when this happened. Only set the p.err once we've determined that it's a real error.