### PR TITLE
spi: rename variables 'bus' to 'port' where applicable

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -40,7 +40,7 @@ it](https://periph.io/project/contributing/).
 - [i2c-list](i2c-list): Lists which I²C buses are enabled and where the pins
   are.
 - [spi-io](spi-io): Reads and/or writes to an SPI device.
-- [spi-list](spi-list): Lists which SPI buses are enabled and where the pins
+- [spi-list](spi-list): Lists which SPI ports are enabled and where the pins
   are.
 
 

--- a/cmd/apa102/main.go
+++ b/cmd/apa102/main.go
@@ -110,12 +110,12 @@ func showImage(display devices.Display, img image.Image, sleep time.Duration, lo
 
 func mainImpl() error {
 	verbose := flag.Bool("v", false, "verbose mode")
-	spiName := flag.String("spi", "", "SPI bus to use")
+	spiID := flag.String("spi", "", "SPI port to use")
 
 	numLights := flag.Int("n", 150, "number of lights on the strip")
 	intensity := flag.Int("l", 127, "light intensity [1-255]")
 	temperature := flag.Int("t", 5000, "light temperature in °Kelvin [3500-7500]")
-	hz := flag.Int("hz", 0, "SPI bus speed")
+	hz := flag.Int("hz", 0, "SPI port speed")
 	color := flag.String("color", "208020", "hex encoded color to show")
 	imgName := flag.String("img", "", "image to load")
 	lineMs := flag.Int("linems", 2, "number of ms to show each line of the image")
@@ -140,21 +140,21 @@ func mainImpl() error {
 	}
 
 	// Open the display device.
-	bus, err := spireg.Open(*spiName)
+	s, err := spireg.Open(*spiID)
 	if err != nil {
 		return err
 	}
-	defer bus.Close()
+	defer s.Close()
 	if *hz != 0 {
-		if err := bus.LimitSpeed(int64(*hz)); err != nil {
+		if err := s.LimitSpeed(int64(*hz)); err != nil {
 			return err
 		}
 	}
-	if p, ok := bus.(spi.Pins); ok {
+	if p, ok := s.(spi.Pins); ok {
 		// TODO(maruel): Print where the pins are located.
 		log.Printf("Using pins CLK: %s  MOSI: %s  MISO: %s", p.CLK(), p.MOSI(), p.MISO())
 	}
-	display, err := apa102.New(bus, *numLights, uint8(*intensity), uint16(*temperature))
+	display, err := apa102.New(s, *numLights, uint8(*intensity), uint16(*temperature))
 	if err != nil {
 		return err
 	}

--- a/cmd/bme280/main.go
+++ b/cmd/bme280/main.go
@@ -55,8 +55,8 @@ func read(e devices.Environmental, interval time.Duration) error {
 func mainImpl() error {
 	i2cID := flag.String("i2c", "", "I²C bus to use")
 	i2cADDR := flag.Uint("ia", 0, "I²C bus address to use")
-	spiID := flag.String("spi", "", "SPI bus to use")
-	hz := flag.Int("hz", 0, "I²C/SPI bus speed")
+	spiID := flag.String("spi", "", "SPI port to use")
+	hz := flag.Int("hz", 0, "I²C bus/SPI port speed")
 	sample1x := flag.Bool("s1", false, "sample at 1x")
 	sample2x := flag.Bool("s2", false, "sample at 2x")
 	sample4x := flag.Bool("s4", false, "sample at 4x")
@@ -109,41 +109,41 @@ func mainImpl() error {
 
 	var dev *bme280.Dev
 	if *spiID != "" {
-		bus, err := spireg.Open(*spiID)
+		s, err := spireg.Open(*spiID)
 		if err != nil {
 			return err
 		}
-		defer bus.Close()
-		if p, ok := bus.(spi.Pins); ok {
+		defer s.Close()
+		if p, ok := s.(spi.Pins); ok {
 			printPin("CLK", p.CLK())
 			printPin("MOSI", p.MOSI())
 			printPin("MISO", p.MISO())
 			printPin("CS", p.CS())
 		}
 		if *hz != 0 {
-			if err := bus.LimitSpeed(int64(*hz)); err != nil {
+			if err := s.LimitSpeed(int64(*hz)); err != nil {
 				return err
 			}
 		}
-		if dev, err = bme280.NewSPI(bus, &opts); err != nil {
+		if dev, err = bme280.NewSPI(s, &opts); err != nil {
 			return err
 		}
 	} else {
-		bus, err := i2creg.Open(*i2cID)
+		i, err := i2creg.Open(*i2cID)
 		if err != nil {
 			return err
 		}
-		defer bus.Close()
-		if p, ok := bus.(i2c.Pins); ok {
+		defer i.Close()
+		if p, ok := i.(i2c.Pins); ok {
 			printPin("SCL", p.SCL())
 			printPin("SDA", p.SDA())
 		}
 		if *hz != 0 {
-			if err := bus.SetSpeed(int64(*hz)); err != nil {
+			if err := i.SetSpeed(int64(*hz)); err != nil {
 				return err
 			}
 		}
-		if dev, err = bme280.NewI2C(bus, &opts); err != nil {
+		if dev, err = bme280.NewI2C(i, &opts); err != nil {
 			return err
 		}
 	}

--- a/cmd/lepton/main.go
+++ b/cmd/lepton/main.go
@@ -381,11 +381,11 @@ func grabFrame(dev *lepton.Dev, path string, meta bool) error {
 }
 
 func mainImpl() error {
-	i2cName := flag.String("i2c", "", "I²C bus to use")
-	spiName := flag.String("spi", "", "SPI bus to use")
-	csName := flag.String("cs", "", "SPI CS line to use instead of the default")
+	i2cID := flag.String("i2c", "", "I²C bus to use")
+	spiID := flag.String("spi", "", "SPI port to use")
+	csID := flag.String("cs", "", "SPI CS line to use instead of the default")
 	i2cHz := flag.Int("i2chz", 0, "I²C bus speed")
-	spiHz := flag.Int("spihz", 0, "SPI bus speed")
+	spiHz := flag.Int("spihz", 0, "SPI port speed")
 
 	meta := flag.Bool("meta", false, "print metadata")
 	output := flag.String("o", "", "PNG file to save")
@@ -411,26 +411,26 @@ func mainImpl() error {
 	if _, err := host.Init(); err != nil {
 		return err
 	}
-	spiBus, err := spireg.Open(*spiName)
+	spiPort, err := spireg.Open(*spiID)
 	if err != nil {
 		return err
 	}
-	defer spiBus.Close()
+	defer spiPort.Close()
 	if *spiHz != 0 {
-		if err := spiBus.LimitSpeed(int64(*spiHz)); err != nil {
+		if err := spiPort.LimitSpeed(int64(*spiHz)); err != nil {
 			return err
 		}
 	}
 	var cs gpio.PinOut
-	if len(*csName) != 0 {
-		if p := gpioreg.ByName(*csName); p != nil {
+	if len(*csID) != 0 {
+		if p := gpioreg.ByName(*csID); p != nil {
 			cs = p
 		} else {
-			return fmt.Errorf("%s is not a valid pin", *csName)
+			return fmt.Errorf("%s is not a valid pin", *csID)
 		}
 	}
 
-	i2cBus, err := i2creg.Open(*i2cName)
+	i2cBus, err := i2creg.Open(*i2cID)
 	if err != nil {
 		return err
 	}
@@ -440,7 +440,7 @@ func mainImpl() error {
 			return err
 		}
 	}
-	dev, err := lepton.New(spiBus, i2cBus, cs)
+	dev, err := lepton.New(spiPort, i2cBus, cs)
 	if err != nil {
 		return fmt.Errorf("%s\nIf testing without hardware, use -fake to simulate a camera", err)
 	}

--- a/cmd/periph-info/README.md
+++ b/cmd/periph-info/README.md
@@ -42,7 +42,7 @@ running **as a user** (not root):
     - bcm283x  : bcm283x CPU not detected
     - rpi      : dependency not loaded: "bcm283x"
     - sysfs-led: no LED found
-    - sysfs-spi: no SPI bus found
+    - sysfs-spi: no SPI port found
     Drivers failed to load and the error:
     - allwinner   : need more access, try as root: open /dev/mem: permission denied
     - allwinner_pl: need more access, try as root: open /dev/mem: permission denied
@@ -63,7 +63,7 @@ root**:
     - bcm283x  : bcm283x CPU not detected
     - rpi      : dependency not loaded: "bcm283x"
     - sysfs-led: no LED found
-    - sysfs-spi: no SPI bus found
+    - sysfs-spi: no SPI port found
     Drivers failed to load and the error:
       <none>
 

--- a/cmd/spi-io/main.go
+++ b/cmd/spi-io/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// spi-io writes to an SPI bus data from stdin and outputs to stdout or writes
+// spi-io writes to an SPI port data from stdin and outputs to stdout or writes
 // arguments and outputs hex encoded output.
 //
 // Usage:
@@ -87,8 +87,8 @@ func runTx(s spi.Conn, args []string) error {
 }
 
 func mainImpl() error {
-	busName := flag.String("b", "", "SPI bus to use")
-	hz := flag.Int("hz", 1000000, "SPI bus speed")
+	spiID := flag.String("b", "", "SPI port to use")
+	hz := flag.Int("hz", 1000000, "SPI port speed")
 
 	nocs := flag.Bool("nocs", false, "do not assert the CS line")
 	half := flag.Bool("half", false, "half duplex mode, sharing MOSI and MISO")
@@ -122,12 +122,12 @@ func mainImpl() error {
 	if _, err := host.Init(); err != nil {
 		return err
 	}
-	bus, err := spireg.Open(*busName)
+	s, err := spireg.Open(*spiID)
 	if err != nil {
 		return err
 	}
-	defer bus.Close()
-	c, err := bus.DevParams(int64(*hz), m, *bits)
+	defer s.Close()
+	c, err := s.DevParams(int64(*hz), m, *bits)
 	if err != nil {
 		return err
 	}

--- a/cmd/spi-list/main.go
+++ b/cmd/spi-list/main.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// spi-list lists all SPI buses.
+// spi-list lists all SPI ports.
 package main
 
 import (
@@ -41,18 +41,18 @@ func mainImpl() error {
 				fmt.Printf("    %s\n", a)
 			}
 		}
-		bus, err := ref.Open()
+		s, err := ref.Open()
 		if err != nil {
 			fmt.Printf("  Failed to open: %v\n", err)
 			continue
 		}
-		if p, ok := bus.(spi.Pins); ok {
+		if p, ok := s.(spi.Pins); ok {
 			printPin("CLK", p.CLK())
 			printPin("MOSI", p.MOSI())
 			printPin("MISO", p.MISO())
 			printPin("CS", p.CS())
 		}
-		if err := bus.Close(); err != nil {
+		if err := s.Close(); err != nil {
 			return err
 		}
 	}

--- a/conn/i2c/i2csmoketest/i2csmoketest.go
+++ b/conn/i2c/i2csmoketest/i2csmoketest.go
@@ -46,15 +46,15 @@ func (s *SmokeTest) Description() string {
 // Run implements the SmokeTest interface.
 func (s *SmokeTest) Run(args []string) error {
 	f := flag.NewFlagSet("i2c", flag.ExitOnError)
-	busName := f.String("bus", "", "I²C bus to use")
+	i2cID := f.String("bus", "", "I²C bus to use")
 	wc := f.String("wc", "", "gpio pin for EEPROM write-control pin")
 	seed := f.Int64("seed", 0, "random number seed, default is to use the time")
 	f.Parse(args)
 
 	// Open the bus.
-	i2cBus, err := i2creg.Open(*busName)
+	i2cBus, err := i2creg.Open(*i2cID)
 	if err != nil {
-		return fmt.Errorf("error opening %s: %v", *busName, err)
+		return fmt.Errorf("error opening %s: %v", *i2cID, err)
 	}
 	defer i2cBus.Close()
 

--- a/conn/spi/spi.go
+++ b/conn/spi/spi.go
@@ -88,7 +88,7 @@ type Packet struct {
 	// KeepCS:false, there is a few µs with CS asserted after the clock stops,
 	// then 11.2µs with CS not asserted, then CS is asserted for (roughly) one
 	// clock cycle before the clock starts again for the next packet. This seems
-	// to be independent of the bus clock speed but this wasn't fully verified.
+	// to be independent of the port clock speed but this wasn't fully verified.
 	//
 	// It cannot be expected that the driver will correctly keep CS asserted even
 	// if KeepCS:true on the last packet.
@@ -124,10 +124,10 @@ type Port interface {
 	// The device driver must calls this function exactly once.
 	//
 	// maxHz must specify the maximum rated speed by the device's spec. The lowest
-	// speed between the bus speed and the device speed is selected. Use 0 for
+	// speed between the port speed and the device speed is selected. Use 0 for
 	// maxHz if there is no known maximum value for this device.
 	//
-	// mode specifies the clock and signal polarities, if the bus is using half
+	// mode specifies the clock and signal polarities, if the port is using half
 	// duplex (shared MISO and MOSI) or if CS is not needed.
 	DevParams(maxHz int64, mode Mode, bits int) (Conn, error)
 }
@@ -138,19 +138,19 @@ type Port interface {
 type PortCloser interface {
 	io.Closer
 	Port
-	// LimitSpeed sets the maximum bus speed.
+	// LimitSpeed sets the maximum port speed.
 	//
 	// It lets an application use a device at a lower speed than the maximum
 	// speed as rated by the device driver. This is useful for example when the
 	// wires are long or the connection is of poor quality.
 	//
 	// This function can be called multiple times and resets the previous value.
-	// 0 is not a value value for maxHz. The lowest speed between the bus speed
+	// 0 is not a value value for maxHz. The lowest speed between the port speed
 	// and the device speed is selected.
 	LimitSpeed(maxHz int64) error
 }
 
-// Pins defines the pins that a SPI bus interconnect is using on the host.
+// Pins defines the pins that a SPI port interconnect is using on the host.
 //
 // It is expected that a implementer of ConnCloser or Conn also implement Pins
 // but this is not a requirement.

--- a/conn/spi/spireg/spireg.go
+++ b/conn/spi/spireg/spireg.go
@@ -17,7 +17,7 @@ import (
 
 // Opener opens an handle to a port.
 //
-// It is provided by the actual bus driver.
+// It is provided by the actual port driver.
 type Opener func() (spi.PortCloser, error)
 
 // Ref references a SPI port.
@@ -34,6 +34,8 @@ type Ref struct {
 	//
 	// Buses provided by the CPU normally have a 0 based number. Buses provided
 	// via an addon (like over USB) generally are not numbered.
+	//
+	// The port is a bus number plus a CS line.
 	Number int
 	// Open is the factory to open an handle to this SPI port.
 	Open Opener

--- a/conn/spi/spireg/spireg_test.go
+++ b/conn/spi/spireg/spireg_test.go
@@ -18,8 +18,8 @@ import (
 )
 
 func ExampleAll() {
-	// Enumerate all SPI buses available and the corresponding pins.
-	fmt.Print("SPI buses available:\n")
+	// Enumerate all SPI ports available and the corresponding pins.
+	fmt.Print("SPI ports available:\n")
 	for _, ref := range All() {
 		fmt.Printf("- %s\n", ref.Name)
 		if ref.Number != -1 {
@@ -46,14 +46,14 @@ func ExampleAll() {
 }
 
 func ExampleOpen() {
-	// On linux, the following calls will likely open the same bus.
+	// On linux, the following calls will likely open the same port.
 	Open("/dev/spidev1.0")
 	Open("SPI1.0")
 	Open("1")
 
-	// How a command line tool may let the user choose an SPI bus, yet default to
-	// the first bus known.
-	name := flag.String("spi", "", "SPI bus to use")
+	// How a command line tool may let the user choose a SPI port, yet
+	// default to the first port known.
+	name := flag.String("spi", "", "SPI port to use")
 	flag.Parse()
 	b, err := Open(*name)
 	if err != nil {
@@ -75,9 +75,9 @@ func ExampleOpen() {
 func TestOpen(t *testing.T) {
 	defer reset()
 	if _, err := Open(""); err == nil {
-		t.Fatal("no bus registered")
+		t.Fatal("no port registered")
 	}
-	if err := Register("a", []string{"x"}, 1, fakeBuser); err != nil {
+	if err := Register("a", []string{"x"}, 1, getFakePort); err != nil {
 		t.Fatal(err)
 	}
 	if o, err := Open(""); o == nil || err != nil {
@@ -96,7 +96,7 @@ func TestOpen(t *testing.T) {
 
 func TestDefault_NoNumber(t *testing.T) {
 	defer reset()
-	if err := Register("a", nil, -1, fakeBuser); err != nil {
+	if err := Register("a", nil, -1, getFakePort); err != nil {
 		t.Fatal(err)
 	}
 	if o, err := Open(""); o == nil || err != nil {
@@ -109,10 +109,10 @@ func TestAll(t *testing.T) {
 	if a := All(); len(a) != 0 {
 		t.Fatal(a)
 	}
-	if err := Register("a", nil, 1, fakeBuser); err != nil {
+	if err := Register("a", nil, 1, getFakePort); err != nil {
 		t.Fatal(err)
 	}
-	if err := Register("b", nil, 2, fakeBuser); err != nil {
+	if err := Register("b", nil, 2, getFakePort); err != nil {
 		t.Fatal(err)
 	}
 	if a := All(); len(a) != 2 {
@@ -130,23 +130,23 @@ func TestRefList(t *testing.T) {
 
 func TestRegister(t *testing.T) {
 	defer reset()
-	if err := Register("a", []string{"b"}, 42, fakeBuser); err != nil {
+	if err := Register("a", []string{"b"}, 42, getFakePort); err != nil {
 		t.Fatal(err)
 	}
-	if Register("a", nil, -1, fakeBuser) == nil {
-		t.Fatal("same bus name")
+	if Register("a", nil, -1, getFakePort) == nil {
+		t.Fatal("same port name")
 	}
-	if Register("b", nil, -1, fakeBuser) == nil {
-		t.Fatal("same bus alias name")
+	if Register("b", nil, -1, getFakePort) == nil {
+		t.Fatal("same port alias name")
 	}
-	if Register("c", nil, 42, fakeBuser) == nil {
-		t.Fatal("same bus number")
+	if Register("c", nil, 42, getFakePort) == nil {
+		t.Fatal("same port number")
 	}
-	if Register("c", []string{"a"}, -1, fakeBuser) == nil {
-		t.Fatal("same bus alias")
+	if Register("c", []string{"a"}, -1, getFakePort) == nil {
+		t.Fatal("same port alias")
 	}
-	if Register("c", []string{"b"}, -1, fakeBuser) == nil {
-		t.Fatal("same bus alias")
+	if Register("c", []string{"b"}, -1, getFakePort) == nil {
+		t.Fatal("same port alias")
 	}
 }
 
@@ -155,28 +155,28 @@ func TestRegister_fail(t *testing.T) {
 	if Register("a", nil, -1, nil) == nil {
 		t.Fatal("missing Opener")
 	}
-	if Register("a", nil, -2, fakeBuser) == nil {
-		t.Fatal("bad bus number")
+	if Register("a", nil, -2, getFakePort) == nil {
+		t.Fatal("bad port number")
 	}
-	if Register("", nil, 42, fakeBuser) == nil {
+	if Register("", nil, 42, getFakePort) == nil {
 		t.Fatal("missing name")
 	}
-	if Register("1", nil, 42, fakeBuser) == nil {
+	if Register("1", nil, 42, getFakePort) == nil {
 		t.Fatal("numeric name")
 	}
-	if Register("a:b", nil, 42, fakeBuser) == nil {
+	if Register("a:b", nil, 42, getFakePort) == nil {
 		t.Fatal("':' in name")
 	}
-	if Register("a", []string{"a"}, 0, fakeBuser) == nil {
+	if Register("a", []string{"a"}, 0, getFakePort) == nil {
 		t.Fatal("\"a\" is already registered")
 	}
-	if Register("a", []string{""}, 0, fakeBuser) == nil {
+	if Register("a", []string{""}, 0, getFakePort) == nil {
 		t.Fatal("empty alias")
 	}
-	if Register("a", []string{"1"}, 0, fakeBuser) == nil {
+	if Register("a", []string{"1"}, 0, getFakePort) == nil {
 		t.Fatal("numeric alias")
 	}
-	if Register("a", []string{"a:b"}, 0, fakeBuser) == nil {
+	if Register("a", []string{"a:b"}, 0, getFakePort) == nil {
 		t.Fatal("':' in alias")
 	}
 	if a := All(); len(a) != 0 {
@@ -192,7 +192,7 @@ func TestUnregister(t *testing.T) {
 	if Unregister("a") == nil {
 		t.Fatal("unregister non-existing")
 	}
-	if err := Register("a", []string{"b"}, 0, fakeBuser); err != nil {
+	if err := Register("a", []string{"b"}, 0, getFakePort); err != nil {
 		t.Fatal(err)
 	}
 	if err := Unregister("a"); err != nil {
@@ -202,38 +202,38 @@ func TestUnregister(t *testing.T) {
 
 //
 
-func fakeBuser() (spi.PortCloser, error) {
-	return &fakeBus{}, nil
+func getFakePort() (spi.PortCloser, error) {
+	return &fakePort{}, nil
 }
 
-type fakeBus struct {
+type fakePort struct {
 }
 
-func (f *fakeBus) String() string {
+func (f *fakePort) String() string {
 	return "fake"
 }
 
-func (f *fakeBus) Close() error {
+func (f *fakePort) Close() error {
 	return errors.New("not implemented")
 }
 
-func (f *fakeBus) Tx(w, r []byte) error {
+func (f *fakePort) Tx(w, r []byte) error {
 	return errors.New("not implemented")
 }
 
-func (f *fakeBus) Duplex() conn.Duplex {
+func (f *fakePort) Duplex() conn.Duplex {
 	return conn.DuplexUnknown
 }
 
-func (f *fakeBus) LimitSpeed(maxHz int64) error {
+func (f *fakePort) LimitSpeed(maxHz int64) error {
 	return errors.New("not implemented")
 }
 
-func (f *fakeBus) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+func (f *fakePort) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	return f, errors.New("not implemented")
 }
 
-func (f *fakeBus) TxPackets(p []spi.Packet) error {
+func (f *fakePort) TxPackets(p []spi.Packet) error {
 	return errors.New("not implemented")
 }
 

--- a/conn/spi/spismoketest/README.md
+++ b/conn/spi/spismoketest/README.md
@@ -1,6 +1,6 @@
 # 'spi-testboard' smoke test
 
-Verifies that a EEPROM can be accessed on the bus. Typically used with
+Verifies that a EEPROM can be accessed on the SPI port. Typically used with
 the periph-tester board.
 
 Requires a gpio pin to be tied to the EEPROM's write protect (active low write

--- a/conn/spi/spismoketest/spismoketest.go
+++ b/conn/spi/spismoketest/spismoketest.go
@@ -3,10 +3,10 @@
 // that can be found in the LICENSE file.
 
 // Package spismoketest is leveraged by periph-smoketest to verify that an
-// EEPROM device can be accessed on an SPI bus.
+// EEPROM device can be accessed on a SPI port.
 //
-// This assumes the presence of the periph-tester board, which includes these two devices.
-// See https://github.com/tve/periph-tester
+// This assumes the presence of the periph-tester board, which includes these
+// two devices. See https://github.com/tve/periph-tester
 package spismoketest
 
 import (
@@ -44,22 +44,22 @@ func (s *SmokeTest) Description() string {
 // Run implements the SmokeTest interface.
 func (s *SmokeTest) Run(args []string) error {
 	f := flag.NewFlagSet("spi", flag.ExitOnError)
-	busName := f.String("spi", "", "SPI bus to use")
+	spiID := f.String("spi", "", "SPI port to use")
 	wp := f.String("wp", "", "gpio pin for EEPROM write-protect")
 	seed := f.Int64("seed", 0, "random number seed, default is to use the time")
 	f.Parse(args)
 
-	// Open the bus.
-	spiDev, err := spireg.Open(*busName)
+	// Open the port.
+	spiDev, err := spireg.Open(*spiID)
 	if err != nil {
-		return fmt.Errorf("error opening %s: %v", *busName, err)
+		return fmt.Errorf("error opening %s: %v", *spiID, err)
 	}
 	defer spiDev.Close()
 
 	// Set SPI parameters.
 	c, err := spiDev.DevParams(4000000, spi.Mode0, 8)
 	if err != nil {
-		return fmt.Errorf("error setting bus parameters: %v", err)
+		return fmt.Errorf("error setting SPI parameters: %v", err)
 	}
 
 	// Open the WC pin.
@@ -81,7 +81,7 @@ func (s *SmokeTest) Run(args []string) error {
 	return s.eeprom(c, wpPin)
 }
 
-// eeprom tests a 5080 8Kbit serial EEPROM attached to the SPI bus.
+// eeprom tests a 5080 8Kbit serial EEPROM attached to the SPI port.
 // Such a chip is included on the periph-tester board.
 //
 // The test performs some longish writes and reads and also tests a

--- a/conn/spi/spitest/spitest.go
+++ b/conn/spi/spitest/spitest.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// Package spitest is meant to be used to test drivers over a fake SPI bus.
+// Package spitest is meant to be used to test drivers over a fake SPI port.
 package spitest
 
 import (
@@ -164,7 +164,7 @@ func (r *Record) txInternal(c spi.Conn, w, read []byte) error {
 	defer r.Unlock()
 	if r.Port == nil {
 		if len(read) != 0 {
-			return conntest.Errorf("spitest: read unsupported when no bus is connected")
+			return conntest.Errorf("spitest: read unsupported when no port is connected")
 		}
 	} else {
 		if err := c.Tx(w, read); err != nil {

--- a/conn/spi/spitest/spitest_test.go
+++ b/conn/spi/spitest/spitest_test.go
@@ -48,7 +48,7 @@ func TestRecord_empty(t *testing.T) {
 		t.Fatal(err)
 	}
 	if c.Tx(nil, []byte{'a'}) == nil {
-		t.Fatal("Bus is nil")
+		t.Fatal("Port is nil")
 	}
 	if err := c.TxPackets(nil); err == nil {
 		t.Fatal("not yet implemented")
@@ -93,7 +93,7 @@ func TestRecord_Tx_empty(t *testing.T) {
 		t.Fatal(r.Ops)
 	}
 	if c.Tx([]byte{'a', 'b'}, []byte{'d'}) == nil {
-		t.Fatal("Bus is nil")
+		t.Fatal("Port is nil")
 	}
 	if len(r.Ops) != 2 {
 		t.Fatal(r.Ops)

--- a/devices/apa102/apa102.go
+++ b/devices/apa102/apa102.go
@@ -210,7 +210,7 @@ func ToRGB(p []color.NRGBA) []byte {
 	return b
 }
 
-// Dev represents a strip of APA-102 LEDs as a strip connected over a SPI bus.
+// Dev represents a strip of APA-102 LEDs as a strip connected over a SPI port.
 // It accepts a stream of raw RGB pixels and converts it to the full dynamic
 // range as supported by APA102 protocol (nearly 8000:1 contrast ratio).
 //
@@ -284,7 +284,7 @@ func (d *Dev) Halt() error {
 
 // New returns a strip that communicates over SPI to APA102 LEDs.
 //
-// The SPI bus speed should be high, at least in the Mhz range, as
+// The SPI port speed should be high, at least in the Mhz range, as
 // there's 32 bits sent per LED, creating a staggered effect. See
 // https://cpldcpu.wordpress.com/2014/11/30/understanding-the-apa102-superled/
 //

--- a/devices/apa102/apa102_test.go
+++ b/devices/apa102/apa102_test.go
@@ -552,18 +552,18 @@ func TestDrawRGBA(t *testing.T) {
 }
 
 func TestHalt(t *testing.T) {
-	bus := spitest.Playback{
+	s := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				{W: []byte{0x0, 0x0, 0x0, 0x0, 0xe1, 0x0, 0x0, 0x0, 0xe1, 0x0, 0x0, 0x0, 0xe1, 0x0, 0x0, 0x0, 0xe1, 0x0, 0x0, 0x0, 0xff}},
 			},
 		},
 	}
-	d, _ := New(&bus, 4, 250, 5000)
+	d, _ := New(&s, 4, 250, 5000)
 	if err := d.Halt(); err != nil {
 		t.Fatal(err)
 	}
-	if err := bus.Close(); err != nil {
+	if err := s.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -580,14 +580,14 @@ func TestInit(t *testing.T) {
 //
 
 func Example() {
-	bus, err := spireg.Open("")
+	s, err := spireg.Open("")
 	if err != nil {
 		log.Fatalf("failed to open SPI: %v", err)
 	}
-	defer bus.Close()
+	defer s.Close()
 	// Opens a strip of 150 lights are 50% intensity with color temperature at
 	// 5000 Kelvin.
-	dev, err := New(bus, 150, 127, 5000)
+	dev, err := New(s, 150, 127, 5000)
 	if err != nil {
 		log.Fatalf("failed to open apa102: %v", err)
 	}

--- a/devices/apa102/doc.go
+++ b/devices/apa102/doc.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// Package apa102 drives a strip of APA102 LEDs connected on a SPI bus.
+// Package apa102 drives a strip of APA102 LEDs connected on a SPI port.
 //
 // These devices are interesting because they have 2 PWMs: one global of 5 bits
 // of resolution and one per channel of 8 bits of resolution. This means that

--- a/devices/bme280/bme280_test.go
+++ b/devices/bme280/bme280_test.go
@@ -41,7 +41,7 @@ var calib = calibration{
 }
 
 func TestSPISense_success(t *testing.T) {
-	bus := spitest.Playback{
+	s := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				// Chipd ID detection.
@@ -75,7 +75,7 @@ func TestSPISense_success(t *testing.T) {
 		Standby:     S1s,
 		Filter:      FOff,
 	}
-	dev, err := NewSPI(&bus, &opts)
+	dev, err := NewSPI(&s, &opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestSPISense_success(t *testing.T) {
 	if env.Humidity != 995 {
 		t.Fatalf("humidity %d", env.Humidity)
 	}
-	if err := bus.Close(); err != nil {
+	if err := s.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -110,7 +110,7 @@ func TestNewSPI_fail(t *testing.T) {
 }
 
 func TestNewSPI_fail_len(t *testing.T) {
-	bus := spitest.Playback{
+	s := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				{
@@ -122,18 +122,18 @@ func TestNewSPI_fail_len(t *testing.T) {
 			DontPanic: true,
 		},
 	}
-	if dev, err := NewSPI(&bus, nil); dev != nil || err == nil {
+	if dev, err := NewSPI(&s, nil); dev != nil || err == nil {
 		t.Fatal("read failed")
 	}
 	// The I/O didn't occur.
-	bus.Count++
-	if err := bus.Close(); err != nil {
+	s.Count++
+	if err := s.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestNewSPI_fail_chipid(t *testing.T) {
-	bus := spitest.Playback{
+	s := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				{
@@ -144,10 +144,10 @@ func TestNewSPI_fail_chipid(t *testing.T) {
 			},
 		},
 	}
-	if dev, err := NewSPI(&bus, nil); dev != nil || err == nil {
+	if dev, err := NewSPI(&s, nil); dev != nil || err == nil {
 		t.Fatal("read failed")
 	}
-	if err := bus.Close(); err != nil {
+	if err := s.Close(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/devices/lepton/lepton_test.go
+++ b/devices/lepton/lepton_test.go
@@ -199,7 +199,7 @@ func TestReadImg_fail_Tx(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := d.ReadImg(); err == nil {
-		t.Fatal("spi bus Tx failed")
+		t.Fatal("spi port Tx failed")
 	}
 	if err := i.Close(); err != nil {
 		t.Fatal(err)
@@ -214,7 +214,7 @@ func TestReadImg_fail_OUt(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := d.ReadImg(); err == nil {
-		t.Fatal("spi bus Tx failed")
+		t.Fatal("spi port Tx failed")
 	}
 	if err := i.Close(); err != nil {
 		t.Fatal(err)

--- a/devices/ssd1306/ssd1306.go
+++ b/devices/ssd1306/ssd1306.go
@@ -149,8 +149,8 @@ func NewI2C(i i2c.Bus, w, h int, rotated bool) (*Dev, error) {
 	return newDev(&i2c.Dev{Bus: i, Addr: 0x3C}, w, h, rotated, false, nil)
 }
 
-// newDev is the common initialization code that is independent of the bus
-// being used.
+// newDev is the common initialization code that is independent of the
+// communication protocol (I²C or SPI) being used.
 func newDev(c conn.Conn, w, h int, rotated, usingSPI bool, dc gpio.PinOut) (*Dev, error) {
 	if w < 8 || w > 128 || w&7 != 0 {
 		return nil, fmt.Errorf("ssd1306: invalid width %d", w)

--- a/devices/ssd1306/ssd1306_test.go
+++ b/devices/ssd1306/ssd1306_test.go
@@ -420,12 +420,12 @@ func TestSPI_3wire(t *testing.T) {
 }
 
 func TestSPI_4wire_String(t *testing.T) {
-	bus := spitest.Playback{
+	port := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{{W: getInitCmd(128, 64, false)}},
 		},
 	}
-	dev, err := NewSPI(&bus, &gpiotest.Pin{N: "pin1", Num: 42}, 128, 64, false)
+	dev, err := NewSPI(&port, &gpiotest.Pin{N: "pin1", Num: 42}, 128, 64, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -433,7 +433,7 @@ func TestSPI_4wire_String(t *testing.T) {
 	if s := dev.String(); s != expected {
 		t.Fatalf("%q != %q", expected, s)
 	}
-	if err := bus.Close(); err != nil {
+	if err := port.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -444,7 +444,7 @@ func TestSPI_4wire_Write_differential(t *testing.T) {
 	buf2 := make([]byte, 128)
 	buf2[130-128] = 1
 	buf2[131-128] = 2
-	bus := spitest.Playback{
+	port := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				{W: getInitCmd(128, 64, false)},
@@ -455,7 +455,7 @@ func TestSPI_4wire_Write_differential(t *testing.T) {
 			},
 		},
 	}
-	dev, err := NewSPI(&bus, &gpiotest.Pin{N: "pin1", Num: 42}, 128, 64, false)
+	dev, err := NewSPI(&port, &gpiotest.Pin{N: "pin1", Num: 42}, 128, 64, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -468,7 +468,7 @@ func TestSPI_4wire_Write_differential(t *testing.T) {
 	if n, err := dev.Write(pix); n != len(pix) || err != nil {
 		t.Fatal(n, err)
 	}
-	if err := bus.Close(); err != nil {
+	if err := port.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -476,7 +476,7 @@ func TestSPI_4wire_Write_differential(t *testing.T) {
 func TestSPI_4wire_Write_differential_fail(t *testing.T) {
 	buf1 := make([]byte, 1024)
 	buf1[130] = 1
-	bus := spitest.Playback{
+	port := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				{W: getInitCmd(128, 64, false)},
@@ -485,7 +485,7 @@ func TestSPI_4wire_Write_differential_fail(t *testing.T) {
 			DontPanic: true,
 		},
 	}
-	dev, err := NewSPI(&bus, &gpiotest.Pin{N: "pin1", Num: 42}, 128, 64, false)
+	dev, err := NewSPI(&port, &gpiotest.Pin{N: "pin1", Num: 42}, 128, 64, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -498,19 +498,19 @@ func TestSPI_4wire_Write_differential_fail(t *testing.T) {
 	if n, err := dev.Write(pix); n != 0 || !conntest.IsErr(err) {
 		t.Fatalf("expected conntest error: %v", err)
 	}
-	if err := bus.Close(); err != nil {
+	if err := port.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSPI_4wire_gpio_fail(t *testing.T) {
-	bus := spitest.Playback{
+	port := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{{W: getInitCmd(128, 64, false)}},
 		},
 	}
 	pin := &failPin{fail: false}
-	dev, err := NewSPI(&bus, pin, 128, 64, false)
+	dev, err := NewSPI(&port, pin, 128, 64, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -522,7 +522,7 @@ func TestSPI_4wire_gpio_fail(t *testing.T) {
 	if err := dev.Halt(); err == nil || err.Error() != "injected error" {
 		t.Fatalf("expected gpio error: %v", err)
 	}
-	if err := bus.Close(); err != nil {
+	if err := port.Close(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/experimental/cmd/bmp180/main.go
+++ b/experimental/cmd/bmp180/main.go
@@ -78,18 +78,18 @@ func mainImpl() error {
 		return err
 	}
 
-	bus, err := i2creg.Open(*i2cID)
+	i, err := i2creg.Open(*i2cID)
 	if err != nil {
 		return err
 	}
-	defer bus.Close()
+	defer i.Close()
 
-	if p, ok := bus.(i2c.Pins); ok {
+	if p, ok := i.(i2c.Pins); ok {
 		printPin("SCL", p.SCL())
 		printPin("SDA", p.SDA())
 	}
 
-	dev, err := bmp180.New(bus, os)
+	dev, err := bmp180.New(i, os)
 	if err != nil {
 		return err
 	}

--- a/experimental/devices/bitbang/spi.go
+++ b/experimental/devices/bitbang/spi.go
@@ -31,7 +31,7 @@ type SPI struct {
 	csn gpio.PinOut // CS
 
 	mu        sync.Mutex
-	maxHzBus  int64
+	maxHzPort int64
 	maxHzDev  int64
 	mode      spi.Mode
 	bits      int
@@ -60,8 +60,8 @@ func (s *SPI) LimitSpeed(maxHz int64) error {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.maxHzBus = maxHz
-	if s.maxHzDev == 0 || s.maxHzBus < s.maxHzDev {
+	s.maxHzPort = maxHz
+	if s.maxHzDev == 0 || s.maxHzPort < s.maxHzDev {
 		s.halfCycle = time.Second / time.Duration(maxHz) / time.Duration(2)
 	}
 	return nil
@@ -78,7 +78,7 @@ func (s *SPI) DevParams(maxHz int64, mode spi.Mode, bits int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.maxHzDev = maxHz
-	if s.maxHzDev != 0 && (s.maxHzBus == 0 || s.maxHzDev < s.maxHzBus) {
+	if s.maxHzDev != 0 && (s.maxHzPort == 0 || s.maxHzDev < s.maxHzPort) {
 		s.halfCycle = time.Second / time.Duration(maxHz) / time.Duration(2)
 	}
 	s.mode = mode

--- a/host/sysfs/spi_test.go
+++ b/host/sysfs/spi_test.go
@@ -34,17 +34,17 @@ func ExampleNewSPI() {
 //
 
 func TestNewSPI(t *testing.T) {
-	if b, err := NewSPI(-1, -1); b != nil || err == nil {
-		t.Fatal("invalid bus")
+	if b, err := NewSPI(-1, 0); b != nil || err == nil {
+		t.Fatal("invalid bus number")
 	}
 	if b, err := NewSPI(0, -1); b != nil || err == nil {
-		t.Fatal("invalid bus")
+		t.Fatal("invalid CS")
 	}
 }
 
 func TestSPI_IO(t *testing.T) {
-	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	c, err := bus.DevParams(1, spi.Mode3, 8)
+	port := SPI{f: ioctlClose(0), busNumber: 24}
+	c, err := port.DevParams(1, spi.Mode3, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,70 +102,70 @@ func TestSPI_IO(t *testing.T) {
 	if d := c.Duplex(); d != conn.Full {
 		t.Fatal(d)
 	}
-	if err := bus.Close(); err != nil {
+	if err := port.Close(); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestSPI_IO_not_initialized(t *testing.T) {
-	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	if _, err := bus.txInternal([]byte{0}, []byte{0}); err == nil {
+	port := SPI{f: ioctlClose(0), busNumber: 24}
+	if _, err := port.txInternal([]byte{0}, []byte{0}); err == nil {
 		t.Fatal("not initialized")
 	}
-	if bus.txPackets([]spi.Packet{{W: []byte{0}}}) == nil {
+	if port.txPackets([]spi.Packet{{W: []byte{0}}}) == nil {
 		t.Fatal("not initialized")
 	}
 }
 
 func TestSPI_pins(t *testing.T) {
-	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	if p := bus.CLK(); p != gpio.INVALID {
+	port := SPI{f: ioctlClose(0), busNumber: 24}
+	if p := port.CLK(); p != gpio.INVALID {
 		t.Fatal(p)
 	}
-	if p := bus.MOSI(); p != gpio.INVALID {
+	if p := port.MOSI(); p != gpio.INVALID {
 		t.Fatal(p)
 	}
-	if p := bus.MISO(); p != gpio.INVALID {
+	if p := port.MISO(); p != gpio.INVALID {
 		t.Fatal(p)
 	}
-	if p := bus.CS(); p != gpio.INVALID {
+	if p := port.CS(); p != gpio.INVALID {
 		t.Fatal(p)
 	}
 }
 
 func TestSPI_other(t *testing.T) {
-	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	if s := bus.String(); s != "SPI24.0" {
+	port := SPI{f: ioctlClose(0), busNumber: 24}
+	if s := port.String(); s != "SPI24.0" {
 		t.Fatal(s)
 	}
-	if err := bus.LimitSpeed(0); err == nil {
+	if err := port.LimitSpeed(0); err == nil {
 		t.Fatal("invalid speed")
 	}
-	if err := bus.LimitSpeed(1); err != nil {
+	if err := port.LimitSpeed(1); err != nil {
 		t.Fatal(err)
 	}
-	if v := bus.MaxTxSize(); v != spiBufSize {
+	if v := port.MaxTxSize(); v != spiBufSize {
 		t.Fatal(v, spiBufSize)
 	}
 }
 
 func TestSPI_DevParams(t *testing.T) {
 	// Create a fake SPI to test methods.
-	bus := SPI{f: ioctlClose(0), busNumber: 24}
-	if _, err := bus.DevParams(-1, spi.Mode0, 8); err == nil {
+	port := SPI{f: ioctlClose(0), busNumber: 24}
+	if _, err := port.DevParams(-1, spi.Mode0, 8); err == nil {
 		t.Fatal("invalid speed")
 	}
-	if _, err := bus.DevParams(1, -1, 8); err == nil {
+	if _, err := port.DevParams(1, -1, 8); err == nil {
 		t.Fatal("invalid mode")
 	}
-	if _, err := bus.DevParams(1, spi.Mode0, 0); err == nil {
+	if _, err := port.DevParams(1, spi.Mode0, 0); err == nil {
 		t.Fatal("invalid bit")
 	}
-	c, err := bus.DevParams(1, spi.Mode0|spi.HalfDuplex|spi.NoCS|spi.LSBFirst, 8)
+	c, err := port.DevParams(1, spi.Mode0|spi.HalfDuplex|spi.NoCS|spi.LSBFirst, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := bus.DevParams(1, spi.Mode0, 8); err == nil {
+	if _, err := port.DevParams(1, spi.Mode0, 8); err == nil {
 		t.Fatal("double initialization")
 	}
 	if d := c.Duplex(); d != conn.Half {


### PR DESCRIPTION
As people like to copy paste code, make sure that the semantic of the variable
names is always relevant w.r.t. the object they refer to. In particular, do not
use 'bus' to refer to an spi.Port or spi.PortCloser, as this is blur the
distinction.

Also rename a few fooName to fooID.