### PR TITLE
pmem: rename Struct to AsPOD; add support for slice and array

### DIFF
--- a/host/allwinner/dma.go
+++ b/host/allwinner/dma.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 
 	"github.com/kr/pretty"
 	"periph.io/x/periph/host/pmem"
@@ -417,23 +416,23 @@ func (d *driverDMA) Init() (bool, error) {
 		return false, errors.New("unsupported CPU architecture")
 	}
 
-	if err := pmem.MapStruct(uint64(dmaBaseAddr), reflect.ValueOf(&dmaMemory)); err != nil {
+	if err := pmem.MapAsPOD(uint64(dmaBaseAddr), &dmaMemory); err != nil {
 		if os.IsPermission(err) {
 			return true, fmt.Errorf("need more access, try as root: %v", err)
 		}
 		return true, err
 	}
 
-	if err := pmem.MapStruct(uint64(pwmBaseAddr), reflect.ValueOf(&pwmMemory)); err != nil {
+	if err := pmem.MapAsPOD(uint64(pwmBaseAddr), &pwmMemory); err != nil {
 		return true, err
 	}
-	if err := pmem.MapStruct(uint64(timerBaseAddr), reflect.ValueOf(&timerMemory)); err != nil {
+	if err := pmem.MapAsPOD(uint64(timerBaseAddr), &timerMemory); err != nil {
 		return true, err
 	}
-	if err := pmem.MapStruct(uint64(clockBaseAddr), reflect.ValueOf(&clockMemory)); err != nil {
+	if err := pmem.MapAsPOD(uint64(clockBaseAddr), &clockMemory); err != nil {
 		return true, err
 	}
-	if err := pmem.MapStruct(uint64(spiBaseAddr), reflect.ValueOf(&spiMemory)); err != nil {
+	if err := pmem.MapAsPOD(uint64(spiBaseAddr), &spiMemory); err != nil {
 		return true, err
 	}
 

--- a/host/allwinner/gpio.go
+++ b/host/allwinner/gpio.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -608,7 +607,7 @@ func (d *driverGPIO) Init() (bool, error) {
 		return false, errors.New("Allwinner CPU not detected")
 	}
 	gpioBaseAddr = uint32(getBaseAddress())
-	if err := pmem.MapStruct(uint64(gpioBaseAddr), reflect.ValueOf(&gpioMemory)); err != nil {
+	if err := pmem.MapAsPOD(uint64(gpioBaseAddr), &gpioMemory); err != nil {
 		if os.IsPermission(err) {
 			return true, fmt.Errorf("need more access, try as root: %v", err)
 		}

--- a/host/allwinner/gpio_pl.go
+++ b/host/allwinner/gpio_pl.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -348,7 +347,7 @@ func (d *driverGPIOPL) Init() (bool, error) {
 		}
 		return true, err
 	}
-	if err := m.Struct(reflect.ValueOf(&gpioMemoryPL)); err != nil {
+	if err := m.AsPOD(&gpioMemoryPL); err != nil {
 		return true, err
 	}
 

--- a/host/bcm283x/dma_test.go
+++ b/host/bcm283x/dma_test.go
@@ -4,7 +4,10 @@
 
 package bcm283x
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestDmaStatus_String(t *testing.T) {
 	if s := dmaStatus(0).String(); s != "0" {
@@ -128,9 +131,21 @@ func TestDmaChannel_GoString(t *testing.T) {
 	}
 }
 
-func TestDmaMap(t *testing.T) {
+func TestDmaMap_GoString(t *testing.T) {
 	d := dmaMap{}
+	// I have to admit, this is the worst test ever.
 	if s := d.GoString(); len(s) != 3629 {
 		t.Fatal(s, len(s))
 	}
+}
+
+func TestStructSizes(t *testing.T) {
+	// Verify internal assumptions.
+	if s := reflect.TypeOf((*controlBlock)(nil)).Elem().Size(); s != 256/8 {
+		t.Fatalf("controlBlock size: %d", s)
+	}
+	if s := reflect.TypeOf((*dmaChannel)(nil)).Elem().Size(); s != 0x100 {
+		t.Fatalf("dmaChannel size: %d", s)
+	}
+
 }

--- a/host/bcm283x/gpio.go
+++ b/host/bcm283x/gpio.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
@@ -640,7 +639,7 @@ func (d *driverGPIO) Init() (bool, error) {
 			return true, err
 		}
 	}
-	if err := m.Struct(reflect.ValueOf(&gpioMemory)); err != nil {
+	if err := m.AsPOD(&gpioMemory); err != nil {
 		return true, err
 	}
 

--- a/host/pmem/alloc.go
+++ b/host/pmem/alloc.go
@@ -24,14 +24,23 @@ type Mem interface {
 	//
 	// It is the raw view of the memory from this process.
 	Bytes() []byte
-	// Struct initializes a pointer to a struct or array to point to the memory
-	// mapped region.
+	// AsPOD initializes a pointer to a POD (plain old data) to point to the
+	// memory mapped region.
 	//
-	// pp must be a pointer to a pointer to a struct and the pointer to struct
-	// must be nil. Returns an error otherwise.
+	// pp must be a pointer to:
+	//
+	// - pointer to a base size type (uint8, int64, float32, etc)
+	// - struct
+	// - array of the above
+	// - slice of the above
+	//
+	// and the value must be nil. Returns an error otherwise.
+	//
+	// If a pointer to a slice is passed in, it is initialized to the length and
+	// capacity set to the maximum number of elements this slice can represent.
 	//
 	// The pointer initialized points to the same address as Bytes().
-	Struct(pp reflect.Value) error
+	AsPOD(pp interface{}) error
 	// PhysAddr is the physical address. It can be either 32 bits or 64 bits,
 	// depending on the bitness of the OS kernel, not on the user mode build,
 	// e.g. you could have compiled on a 32 bits Go toolchain but running on a

--- a/host/pmem/doc.go
+++ b/host/pmem/doc.go
@@ -4,43 +4,66 @@
 
 // Package pmem implements handling of physical memory for user space programs.
 //
-// To make things confusing, a modern computer has many view of the memory:
+// To make things confusing, a modern computer has many view of the memory
+// (address spaces):
 //
-// - user mode memory is the virtual address space that an application runs in.
-//   It is generally a tad less than half the addressable memory, so on a 32
-//   bits system, the addressable range is 1.9Gb. For 64 bits OS, it depends
-//   but it usually at least 4Gb. The memory is virtual and can be flushed to
-//   disk in the swap file unless individual pages are locked.
+// User
 //
-// - kernel memory is the virtual address space the kernel sees. It often can
-//   see the currently active user space program on the current CPU core in
-//   addition to all the memory the kernel sees. The kernel memory pages
-//   that were not mlock()'ed is 'virtual' and can be flushed to disk in the
-//   swap file when there's not enough RAM available. On linux systems, the
-//   kernel addressed memory can be mapped in user space via `/dev/kmem`.
+// User mode address space is the virtual address space that an application
+// runs in.  It is generally a tad less than half the addressable memory, so on
+// a 32 bits system, the addressable range is 1.9Gb. For 64 bits OS, it depends
+// but it usually at least 3.5Gb. The memory is virtual and can be flushed to
+// disk in the swap file unless individual pages are locked.
 //
-// - physical memory is the actual address of each page in the DRAM chip and
-//   anything connected to the memory controller. The mapping may be different
-//   depending on what controller looks at the bus. So a peripheral (GPU, DMA
-//   controller) may have a different view of the physical memory than the host
-//   CPU. On linux systems, this memory can be mapped in user space via
-//   `/dev/mem`.
+// Kernel
 //
-// - The CPU may memory map registers (for example, to control GPIO pins, clock
-//   speed, etc). This is not "real" memory, this is a view of registers but it
-//   still follows "mostly" the same semantic as DRAM backed physical memory.
+// Kernel address space is the virtual address space the kernel sees. It often
+// can see the currently active user space program on the current CPU core in
+// addition to all the memory the kernel sees. The kernel memory pages that are
+// not mlock()'ed are 'virtual' and can be flushed to disk in the swap file
+// when there's not enough RAM available. On linux systems, the kernel
+// addressed memory can be mapped in user space via `/dev/kmem`.
 //
-// - CPU memory accesses are layered with multiple caches, usually named L1, L2
-//   and optionally L3. Some controllers (DMA) can see some cache levels (L2)
-//   but not others (L1) on some CPU architecture (bcm283x). This means that a
-//   user space program writing data to a memory page and immediately asking
-//   the DMA controller to read it may cause stale data to be read!
+// Physical
 //
-// - Hypervisor can change the complete memory mapping as seen by the kernel.
-//   This is outside the scope of this project. :)
+// Physical memory address space is the actual address of each page in the DRAM
+// chip and anything connected to the memory controller. The mapping may be
+// different depending on what controller looks at the bus, like with IOMMU. So
+// a peripheral (GPU, DMA controller) may have a different view of the physical
+// memory than the host CPU. On linux systems, this memory can be mapped in
+// user space via `/dev/mem`.
+//
+// CPU
+//
+// The CPU or its subsystems may memory map registers (for example, to control
+// GPIO pins, clock speed, etc). This is not "real" memory, this is a view of
+// registers but it still follows "mostly" the same semantic as DRAM backed
+// physical memory.
+//
+// Some CPU memory may have very special semantic where the mere fact of
+// reading has side effects. For example reading a specific register may
+// latches another.
+//
+// CPU memory accesses are layered with multiple caches, usually named L1, L2
+// and optionally L3. Some controllers (DMA) can see some cache levels (L2) but
+// not others (L1) on some CPU architecture (bcm283x). This means that a user
+// space program writing data to a memory page and immediately asking the DMA
+// controller to read it may cause stale data to be read!
+//
+// Hypervisor
+//
+// Hypervisor can change the complete memory mapping as seen by the kernel.
+// This is outside the scope of this project. :)
+//
+// Summary
 //
 // In practice, the semantics change between CPU manufacturers (Broadcom vs
 // Allwinner) and between architectures (ARM vs x86). The most tricky one is to
 // understand cached memory and how it affects coherence and performance.
 // Uncached memory is extremely slow so it must only be used when necessary.
+//
+// References
+//
+// Overview of IOMMU:
+// https://en.wikipedia.org/wiki/Input-output_memory_management_unit
 package pmem


### PR DESCRIPTION
- bcm283x: Migrate 'smokeTest' struct size check to unit test.
- pmem: Improve package documentation.
- pmem: Remove the need from callers to use reflect.ValueOf().
- pmem: Add support to map a slice which calculate the len/cap automatically.
- pmem: Rename Struct() to AsPOD().
- pmem: Add AsPOD() support for native POD (plain old data) types like uint8,
  float64, etc.
- pmem: Add AsPOD() support for array of POD.
- pmem: Make AsPOD() check for struct much stricter.