### PR TITLE
periph: Improve the package doc

### DIFF
--- a/periph.go
+++ b/periph.go
@@ -23,21 +23,26 @@
 // The user must call periph.Init() on startup to initialize all the registered
 // drivers in the correct order all at once.
 //
-//   - cmd/ contains executables to communicate directly with the devices or the
-//     buses using raw protocols.
-//   - conn/ contains interfaces and registries for all the supported protocols
-//     and connections (I²C, SPI, GPIO, etc).
-//   - devices/ contains devices drivers that are connected to a bus (i.e I²C,
-//     SPI, GPIO) that can be controlled by the host, i.e. ssd1306 (display
-//     controller), bm280 (environmental sensor), etc. 'devices' contains the
-//     interfaces and subpackages contain contain concrete types.
-//   - experimental/ contains the drivers that are in the experimental area,
-//     not yet considered stable. See doc/drivers/DESIGN.md for the process to
-//     move drivers out of this area.
-//   - host/ contains all the implementations relating to the host itself, the
-//     CPU and buses that are exposed by the host onto which devices can be
-//     connected, i.e. I²C, SPI, GPIO, etc. 'host' contains the interfaces
-//     and subpackages contain contain concrete types.
+// → cmd/ contains executables to communicate directly with the devices or the
+// buses using raw protocols.
+//
+// → conn/ contains interfaces and registries for all the supported protocols
+// and connections (I²C, SPI, GPIO, etc).
+//
+// → devices/ contains devices drivers that are connected to a bus (i.e I²C,
+// SPI, GPIO) that can be controlled by the host, i.e. ssd1306 (display
+// controller), bm280 (environmental sensor), etc. 'devices' contains the
+// interfaces and subpackages contain contain concrete types.
+//
+// → experimental/ contains the drivers that are in the experimental area, not
+// yet considered stable. See
+// https://periph.io/project/#driver-lifetime-management for the process to
+// move drivers out of this area.
+//
+// → host/ contains all the implementations relating to the host itself, the
+// CPU and buses that are exposed by the host onto which devices can be
+// connected, i.e. I²C, SPI, GPIO, etc. 'host' contains the interfaces and
+// subpackages contain contain concrete types.
 package periph // import "periph.io/x/periph"
 
 import (


### PR DESCRIPTION
And update a stale reference to DESIGN.md which now is on the official web site

The new layout is easier to read in godoc.