### PR TITLE
spi: Rename Port.DevParams to Connect

### DIFF
--- a/cmd/spi-io/main.go
+++ b/cmd/spi-io/main.go
@@ -127,7 +127,7 @@ func mainImpl() error {
 		return err
 	}
 	defer s.Close()
-	c, err := s.DevParams(int64(*hz), m, *bits)
+	c, err := s.Connect(int64(*hz), m, *bits)
 	if err != nil {
 		return err
 	}

--- a/conn/spi/spi.go
+++ b/conn/spi/spi.go
@@ -76,9 +76,9 @@ func (m Mode) String() string {
 // Packet represents one packet when sending multiple packets as a transaction.
 type Packet struct {
 	// W and R are the output and input data. When HalfDuplex is specified to
-	// DevParams, only one of the two can be set.
+	// Connect, only one of the two can be set.
 	W, R []byte
-	// BitsPerWord overrides the default bits per word value set in DevParams.
+	// BitsPerWord overrides the default bits per word value set in Connect.
 	BitsPerWord uint8
 	// KeepCS tells the driver to keep CS asserted after this packet is
 	// completed. This can be leveraged to create long transaction as multiple
@@ -93,7 +93,7 @@ type Packet struct {
 	// It cannot be expected that the driver will correctly keep CS asserted even
 	// if KeepCS:true on the last packet.
 	//
-	// KeepCS is ignored when NoCS was specified to DevParams.
+	// KeepCS is ignored when NoCS was specified to Connect.
 	KeepCS bool
 }
 
@@ -116,12 +116,12 @@ type Conn interface {
 // Port is the interface to be provided to device drivers.
 //
 // The device driver, that is the driver for the peripheral connected over
-// this port, calls DevParams() to retrieve a configured connection as Conn.
+// this port, calls Connect() to retrieve a configured connection as Conn.
 type Port interface {
-	// DevParams sets the communication parameters of the connection for use by a
+	// Connect sets the communication parameters of the connection for use by a
 	// device.
 	//
-	// The device driver must calls this function exactly once.
+	// The device driver must call this function exactly once.
 	//
 	// maxHz must specify the maximum rated speed by the device's spec. The lowest
 	// speed between the port speed and the device speed is selected. Use 0 for
@@ -129,7 +129,9 @@ type Port interface {
 	//
 	// mode specifies the clock and signal polarities, if the port is using half
 	// duplex (shared MISO and MOSI) or if CS is not needed.
-	DevParams(maxHz int64, mode Mode, bits int) (Conn, error)
+	//
+	// bits is the number of bits per word. Generally you should use 8.
+	Connect(maxHz int64, mode Mode, bits int) (Conn, error)
 }
 
 // PortCloser is a SPI port that can be closed.

--- a/conn/spi/spireg/spireg_test.go
+++ b/conn/spi/spireg/spireg_test.go
@@ -62,7 +62,7 @@ func ExampleOpen() {
 	defer b.Close()
 
 	// Pass b to a device driver, or if using b directly, do:
-	c, err := b.DevParams(1000000, spi.Mode3, 8)
+	c, err := b.Connect(1000000, spi.Mode3, 8)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -229,7 +229,7 @@ func (f *fakePort) LimitSpeed(maxHz int64) error {
 	return errors.New("not implemented")
 }
 
-func (f *fakePort) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+func (f *fakePort) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	return f, errors.New("not implemented")
 }
 

--- a/conn/spi/spismoketest/spismoketest.go
+++ b/conn/spi/spismoketest/spismoketest.go
@@ -57,7 +57,7 @@ func (s *SmokeTest) Run(args []string) error {
 	defer spiDev.Close()
 
 	// Set SPI parameters.
-	c, err := spiDev.DevParams(4000000, spi.Mode0, 8)
+	c, err := spiDev.Connect(4000000, spi.Mode0, 8)
 	if err != nil {
 		return fmt.Errorf("error setting SPI parameters: %v", err)
 	}

--- a/conn/spi/spitest/spitest.go
+++ b/conn/spi/spitest/spitest.go
@@ -41,12 +41,12 @@ func (r *RecordRaw) LimitSpeed(maxHz int64) error {
 	return nil
 }
 
-// DevParams is a no-op.
-func (r *RecordRaw) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+// Connect is a no-op.
+func (r *RecordRaw) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	r.Lock()
 	defer r.Unlock()
 	if r.Initialized {
-		return nil, conntest.Errorf("spitest: DevParams cannot be called twice")
+		return nil, conntest.Errorf("spitest: Connect cannot be called twice")
 	}
 	r.Initialized = true
 	return &recordRawConn{r}, nil
@@ -104,16 +104,16 @@ func (r *Record) LimitSpeed(maxHz int64) error {
 	return nil
 }
 
-// DevParams implements spi.PortCloser.
-func (r *Record) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+// Connect implements spi.PortCloser.
+func (r *Record) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	r.Lock()
 	defer r.Unlock()
 	if r.Initialized {
-		return nil, conntest.Errorf("spitest: DevParams cannot be called twice")
+		return nil, conntest.Errorf("spitest: Connect cannot be called twice")
 	}
 	r.Initialized = true
 	if r.Port != nil {
-		c, err := r.Port.DevParams(maxHz, mode, bits)
+		c, err := r.Port.Connect(maxHz, mode, bits)
 		if err != nil {
 			return nil, err
 		}
@@ -253,10 +253,10 @@ func (p *Playback) LimitSpeed(maxHz int64) error {
 	return nil
 }
 
-// DevParams implements spi.PortCloser.
-func (p *Playback) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+// Connect implements spi.PortCloser.
+func (p *Playback) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	if p.Initialized {
-		return nil, conntest.Errorf("spitest: DevParams cannot be called twice")
+		return nil, conntest.Errorf("spitest: Connect cannot be called twice")
 	}
 	p.Initialized = true
 	return &playbackConn{p}, nil
@@ -339,10 +339,10 @@ func (l *Log) LimitSpeed(maxHz int64) error {
 	return err
 }
 
-// DevParams implements spi.PortCloser.
-func (l *Log) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
-	c, err := l.Port.DevParams(maxHz, mode, bits)
-	log.Printf("%s.DevParams(%d, %d, %d) = %v", l.Port, maxHz, mode, bits, err)
+// Connect implements spi.PortCloser.
+func (l *Log) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+	c, err := l.Port.Connect(maxHz, mode, bits)
+	log.Printf("%s.Connect(%d, %d, %d) = %v", l.Port, maxHz, mode, bits, err)
 	return &LogConn{c}, err
 }
 

--- a/conn/spi/spitest/spitest_test.go
+++ b/conn/spi/spitest/spitest_test.go
@@ -23,7 +23,7 @@ func TestRecordRaw(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	c, err := r.DevParams(0, spi.Mode0, 0)
+	c, err := r.Connect(0, spi.Mode0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestRecord_empty(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	c, err := r.DevParams(0, spi.Mode0, 0)
+	c, err := r.Connect(0, spi.Mode0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestRecord_empty(t *testing.T) {
 
 func TestRecord_Tx_empty(t *testing.T) {
 	r := Record{}
-	c, err := r.DevParams(0, spi.Mode0, 8)
+	c, err := r.Connect(0, spi.Mode0, 8)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestPlayback(t *testing.T) {
 	if err := p.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	c, err := p.DevParams(0, spi.Mode0, 0)
+	c, err := p.Connect(0, spi.Mode0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +127,7 @@ func TestPlayback_Tx_err(t *testing.T) {
 			DontPanic: true,
 		},
 	}
-	c, err := p.DevParams(0, spi.Mode0, 8)
+	c, err := p.Connect(0, spi.Mode0, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestPlayback_Tx_err(t *testing.T) {
 
 func TestPlayback_Tx_empty(t *testing.T) {
 	p := Playback{Playback: conntest.Playback{DontPanic: true}}
-	c, err := p.DevParams(0, spi.Mode0, 8)
+	c, err := p.Connect(0, spi.Mode0, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +159,7 @@ func TestPlayback_Tx(t *testing.T) {
 			Ops: []conntest.IO{{W: []byte{10}, R: []byte{12}}},
 		},
 	}
-	c, err := p.DevParams(0, spi.Mode0, 8)
+	c, err := p.Connect(0, spi.Mode0, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestRecord_Playback(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	c, err := r.DevParams(0, spi.Mode0, 8)
+	c, err := r.Connect(0, spi.Mode0, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestLog_Playback(t *testing.T) {
 	if err := r.LimitSpeed(-100); err != nil {
 		t.Fatal(err)
 	}
-	c, err := r.DevParams(0, spi.Mode0, 0)
+	c, err := r.Connect(0, spi.Mode0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/devices/apa102/apa102.go
+++ b/devices/apa102/apa102.go
@@ -294,7 +294,7 @@ func (d *Dev) Halt() error {
 // https://en.wikipedia.org/wiki/Flicker_fusion_threshold is a recommended
 // reading.
 func New(p spi.Port, numLights int, intensity uint8, temperature uint16) (*Dev, error) {
-	c, err := p.DevParams(20000000, spi.Mode3, 8)
+	c, err := p.Connect(20000000, spi.Mode3, 8)
 	if err != nil {
 		return nil, err
 	}

--- a/devices/apa102/apa102_test.go
+++ b/devices/apa102/apa102_test.go
@@ -340,9 +340,9 @@ func TestDevEmpty(t *testing.T) {
 	}
 }
 
-func TestDevParamsFail(t *testing.T) {
+func TestConnectFail(t *testing.T) {
 	if d, err := New(&configFail{}, 150, 255, 6500); d != nil || err == nil {
-		t.Fatal("DevParams() call have failed")
+		t.Fatal("Connect() call have failed")
 	}
 }
 
@@ -703,7 +703,7 @@ type configFail struct {
 	spitest.Record
 }
 
-func (c *configFail) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+func (c *configFail) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	return nil, errors.New("injected error")
 }
 

--- a/devices/bme280/bme280.go
+++ b/devices/bme280/bme280.go
@@ -175,7 +175,7 @@ func NewI2C(b i2c.Bus, opts *Opts) (*Dev, error) {
 // When using SPI, the CS line must be used.
 func NewSPI(p spi.Port, opts *Opts) (*Dev, error) {
 	// It works both in Mode0 and Mode3.
-	c, err := p.DevParams(10000000, spi.Mode3, 8)
+	c, err := p.Connect(10000000, spi.Mode3, 8)
 	if err != nil {
 		return nil, err
 	}

--- a/devices/bme280/bme280_test.go
+++ b/devices/bme280/bme280_test.go
@@ -105,7 +105,7 @@ func TestSPISense_success(t *testing.T) {
 
 func TestNewSPI_fail(t *testing.T) {
 	if d, err := NewSPI(&spiFail{}, nil); d != nil || err == nil {
-		t.Fatal("DevParams() have failed")
+		t.Fatal("Connect() have failed")
 	}
 }
 
@@ -545,6 +545,6 @@ type spiFail struct {
 	spitest.Playback
 }
 
-func (s *spiFail) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+func (s *spiFail) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	return nil, errors.New("failing")
 }

--- a/devices/lepton/lepton.go
+++ b/devices/lepton/lepton.go
@@ -84,7 +84,7 @@ type Dev struct {
 // New returns an initialized connection to the FLIR Lepton.
 //
 // The CS line is manually managed by using mode spi.NoCS when calling
-// DevParams(). In this case pass nil for the cs parameter. Some spidev drivers
+// Connect(). In this case pass nil for the cs parameter. Some spidev drivers
 // refuse spi.NoCS, they do not implement proper support to not trigger the CS
 // line so a manual CS (really, any GPIO pin) must be used instead.
 //
@@ -112,7 +112,7 @@ func New(p spi.Port, i i2c.Bus, cs gpio.PinOut) (*Dev, error) {
 	}
 	// TODO(maruel): Switch to 16 bits per word, so that big endian 16 bits word
 	// decoding is done by the SPI driver.
-	s, err := p.DevParams(20000000, mode, 8)
+	s, err := p.Connect(20000000, mode, 8)
 	if err != nil {
 		return nil, err
 	}

--- a/devices/lepton/lepton_test.go
+++ b/devices/lepton/lepton_test.go
@@ -144,11 +144,11 @@ func TestNew_fail_no_Pins(t *testing.T) {
 	}
 }
 
-func TestNew_DevParams(t *testing.T) {
+func TestNew_Connect(t *testing.T) {
 	i := i2ctest.Record{}
 	s := spiStream{err: errors.New("injected")}
 	if _, err := New(&s, &i, &gpiotest.Pin{N: "CS"}); err == nil {
-		t.Fatal("DevParams failed")
+		t.Fatal("Connect failed")
 	}
 }
 
@@ -370,7 +370,7 @@ type spiStream struct {
 	err    error
 }
 
-func (s *spiStream) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+func (s *spiStream) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	if maxHz != 20000000 {
 		s.t.Fatal(maxHz)
 	}

--- a/devices/ssd1306/ssd1306.go
+++ b/devices/ssd1306/ssd1306.go
@@ -133,7 +133,7 @@ func NewSPI(p spi.Port, dc gpio.PinOut, w, h int, rotated bool) (*Dev, error) {
 	} else if err := dc.Out(gpio.Low); err != nil {
 		return nil, err
 	}
-	c, err := p.DevParams(3300000, spi.Mode0, bits)
+	c, err := p.Connect(3300000, spi.Mode0, bits)
 	if err != nil {
 		return nil, err
 	}

--- a/devices/ssd1306/ssd1306_test.go
+++ b/devices/ssd1306/ssd1306_test.go
@@ -576,7 +576,7 @@ type configFail struct {
 	spitest.Record
 }
 
-func (c *configFail) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+func (c *configFail) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	return nil, errors.New("injected error")
 }
 

--- a/experimental/devices/bitbang/spi.go
+++ b/experimental/devices/bitbang/spi.go
@@ -67,8 +67,8 @@ func (s *SPI) LimitSpeed(maxHz int64) error {
 	return nil
 }
 
-// DevParams implements spi.Conn.
-func (s *SPI) DevParams(maxHz int64, mode spi.Mode, bits int) error {
+// Connect implements spi.Conn.
+func (s *SPI) Connect(maxHz int64, mode spi.Mode, bits int) error {
 	if maxHz < 0 {
 		return errors.New("bitbang-spi: invalid maxHz")
 	}

--- a/host/sysfs/spi.go
+++ b/host/sysfs/spi.go
@@ -99,10 +99,10 @@ func (s *SPI) LimitSpeed(maxHz int64) error {
 	return nil
 }
 
-// DevParams implements spi.Port.
+// Connect implements spi.Port.
 //
 // It must be called before any I/O.
-func (s *SPI) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
+func (s *SPI) Connect(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) {
 	if maxHz < 0 || maxHz >= 1<<32 {
 		return nil, fmt.Errorf("sysfs-spi: invalid speed %d", maxHz)
 	}
@@ -115,7 +115,7 @@ func (s *SPI) DevParams(maxHz int64, mode spi.Mode, bits int) (spi.Conn, error) 
 	s.Lock()
 	defer s.Unlock()
 	if s.initialized {
-		return nil, errors.New("sysfs-spi: DevParams() can only be called exactly once")
+		return nil, errors.New("sysfs-spi: Connect() can only be called exactly once")
 	}
 	s.initialized = true
 	s.maxHzDev = uint32(maxHz)
@@ -196,7 +196,7 @@ func (s *SPI) txInternal(w, r []byte) (int, error) {
 	s.Lock()
 	defer s.Unlock()
 	if !s.initialized {
-		return 0, errors.New("sysfs-spi: DevParams wasn't called")
+		return 0, errors.New("sysfs-spi: Connect wasn't called")
 	}
 	if len(w) != 0 && len(r) != 0 && s.halfDuplex {
 		return 0, errors.New("sysfs-spi: can only specify one of w or r when in half duplex")
@@ -248,7 +248,7 @@ func (s *SPI) txPackets(p []spi.Packet) error {
 	s.Lock()
 	defer s.Unlock()
 	if !s.initialized {
-		return errors.New("sysfs-spi: DevParams wasn't called")
+		return errors.New("sysfs-spi: Connect wasn't called")
 	}
 	// Convert the packets.
 	speed := s.maxHzPort

--- a/host/sysfs/spi_test.go
+++ b/host/sysfs/spi_test.go
@@ -21,7 +21,7 @@ func ExampleNewSPI() {
 	}
 	defer b.Close()
 
-	c, err := b.DevParams(1000000, spi.Mode3, 8)
+	c, err := b.Connect(1000000, spi.Mode3, 8)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func TestNewSPI(t *testing.T) {
 
 func TestSPI_IO(t *testing.T) {
 	port := SPI{f: ioctlClose(0), busNumber: 24}
-	c, err := port.DevParams(1, spi.Mode3, 8)
+	c, err := port.Connect(1, spi.Mode3, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -149,23 +149,23 @@ func TestSPI_other(t *testing.T) {
 	}
 }
 
-func TestSPI_DevParams(t *testing.T) {
+func TestSPI_Connect(t *testing.T) {
 	// Create a fake SPI to test methods.
 	port := SPI{f: ioctlClose(0), busNumber: 24}
-	if _, err := port.DevParams(-1, spi.Mode0, 8); err == nil {
+	if _, err := port.Connect(-1, spi.Mode0, 8); err == nil {
 		t.Fatal("invalid speed")
 	}
-	if _, err := port.DevParams(1, -1, 8); err == nil {
+	if _, err := port.Connect(1, -1, 8); err == nil {
 		t.Fatal("invalid mode")
 	}
-	if _, err := port.DevParams(1, spi.Mode0, 0); err == nil {
+	if _, err := port.Connect(1, spi.Mode0, 0); err == nil {
 		t.Fatal("invalid bit")
 	}
-	c, err := port.DevParams(1, spi.Mode0|spi.HalfDuplex|spi.NoCS|spi.LSBFirst, 8)
+	c, err := port.Connect(1, spi.Mode0|spi.HalfDuplex|spi.NoCS|spi.LSBFirst, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := port.DevParams(1, spi.Mode0, 8); err == nil {
+	if _, err := port.Connect(1, spi.Mode0, 8); err == nil {
 		t.Fatal("double initialization")
 	}
 	if d := c.Duplex(); d != conn.Half {


### PR DESCRIPTION
It better conveys the purpose of the function, which is to create a Conn over a
Port.

This should be the last breaking change before v2.0.0 release.