### PR TITLE
gpioreg: Remove ByNumber()

### DIFF
--- a/conn/gpio/gpio_test.go
+++ b/conn/gpio/gpio_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func ExamplePinIn() {
-	//p := gpioreg.ByNumber(6)
+	//p := gpioreg.ByName("GPIO6")
 	var p PinIn
 	if err := p.In(PullDown, RisingEdge); err != nil {
 		log.Fatal(err)
@@ -24,7 +24,7 @@ func ExamplePinIn() {
 }
 
 func ExamplePinOut() {
-	//p := gpioreg.ByNumber(6)
+	//p := gpioreg.ByName("GPIO6")
 	var p PinOut
 	if err := p.Out(High); err != nil {
 		log.Fatal(err)

--- a/conn/gpio/gpioreg/gpioreg.go
+++ b/conn/gpio/gpioreg/gpioreg.go
@@ -14,23 +14,13 @@ import (
 	"periph.io/x/periph/conn/gpio"
 )
 
-// ByNumber returns a GPIO pin from its number.
+// ByName returns a GPIO pin from its name, gpio number or one of its aliases.
 //
-// Returns nil in case the pin is not present.
-func ByNumber(number int) gpio.PinIO {
-	mu.Lock()
-	defer mu.Unlock()
-	return getByNumber(number)
-}
-
-// ByName returns a GPIO pin from its name.
+// For example on a Raspberry Pi, the following values will return the same
+// GPIO: the gpio as a number "2", the chipset name "GPIO2", the board pin
+// position "P1_3", it's function name "I2C1_SDA".
 //
-// This can be strings like GPIO2, PB8, etc.
-//
-// This function parses string representation of numbers, calling with "6"
-// returns the pin registered as number 6.
-//
-// Returns nil in case the pin is not present.
+// Returns nil if the gpio pin is not present.
 func ByName(name string) gpio.PinIO {
 	mu.Lock()
 	defer mu.Unlock()
@@ -43,7 +33,8 @@ func ByName(name string) gpio.PinIO {
 //
 // This list excludes aliases.
 //
-// This list excludes non-GPIO pins like GROUND, V3_3, etc.
+// This list excludes non-GPIO pins like GROUND, V3_3, etc, since they are not
+// GPIO.
 func All() []gpio.PinIO {
 	mu.Lock()
 	defer mu.Unlock()

--- a/conn/gpio/gpioreg/gpioreg_test.go
+++ b/conn/gpio/gpioreg/gpioreg_test.go
@@ -49,14 +49,6 @@ func ExampleByName_number() {
 	fmt.Printf("%s: %s\n", p, p.Function())
 }
 
-func ExampleByNumber() {
-	p := ByNumber(6)
-	if p == nil {
-		log.Fatal("Failed to find #6")
-	}
-	fmt.Printf("%s: %s\n", p, p.Function())
-}
-
 func TestRegister(t *testing.T) {
 	defer reset()
 	// Low priority pin.
@@ -87,12 +79,6 @@ func TestRegister(t *testing.T) {
 	}
 	if a := Aliases(); len(a) != 0 {
 		t.Fatalf("Expected zero alias, got %v", a)
-	}
-	if ByNumber(0) == nil {
-		t.Fatal("failed to get pin #0")
-	}
-	if ByNumber(1) != nil {
-		t.Fatal("there is no get pin #1")
 	}
 	if ByName("a") == nil {
 		t.Fatal("failed to get pin 'a'")
@@ -168,8 +154,8 @@ func TestRegisterAlias(t *testing.T) {
 		t.Fatal("can't register a pin implementing RealPin")
 	}
 
-	if ByNumber(0) == nil {
-		t.Fatal("getByNumber for low priority pin")
+	if ByName("0") == nil {
+		t.Fatal("getByName for low priority pin")
 	}
 }
 

--- a/conn/gpio/gpiotest/gpiotest_test.go
+++ b/conn/gpio/gpiotest/gpiotest_test.go
@@ -71,21 +71,18 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func TestByNumber(t *testing.T) {
-	if gpioreg.ByNumber(1) != nil {
-		t.Fatal("1 exist")
-	}
-	if gpioreg.ByNumber(2) != gpio2 {
-		t.Fatal("2 missing")
-	}
-}
-
 func TestByName(t *testing.T) {
 	if gpioreg.ByName("GPIO0") != nil {
 		t.Fatal("GPIO0 doesn't exist")
 	}
 	if gpioreg.ByName("GPIO2") != gpio2 {
 		t.Fatal("GPIO2 should have been found")
+	}
+	if gpioreg.ByName("1") != nil {
+		t.Fatal("1 exist")
+	}
+	if gpioreg.ByName("2") != gpio2 {
+		t.Fatal("2 missing")
 	}
 }
 

--- a/devices/tm1637/tm1637_test.go
+++ b/devices/tm1637/tm1637_test.go
@@ -20,7 +20,7 @@ func Example() {
 	if _, err := host.Init(); err != nil {
 		log.Fatalf("failed to initialize periph: %v", err)
 	}
-	dev, err := New(gpioreg.ByNumber(6), gpioreg.ByNumber(12))
+	dev, err := New(gpioreg.ByName("GPIO6"), gpioreg.ByName("GPIO12"))
 	if err != nil {
 		log.Fatalf("failed to initialize tm1637: %v", err)
 	}

--- a/host/chip/chipsmoketest/chipsmoketest.go
+++ b/host/chip/chipsmoketest/chipsmoketest.go
@@ -9,6 +9,7 @@ package chipsmoketest
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	"periph.io/x/periph/conn/gpio"
 	"periph.io/x/periph/conn/gpio/gpioreg"
@@ -77,7 +78,7 @@ func testChipHeaders() error {
 func testChipGpioNumbers() error {
 	must := map[int]string{34: "PB2", 108: "PD12", 139: "PE11", 1022: "GPIO1022"}
 	for number, name := range must {
-		pin := gpioreg.ByNumber(number)
+		pin := gpioreg.ByName(strconv.Itoa(number))
 		if pin == nil {
 			return fmt.Errorf("could not get gpio pin %d (should be %s)", number, name)
 		}
@@ -236,7 +237,7 @@ func pinByName(name string) (gpio.PinIO, error) {
 
 // pinByNumber gets a *sysfs* pin by number and calls Fatal if it fails
 func pinByNumber(n int) (gpio.PinIO, error) {
-	p, err := sysfs.PinByNumber(n)
+	p := sysfs.Pins[n]
 	if p == nil {
 		return nil, fmt.Errorf("Failed to open sysfs(%d): %s", n, err)
 	}

--- a/host/odroidc1/odroidc1smoketest/odroidc1smoketest.go
+++ b/host/odroidc1/odroidc1smoketest/odroidc1smoketest.go
@@ -9,6 +9,7 @@ package odroidc1smoketest
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
 	"periph.io/x/periph/conn/gpio"
 	"periph.io/x/periph/conn/gpio/gpioreg"
@@ -61,7 +62,7 @@ func testOdroidC1GpioNumbers() error {
 	must := map[int]string{74: "I2CA_SDA", 75: "I2CA_SCL", 76: "I2CB_SDA", 77: "I2C_SCL",
 		107: "SPI0_MOSI", 106: "SPI0_MISO", 105: "SPI0_SCLK", 117: "SPI0_CS0"}
 	for number, name := range must {
-		pin := gpioreg.ByNumber(number)
+		pin := gpioreg.ByName(strconv.Itoa(number))
 		if pin == nil {
 			return fmt.Errorf("could not get gpio pin %d (should be %s)", number, name)
 		}


### PR DESCRIPTION
It is still possible to get a pin by its logical number using the string
representation, but the function is not exported anymore.

This simplifies the interface, one less way to do the same thing.