### PR TITLE
gpiostream: add PinIn and PinOut, add fakes.

### DIFF
--- a/conn/gpio/gpiostream/gpiostream.go
+++ b/conn/gpio/gpiostream/gpiostream.go
@@ -8,6 +8,8 @@ package gpiostream
 import (
 	"sort"
 	"time"
+
+	"periph.io/x/periph/conn/gpio"
 )
 
 // Stream is the interface to define a generic stream
@@ -53,7 +55,7 @@ func (b *BitStream) Duration() time.Duration {
 //
 // This struct is more efficient than BitStream for repetitive pulses, like
 // controlling a servo. A PWM can be created by specifying a slice of twice the
-// same resolution and make it looping.
+// same resolution and make it looping via a Program.
 type EdgeStream struct {
 	// Edges is the list of Level change. It is assumed that the signal starts
 	// with gpio.High. Use a duration of 0 to start with a Low.
@@ -135,6 +137,32 @@ func (p *Program) Duration() time.Duration {
 	}
 	return d
 }
+
+//
+
+// PinIn allows to read a bit stream from a pin.
+//
+// Caveat: This interface doesn't enable sampling multiple pins in a
+// synchronized way or reading in a continuous uninterrupted way. As such, it
+// should be considered experimental.
+type PinIn interface {
+	StreamIn(p gpio.Pull, b *BitStream) error
+}
+
+// PinOut allows to stream to a pin.
+//
+// The Stream may be a Program, a BitStream or an EdgeStream. If it is a
+// Program that is an infinite loop, a separate goroutine can be used to cancel
+// the program. In this case StreamOut() returns without an error.
+//
+// Caveat: This interface doesn't enable streaming to multiple pins in a
+// synchronized way or reading in a continuous uninterrupted way. As such, it
+// should be considered experimental.
+type PinOut interface {
+	StreamOut(s Stream) error
+}
+
+//
 
 var _ Stream = &BitStream{}
 var _ Stream = &EdgeStream{}

--- a/conn/gpio/gpiostream/gpiostreamtest/gpiostreamtest.go
+++ b/conn/gpio/gpiostream/gpiostreamtest/gpiostreamtest.go
@@ -1,0 +1,184 @@
+// Copyright 2017 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package gpiostreamtest enables testing device driver using gpiostream.PinIn or PinOut.
+package gpiostreamtest
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"sync"
+	"time"
+
+	"periph.io/x/periph/conn/conntest"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpiostream"
+)
+
+// InOp represents an expected replay StreamIn operation.
+type InOp struct {
+	gpio.Pull
+	gpiostream.BitStream
+}
+
+// PinIn implements gpiostream.PinIn.
+//
+// Embed in a struct with gpiotest.Pin for more functionality.
+type PinIn struct {
+	sync.Mutex
+	N         string
+	DontPanic bool
+	Ops       []InOp
+	Count     int
+}
+
+// Close verifies that all the expected Ops have been consumed.
+func (p *PinIn) Close() error {
+	p.Lock()
+	defer p.Unlock()
+	if len(p.Ops) != p.Count {
+		return errorf(p.DontPanic, "gpiostreamtest: expected playback to be empty: I/O count %d; expected %d", p.Count, len(p.Ops))
+	}
+	return nil
+}
+
+func (p *PinIn) String() string {
+	p.Lock()
+	defer p.Unlock()
+	return p.N
+}
+
+// StreamIn implements gpiostream.PinIn.
+func (p *PinIn) StreamIn(pull gpio.Pull, b *gpiostream.BitStream) error {
+	p.Lock()
+	defer p.Unlock()
+	if len(p.Ops) <= p.Count {
+		return errorf(p.DontPanic, "gpiostreamtest: unexpected StreamIn() (count #%d) expecting %#v", p.Count, b)
+	}
+	if b.Res != p.Ops[p.Count].BitStream.Res {
+		return errorf(p.DontPanic, "gpiostreamtest: unexpected StreamIn() Res (count #%d) expected %s, got %s", p.Count, p.Ops[p.Count].BitStream.Res, b.Res)
+	}
+	if len(b.Bits) != len(p.Ops[p.Count].BitStream.Bits) {
+		return errorf(p.DontPanic, "gpiostreamtest: unexpected StreamIn() len(Bits) (count #%d) expected %d, got %d", p.Count, len(p.Ops[p.Count].BitStream.Bits), len(b.Bits))
+	}
+	if pull != p.Ops[p.Count].Pull {
+		return errorf(p.DontPanic, "gpiostreamtest: unexpected StreamIn() pull (count #%d) expected %s, got %s", p.Count, p.Ops[p.Count].Pull, pull)
+	}
+	copy(b.Bits, p.Ops[p.Count].Bits)
+	p.Count++
+	return nil
+}
+
+// PinOutPlayback implements gpiostream.PinOut.
+//
+// Embed in a struct with gpiotest.Pin for more functionality.
+type PinOutPlayback struct {
+	sync.Mutex
+	N         string
+	DontPanic bool
+	Ops       []gpiostream.Stream
+	Count     int
+}
+
+// Close verifies that all the expected Ops have been consumed.
+func (p *PinOutPlayback) Close() error {
+	p.Lock()
+	defer p.Unlock()
+	if len(p.Ops) != p.Count {
+		return errorf(p.DontPanic, "gpiostreamtest: expected playback to be empty: I/O count %d; expected %d", p.Count, len(p.Ops))
+	}
+	return nil
+}
+
+func (p *PinOutPlayback) String() string {
+	return p.N
+}
+
+// StreamOut implements gpiostream.PinOut.
+func (p *PinOutPlayback) StreamOut(s gpiostream.Stream) error {
+	p.Lock()
+	defer p.Unlock()
+	if len(p.Ops) <= p.Count {
+		return errorf(p.DontPanic, "gpiostreamtest: unexpected StreamOut() (count #%d) expecting %#v", p.Count, s)
+	}
+	if !reflect.DeepEqual(s, p.Ops[p.Count]) {
+		return errorf(p.DontPanic, "gpiostreamtest: unexpected StreamOut() content (count #%d) expected %#v, got %#v", p.Count, p.Ops[p.Count], s)
+	}
+	p.Count++
+	return nil
+}
+
+// PinOutRecord implements gpiostream.PinOut that records operations.
+//
+// Embed in a struct with gpiotest.Pin for more functionality.
+type PinOutRecord struct {
+	sync.Mutex
+	N         string
+	DontPanic bool
+	Ops       []gpiostream.Stream
+}
+
+func (p *PinOutRecord) String() string {
+	return p.N
+}
+
+// StreamOut implements gpiostream.PinOut.
+func (p *PinOutRecord) StreamOut(s gpiostream.Stream) error {
+	p.Lock()
+	defer p.Unlock()
+	d, err := deepCopy(s)
+	if err != nil {
+		return errorf(p.DontPanic, "gpiostreamtest: %s", err)
+	}
+	p.Ops = append(p.Ops, d)
+	return nil
+}
+
+//
+
+// errorf is the internal implementation that optionally panic.
+//
+// If dontPanic is false, it panics instead.
+func errorf(dontPanic bool, format string, a ...interface{}) error {
+	err := conntest.Errorf(format, a...)
+	if !dontPanic {
+		panic(err)
+	}
+	return err
+}
+
+func deepCopy(s gpiostream.Stream) (gpiostream.Stream, error) {
+	switch t := s.(type) {
+	case *gpiostream.BitStream:
+		o := &gpiostream.BitStream{Bits: make(gpiostream.Bits, len(t.Bits)), Res: t.Res}
+		copy(o.Bits, t.Bits)
+		return o, nil
+	case *gpiostream.EdgeStream:
+		o := &gpiostream.EdgeStream{Edges: make([]time.Duration, len(t.Edges)), Res: t.Res}
+		copy(o.Edges, t.Edges)
+		return o, nil
+	case *gpiostream.Program:
+		o := &gpiostream.Program{Loops: t.Loops}
+		for _, p := range t.Parts {
+			x, err := deepCopy(p)
+			if err != nil {
+				return nil, err
+			}
+			o.Parts = append(o.Parts, x)
+		}
+		return o, nil
+	default:
+		return nil, fmt.Errorf("invalid type %T", s)
+	}
+}
+
+var _ io.Closer = &PinIn{}
+var _ io.Closer = &PinOutPlayback{}
+var _ fmt.Stringer = &PinIn{}
+var _ fmt.Stringer = &PinOutPlayback{}
+var _ fmt.Stringer = &PinOutRecord{}
+var _ gpiostream.PinIn = &PinIn{}
+var _ gpiostream.PinOut = &PinOutPlayback{}
+var _ gpiostream.PinOut = &PinOutRecord{}

--- a/conn/gpio/gpiostream/gpiostreamtest/gpiostreamtest_test.go
+++ b/conn/gpio/gpiostream/gpiostreamtest/gpiostreamtest_test.go
@@ -1,0 +1,164 @@
+// Copyright 2017 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package gpiostreamtest
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"periph.io/x/periph/conn/conntest"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpiostream"
+)
+
+func TestPinIn(t *testing.T) {
+	p := &PinIn{
+		N:   "Yo",
+		Ops: []InOp{{BitStream: gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}, Pull: gpio.PullNoChange}},
+	}
+	b := gpiostream.BitStream{Res: time.Second, Bits: make(gpiostream.Bits, 1)}
+	if err := p.StreamIn(gpio.PullNoChange, &b); err != nil {
+		t.Fatal(err)
+	}
+	if s := p.String(); s != "Yo" {
+		t.Fatal(s)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPinIn_fail_res(t *testing.T) {
+	p := &PinIn{
+		Ops:       []InOp{{BitStream: gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}, Pull: gpio.PullNoChange}},
+		DontPanic: true,
+	}
+	b := gpiostream.BitStream{Res: time.Minute, Bits: make(gpiostream.Bits, 1)}
+	if p.StreamIn(gpio.PullNoChange, &b) == nil {
+		t.Fatal("different res")
+	}
+	if p.Close() == nil {
+		t.Fatal("Count doesn't match Ops")
+	}
+}
+
+func TestPinIn_fail_len(t *testing.T) {
+	p := &PinIn{
+		Ops:       []InOp{{BitStream: gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}, Pull: gpio.PullNoChange}},
+		DontPanic: true,
+	}
+	b := gpiostream.BitStream{Res: time.Second, Bits: make(gpiostream.Bits, 2)}
+	if p.StreamIn(gpio.PullNoChange, &b) == nil {
+		t.Fatal("different len")
+	}
+}
+
+func TestPinIn_fail_pull(t *testing.T) {
+	p := &PinIn{
+		Ops:       []InOp{{BitStream: gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}, Pull: gpio.PullNoChange}},
+		DontPanic: true,
+	}
+	b := gpiostream.BitStream{Res: time.Second, Bits: make(gpiostream.Bits, 1)}
+	if p.StreamIn(gpio.PullDown, &b) == nil {
+		t.Fatal("different pull")
+	}
+	if p.Close() == nil {
+		t.Fatal("Count doesn't match Ops")
+	}
+}
+
+func TestPinIn_fail_count(t *testing.T) {
+	p := &PinIn{
+		Ops:       []InOp{{BitStream: gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}, Pull: gpio.PullNoChange}},
+		Count:     1,
+		DontPanic: true,
+	}
+	b := gpiostream.BitStream{Res: time.Second, Bits: make(gpiostream.Bits, 1)}
+	if p.StreamIn(gpio.PullNoChange, &b) == nil {
+		t.Fatal("count too large")
+	}
+}
+
+func TestPinIn_panic_res(t *testing.T) {
+	p := &PinIn{
+		Ops: []InOp{{BitStream: gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}, Pull: gpio.PullNoChange}},
+	}
+	defer func() {
+		if err, ok := recover().(error); !ok {
+			t.Fatal("expected conntest error, got nothing")
+		} else if !conntest.IsErr(err) {
+			t.Fatalf("expected conntest error, got %v", err)
+		}
+	}()
+	b := gpiostream.BitStream{Res: time.Minute, Bits: make(gpiostream.Bits, 1)}
+	if p.StreamIn(gpio.PullNoChange, &b) == nil {
+		t.Fatal("different res")
+	}
+}
+
+//
+
+func TestPinOutPlayback(t *testing.T) {
+	p := &PinOutPlayback{N: "Yo", Ops: []gpiostream.Stream{&gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}}}
+	if err := p.StreamOut(&gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}); err != nil {
+		t.Fatal(err)
+	}
+	if s := p.String(); s != "Yo" {
+		t.Fatal(s)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPinOutPlayback_fail(t *testing.T) {
+	p := &PinOutPlayback{DontPanic: true}
+	if p.StreamOut(&gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}) == nil {
+		t.Fatal("expected failure")
+	}
+	p = &PinOutPlayback{DontPanic: true, Ops: []gpiostream.Stream{&gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}}}
+	if p.StreamOut(&gpiostream.BitStream{Res: time.Minute, Bits: gpiostream.Bits{0xCC}}) == nil {
+		t.Fatal("different Res")
+	}
+	p = &PinOutPlayback{DontPanic: true, Ops: []gpiostream.Stream{&gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}}}
+	if p.Close() == nil {
+		t.Fatal("expected failure")
+	}
+}
+
+//
+
+func TestPinOutRecord(t *testing.T) {
+	p := &PinOutRecord{N: "Yo"}
+	data := []gpiostream.Stream{
+		&gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}},
+		&gpiostream.EdgeStream{Res: time.Second, Edges: []time.Duration{time.Minute, 2 * time.Minute}},
+		&gpiostream.Program{Parts: []gpiostream.Stream{&gpiostream.BitStream{Res: time.Second, Bits: gpiostream.Bits{0xCC}}}, Loops: 2},
+	}
+	for _, line := range data {
+		if err := p.StreamOut(line); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := range p.Ops {
+		if !reflect.DeepEqual(data[i], p.Ops[i]) {
+			t.Fatalf("%d data not equal", i)
+		}
+	}
+	if s := p.String(); s != "Yo" {
+		t.Fatal(s)
+	}
+}
+
+func TestPinOutRecord_fail(t *testing.T) {
+	p := &PinOutRecord{DontPanic: true}
+	if p.StreamOut(nil) == nil {
+		t.Fatal("expected failure")
+	}
+	if p.StreamOut(&gpiostream.Program{Parts: []gpiostream.Stream{nil}}) == nil {
+		t.Fatal("expected failure")
+	}
+}


### PR DESCRIPTION
- PinIn only accepts BitStream, as supporting EdgeStream would require
  significantly more work and it's not obvious yet this would be valuable.
- Add gpiostreamtest to enable writting unit tests.