### PR TITLE
bcm283x: activate bcm283x-dma and add Pin.PWM()

### DIFF
--- a/host/bcm283x/dma.go
+++ b/host/bcm283x/dma.go
@@ -46,6 +46,7 @@ import (
 	"os"
 	"strings"
 
+	"periph.io/x/periph"
 	"periph.io/x/periph/host/pmem"
 	"periph.io/x/periph/host/videocore"
 )
@@ -762,10 +763,8 @@ func (d *driverDMA) Close() error {
 	return nil
 }
 
-/* TODO(maruel): This is intense, wait to be sure it works.
 func init() {
 	if isArm {
 		periph.MustRegister(&driverDMA{})
 	}
 }
-*/


### PR DESCRIPTION
- Uses the native PWM or one of the clock source when possible.
- This will likely be refactored later as full DMA based support is implemented
  but this won't change the API itself. Include BUG references as the
  implementation is not 100% complete yet, albeit it is safely usable and smoke
  tested.