### PR TITLE
Add smoketest benchmarks

### DIFF
--- a/cmd/periph-smoketest/main.go
+++ b/cmd/periph-smoketest/main.go
@@ -26,6 +26,7 @@ import (
 	"periph.io/x/periph/host/bcm283x/bcm283xsmoketest"
 	"periph.io/x/periph/host/chip/chipsmoketest"
 	"periph.io/x/periph/host/odroidc1/odroidc1smoketest"
+	"periph.io/x/periph/host/sysfs/sysfssmoketest"
 )
 
 // SmokeTest must be implemented by a smoke test. It will be run by this
@@ -44,7 +45,9 @@ type SmokeTest interface {
 
 // tests is the list of registered smoke tests.
 var tests = []SmokeTest{
+	&allwinnersmoketest.Benchmark{},
 	&allwinnersmoketest.SmokeTest{},
+	&bcm283xsmoketest.Benchmark{},
 	&bcm283xsmoketest.SmokeTest{},
 	&bmx280smoketest.SmokeTest{},
 	&chipsmoketest.SmokeTest{},
@@ -54,6 +57,7 @@ var tests = []SmokeTest{
 	&onewiresmoketest.SmokeTest{},
 	&spismoketest.SmokeTest{},
 	&ssd1306smoketest.SmokeTest{},
+	&sysfssmoketest.Benchmark{},
 }
 
 func usage(fs *flag.FlagSet) {

--- a/host/allwinner/allwinnersmoketest/benchmark.go
+++ b/host/allwinner/allwinnersmoketest/benchmark.go
@@ -1,0 +1,97 @@
+// Copyright 2017 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package allwinnersmoketest
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpioreg"
+	"periph.io/x/periph/host/allwinner"
+)
+
+// Benchmark is imported by periph-smoketest.
+type Benchmark struct {
+	p *allwinner.Pin
+}
+
+// Name implements the SmokeTest interface.
+func (s *Benchmark) Name() string {
+	return "allwinner-benchmark"
+}
+
+// Description implements the SmokeTest interface.
+func (s *Benchmark) Description() string {
+	return "Benchmarks allwinner functionality"
+}
+
+// Run implements the SmokeTest interface.
+func (s *Benchmark) Run(args []string) error {
+	if !allwinner.Present() {
+		return errors.New("this smoke test can only be used on a allwinner based host")
+	}
+	f := flag.NewFlagSet(s.Name(), flag.ExitOnError)
+	name := f.String("p", "", "Pin to use")
+	f.Parse(args)
+	if f.NArg() != 0 {
+		return errors.New("unsupported flags")
+	}
+
+	if *name == "" {
+		return errors.New("-p is required")
+	}
+	ok := false
+	s.p, ok = gpioreg.ByName(*name).(*allwinner.Pin)
+	if !ok {
+		return fmt.Errorf("invalid pin %q", *name)
+	}
+	printBench("Out()", testing.Benchmark(s.benchmarkOut))
+	return nil
+}
+
+func (s *Benchmark) benchmarkOut(b *testing.B) {
+	p := s.p
+	if err := p.Out(gpio.Low); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Out(gpio.High)
+		p.Out(gpio.Low)
+	}
+}
+
+//
+
+func printBench(name string, r testing.BenchmarkResult) {
+	if r.Bytes != 0 {
+		fmt.Fprintf(os.Stderr, "unexpected %d bytes written\n", r.Bytes)
+		return
+	}
+	if r.MemAllocs != 0 || r.MemBytes != 0 {
+		fmt.Fprintf(os.Stderr, "unexpected %d bytes allocated as %d calls\n", r.MemBytes, r.MemAllocs)
+		return
+	}
+	fmt.Printf("%s \t%s\t%s\n", name, r, toHz(r.N, r.T))
+}
+
+func toHz(n int, t time.Duration) string {
+	// Periph has a ban on float64 on the library but it's not too bad on unit
+	// and smoke tests.
+	hz := float64(n) * float64(time.Second) / float64(t)
+	switch {
+	case hz >= 1000000:
+		return fmt.Sprintf("%.1fMhz", hz*0.000001)
+	case hz >= 1000:
+		return fmt.Sprintf("%.1fKhz", hz*0.001)
+	default:
+		return fmt.Sprintf("%.1fhz", hz)
+	}
+}

--- a/host/bcm283x/bcm283xsmoketest/benchmark.go
+++ b/host/bcm283x/bcm283xsmoketest/benchmark.go
@@ -1,0 +1,97 @@
+// Copyright 2017 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package bcm283xsmoketest
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpioreg"
+	"periph.io/x/periph/host/bcm283x"
+)
+
+// Benchmark is imported by periph-smoketest.
+type Benchmark struct {
+	p *bcm283x.Pin
+}
+
+// Name implements the SmokeTest interface.
+func (s *Benchmark) Name() string {
+	return "bcm283x-benchmark"
+}
+
+// Description implements the SmokeTest interface.
+func (s *Benchmark) Description() string {
+	return "Benchmarks bcm283x functionality"
+}
+
+// Run implements the SmokeTest interface.
+func (s *Benchmark) Run(args []string) error {
+	if !bcm283x.Present() {
+		return errors.New("this smoke test can only be used on a bcm283x based host")
+	}
+	f := flag.NewFlagSet(s.Name(), flag.ExitOnError)
+	name := f.String("p", "", "Pin to use")
+	f.Parse(args)
+	if f.NArg() != 0 {
+		return errors.New("unsupported flags")
+	}
+
+	if *name == "" {
+		return errors.New("-p is required")
+	}
+	ok := false
+	s.p, ok = gpioreg.ByName(*name).(*bcm283x.Pin)
+	if !ok {
+		return fmt.Errorf("invalid pin %q", *name)
+	}
+	printBench("Out()", testing.Benchmark(s.benchmarkOut))
+	return nil
+}
+
+func (s *Benchmark) benchmarkOut(b *testing.B) {
+	p := s.p
+	if err := p.Out(gpio.Low); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Out(gpio.High)
+		p.Out(gpio.Low)
+	}
+}
+
+//
+
+func printBench(name string, r testing.BenchmarkResult) {
+	if r.Bytes != 0 {
+		fmt.Fprintf(os.Stderr, "unexpected %d bytes written\n", r.Bytes)
+		return
+	}
+	if r.MemAllocs != 0 || r.MemBytes != 0 {
+		fmt.Fprintf(os.Stderr, "unexpected %d bytes allocated as %d calls\n", r.MemBytes, r.MemAllocs)
+		return
+	}
+	fmt.Printf("%s \t%s\t%s\n", name, r, toHz(r.N, r.T))
+}
+
+func toHz(n int, t time.Duration) string {
+	// Periph has a ban on float64 on the library but it's not too bad on unit
+	// and smoke tests.
+	hz := float64(n) * float64(time.Second) / float64(t)
+	switch {
+	case hz >= 1000000:
+		return fmt.Sprintf("%.1fMhz", hz*0.000001)
+	case hz >= 1000:
+		return fmt.Sprintf("%.1fKhz", hz*0.001)
+	default:
+		return fmt.Sprintf("%.1fhz", hz)
+	}
+}

--- a/host/sysfs/sysfssmoketest/benchmark.go
+++ b/host/sysfs/sysfssmoketest/benchmark.go
@@ -1,0 +1,97 @@
+// Copyright 2017 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package sysfssmoketest verifies that sysfs specific functionality work.
+package sysfssmoketest
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/host/sysfs"
+)
+
+// Benchmark is imported by periph-smoketest.
+type Benchmark struct {
+	p *sysfs.Pin
+}
+
+// Name implements the SmokeTest interface.
+func (s *Benchmark) Name() string {
+	return "sysfs-benchmark"
+}
+
+// Description implements the SmokeTest interface.
+func (s *Benchmark) Description() string {
+	return "Benchmarks sysfs gpio functionality"
+}
+
+// Run implements the SmokeTest interface.
+func (s *Benchmark) Run(args []string) error {
+	f := flag.NewFlagSet(s.Name(), flag.ExitOnError)
+	num := f.Int("p", -1, "Pin number to use")
+	f.Parse(args)
+	if f.NArg() != 0 {
+		return errors.New("unsupported flags")
+	}
+
+	if *num == -1 {
+		return errors.New("-p is required")
+	}
+	if s.p = sysfs.Pins[*num]; s.p == nil {
+		list := make([]int, 0, len(sysfs.Pins))
+		for i := range sysfs.Pins {
+			list = append(list, i)
+		}
+		sort.Ints(list)
+		valid := ""
+		for i, v := range list {
+			if i == 0 {
+				valid += fmt.Sprintf("%d", v)
+			} else {
+				valid += fmt.Sprintf(", %d", v)
+			}
+		}
+		return fmt.Errorf("invalid pin %d; valid: %s", *num, valid)
+	}
+	printBench("Out()", testing.Benchmark(s.benchmarkOut))
+	return nil
+}
+
+func (s *Benchmark) benchmarkOut(b *testing.B) {
+	p := s.p
+	if err := p.Out(gpio.Low); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.Out(gpio.High)
+		p.Out(gpio.Low)
+	}
+}
+
+//
+
+func printBench(name string, r testing.BenchmarkResult) {
+	fmt.Printf("%s \t%s\t%s\n", name, r, toHz(r.N, r.T))
+}
+
+func toHz(n int, t time.Duration) string {
+	// Periph has a ban on float64 on the library but it's not too bad on unit
+	// and smoke tests.
+	hz := float64(n) * float64(time.Second) / float64(t)
+	switch {
+	case hz >= 1000000:
+		return fmt.Sprintf("%.1fMhz", hz*0.000001)
+	case hz >= 1000:
+		return fmt.Sprintf("%.1fKhz", hz*0.001)
+	default:
+		return fmt.Sprintf("%.1fhz", hz)
+	}
+}


### PR DESCRIPTION
They test the performance of the GPIO for allwinner, bcm283x and sysfs.

Outputs looks like this:
$ ./periph-smoketest bcm283x-benchmark -p 12
Out() 	 3000000	       587 ns/op	1.7Mhz
