### PR TITLE
bcm283x: boost Pin.Out perf by 25%

### DIFF
--- a/host/bcm283x/gpio.go
+++ b/host/bcm283x/gpio.go
@@ -266,11 +266,19 @@ func (p *Pin) Out(l gpio.Level) error {
 		p.usingEdge = false
 	}
 	// Change output before changing mode to not create any glitch.
-	offset := p.number / 32
+	mask := uint32(1) << uint(p.number&31)
 	if l == gpio.Low {
-		gpioMemory.outputClear[offset] = 1 << uint(p.number&31)
+		if p.number < 32 {
+			gpioMemory.outputClear[0] = mask
+		} else {
+			gpioMemory.outputClear[1] = mask
+		}
 	} else {
-		gpioMemory.outputSet[offset] = 1 << uint(p.number&31)
+		if p.number < 32 {
+			gpioMemory.outputSet[0] = mask
+		} else {
+			gpioMemory.outputSet[1] = mask
+		}
 	}
 	p.setFunction(out)
 	return nil


### PR DESCRIPTION
Timings for a full cycle (High, Low):
- RPi3:  was 610ns 1.6Mhz, now 460ns, 2.2Mhz (25%)
- RPiZW: was 585ns 1.7Mhz, now 475ns, 2.1Mhz (19%)

It seems that the boundary offset took an unreasonable amount of time compared
to the rest of the execution. Using hard coded offsets in the array with
conditions proved to be significantly faster.