### PR TITLE
bcm283x: Implement FastOut and corresponding benchmark

### DIFF
--- a/host/bcm283x/bcm283xsmoketest/benchmark.go
+++ b/host/bcm283x/bcm283xsmoketest/benchmark.go
@@ -52,8 +52,9 @@ func (s *Benchmark) Run(args []string) error {
 	if !ok {
 		return fmt.Errorf("invalid pin %q", *name)
 	}
-	printBench("In()", testing.Benchmark(s.benchmarkIn))
-	printBench("Out()", testing.Benchmark(s.benchmarkOut))
+	printBench("In()      ", testing.Benchmark(s.benchmarkIn))
+	printBench("Out()     ", testing.Benchmark(s.benchmarkOut))
+	printBench("FastOut() ", testing.Benchmark(s.benchmarkFastOut))
 	return nil
 }
 
@@ -80,6 +81,18 @@ func (s *Benchmark) benchmarkOut(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		p.Out(gpio.High)
 		p.Out(gpio.Low)
+	}
+}
+
+func (s *Benchmark) benchmarkFastOut(b *testing.B) {
+	p := s.p
+	if err := p.Out(gpio.Low); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.FastOut(gpio.High)
+		p.FastOut(gpio.Low)
 	}
 }
 

--- a/host/bcm283x/gpio.go
+++ b/host/bcm283x/gpio.go
@@ -266,6 +266,17 @@ func (p *Pin) Out(l gpio.Level) error {
 		return err
 	}
 	// Change output before changing mode to not create any glitch.
+	p.FastOut(l)
+	p.setFunction(out)
+	return nil
+}
+
+// FastOut sets a pin output level with Absolutely No error checking.
+//
+// Out() Must be called once first before calling FastOut(), otherwise the
+// behavior is undefined. Then FastOut() can be used for minimal CPU overhead
+// to reach Mhz scale bit banging.
+func (p *Pin) FastOut(l gpio.Level) {
 	mask := uint32(1) << uint(p.number&31)
 	if l == gpio.Low {
 		if p.number < 32 {
@@ -280,8 +291,6 @@ func (p *Pin) Out(l gpio.Level) error {
 			gpioMemory.outputSet[1] = mask
 		}
 	}
-	p.setFunction(out)
-	return nil
 }
 
 // Halt implements conn.Resource.


### PR DESCRIPTION
Paging @simokawa .

I started writing a blog post about it at https://github.com/periph/website/blob/blog_gpio_perf/site/content/news/2017/gpio_perf.md