### PR TITLE
allwinner: Implement FastOut()

### DIFF
--- a/host/allwinner/allwinnersmoketest/benchmark.go
+++ b/host/allwinner/allwinnersmoketest/benchmark.go
@@ -52,8 +52,9 @@ func (s *Benchmark) Run(args []string) error {
 	if !ok {
 		return fmt.Errorf("invalid pin %q", *name)
 	}
-	printBench("In()", testing.Benchmark(s.benchmarkIn))
-	printBench("Out()", testing.Benchmark(s.benchmarkOut))
+	printBench("In()     ", testing.Benchmark(s.benchmarkIn))
+	printBench("Out()    ", testing.Benchmark(s.benchmarkOut))
+	printBench("FastOut()", testing.Benchmark(s.benchmarkFastOut))
 	return nil
 }
 
@@ -80,6 +81,18 @@ func (s *Benchmark) benchmarkOut(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		p.Out(gpio.High)
 		p.Out(gpio.Low)
+	}
+}
+
+func (s *Benchmark) benchmarkFastOut(b *testing.B) {
+	p := s.p
+	if err := p.Out(gpio.Low); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		p.FastOut(gpio.High)
+		p.FastOut(gpio.Low)
 	}
 }
 

--- a/host/allwinner/gpio_pl.go
+++ b/host/allwinner/gpio_pl.go
@@ -93,13 +93,7 @@ func (p *PinPL) Function() string {
 	}
 }
 
-// In implemented gpio.PinIn.
-//
-// This requires opening a gpio sysfs file handle. The pin will be exported at
-// /sys/class/gpio/gpio*/. Note that the pin will not be unexported at
-// shutdown.
-//
-// Not all pins support edge detection Allwinner processors!
+// In implements gpio.PinIn. See Pin.In for more information.
 func (p *PinPL) In(pull gpio.Pull, edge gpio.Edge) error {
 	if gpioMemoryPL == nil {
 		return p.wrap(errors.New("subsystem not initialized"))
@@ -138,12 +132,12 @@ func (p *PinPL) In(pull gpio.Pull, edge gpio.Edge) error {
 	return nil
 }
 
-// Read implements gpio.PinIn.
+// Read implements gpio.PinIn. See Pin.Read for more information.
 func (p *PinPL) Read() gpio.Level {
 	return gpio.Level(gpioMemoryPL.data&(1<<p.offset) != 0)
 }
 
-// WaitForEdge does edge detection and implements gpio.PinIn.
+// WaitForEdge implements gpio.PinIn. See Pin.WaitForEdge for more information.
 func (p *PinPL) WaitForEdge(timeout time.Duration) bool {
 	if p.edge != nil {
 		return p.edge.WaitForEdge(timeout)
@@ -151,7 +145,7 @@ func (p *PinPL) WaitForEdge(timeout time.Duration) bool {
 	return false
 }
 
-// Pull implements gpio.PinIn.
+// Pull implements gpio.PinIn. See Pin.Pull for more information.
 func (p *PinPL) Pull() gpio.Pull {
 	if gpioMemoryPL == nil {
 		return gpio.PullNoChange
@@ -169,7 +163,7 @@ func (p *PinPL) Pull() gpio.Pull {
 	}
 }
 
-// Out implements gpio.PinOut.
+// Out implements gpio.PinOut. See Pin.Out for more information.
 func (p *PinPL) Out(l gpio.Level) error {
 	if gpioMemoryPL == nil {
 		return p.wrap(errors.New("subsystem not initialized"))
@@ -181,18 +175,23 @@ func (p *PinPL) Out(l gpio.Level) error {
 		}
 		p.usingEdge = false
 	}
+	p.FastOut(l)
 	if !p.setFunction(out) {
 		return p.wrap(errors.New("failed to set pin as output"))
 	}
-	// TODO(maruel): Set the value *before* changing the pin to be an output, so
-	// there is no glitch.
+	return nil
+}
+
+// FastOut sets a pin output level with Absolutely No error checking.
+//
+// See Pin.FastOut for more information.
+func (p *PinPL) FastOut(l gpio.Level) {
 	bit := uint32(1 << p.offset)
 	if l {
 		gpioMemoryPL.data |= bit
 	} else {
 		gpioMemoryPL.data &^= bit
 	}
-	return nil
 }
 
 // TODO(maruel): PWM support for PL10.


### PR DESCRIPTION
This raises output performance from 540kHz to 1.8MHz on a C.H.I.P.!

Include many documentation updates, especially for PinPL to reduce the
duplication of documentation, which always leads to a stale copy. :)