### PR TITLE
gpio: make all Pin implementations implement conn.Resource; fix In()

### DIFF
--- a/conn/gpio/gpio.go
+++ b/conn/gpio/gpio.go
@@ -277,6 +277,10 @@ func (invalidPin) Function() string {
 	return ""
 }
 
+func (invalidPin) Halt() error {
+	return nil
+}
+
 func (invalidPin) In(Pull, Edge) error {
 	return errInvalidPin
 }

--- a/conn/gpio/gpiotest/gpiotest.go
+++ b/conn/gpio/gpiotest/gpiotest.go
@@ -47,6 +47,13 @@ func (p *Pin) Function() string {
 	return p.Fn
 }
 
+// Halt implements conn.Resource.
+//
+// It has no effect.
+func (p *Pin) Halt() error {
+	return nil
+}
+
 // In is concurrent safe.
 func (p *Pin) In(pull gpio.Pull, edge gpio.Edge) error {
 	p.Lock()

--- a/host/sysfs/led.go
+++ b/host/sysfs/led.go
@@ -73,6 +73,13 @@ func (l *LED) Function() string {
 	return "LED/Off"
 }
 
+// Halt implements conn.Resource.
+//
+// It turns the light off.
+func (l *LED) Halt() error {
+	return l.Out(gpio.Low)
+}
+
 // In implements gpio.PinIn.
 func (l *LED) In(pull gpio.Pull, edge gpio.Edge) error {
 	if pull != gpio.Float && pull != gpio.PullNoChange {


### PR DESCRIPTION
- Halt() is going to be necessary for PWM() but it also makes sense to use
  Halt() to stop edge detection. It conceptually just make sense for any
  continuous operation.
- Changed composite Pin implementation (allwinner and bcm283x) to use an ordered
  flow to switch mode: stop edges, switch function, setup pull, setup edges.
- bcm283x: Move Halt() higher so the methods are in the same order than the
  other Pin implementations.

The interfaces will be updated in v3 as per issue #183, since this is a breaking
change.