### PR TITLE
bcm283x: add PinsRead/Clear/Set global functions

### DIFF
--- a/host/bcm283x/gpio.go
+++ b/host/bcm283x/gpio.go
@@ -82,6 +82,62 @@ func Present() bool {
 	return false
 }
 
+// PinsRead0To31 returns the value of all GPIO0 to GPIO31 at their corresponding
+// bit as a single read operation.
+//
+// This function is extremely fast and does no error checking.
+//
+// The returned bits are valid for both inputs and outputs.
+func PinsRead0To31() uint32 {
+	return gpioMemory.level[0]
+}
+
+// PinsClear0To31 clears the value of GPIO0 to GPIO31 pin for the bit set at
+// their corresponding bit as a single write operation.
+//
+// This function is extremely fast and does no error checking.
+func PinsClear0To31(mask uint32) {
+	gpioMemory.outputClear[0] = mask
+}
+
+// PinsSet0To31 sets the value of GPIO0 to GPIO31 pin for the bit set at their
+// corresponding bit as a single write operation.
+func PinsSet0To31(mask uint32) {
+	gpioMemory.outputSet[0] = mask
+}
+
+// PinsRead32To46 returns the value of all GPIO32 to GPIO46 at their
+// corresponding 'bit minus 32' as a single read operation.
+//
+// This function is extremely fast and does no error checking.
+//
+// The returned bits are valid for both inputs and outputs.
+//
+// Bits above 15 are guaranteed to be 0.
+func PinsRead32To46() uint32 {
+	return gpioMemory.level[1] & 0x7fff
+}
+
+// PinsClear32To46 clears the value of GPIO31 to GPIO46 pin for the bit set at
+// their corresponding 'bit minus 32' as a single write operation.
+//
+// This function is extremely fast and does no error checking.
+//
+// Bits above 15 are ignored.
+func PinsClear32To46(mask uint32) {
+	gpioMemory.outputClear[1] = (mask & 0x7fff)
+}
+
+// PinsSet32To46 sets the value of GPIO31 to GPIO46 pin for the bit set at
+// their corresponding 'bit minus 32' as a single write operation.
+//
+// This function is extremely fast and does no error checking.
+//
+// Bits above 15 are ignored.
+func PinsSet32To46(mask uint32) {
+	gpioMemory.outputSet[1] = (mask & 0x7fff)
+}
+
 // Pin is a GPIO number (GPIOnn) on BCM238(5|6|7).
 //
 // Pin implements gpio.PinIO.

--- a/host/bcm283x/gpio_test.go
+++ b/host/bcm283x/gpio_test.go
@@ -5,6 +5,7 @@
 package bcm283x
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,14 +14,63 @@ import (
 	"periph.io/x/periph/host/videocore"
 )
 
-func TestPresent(t *testing.T) {
-	Present()
-	if gpioMemory != nil {
-		t.Fatal("gpioMemory should not be initialized")
+func ExamplePinsRead0To31() {
+	// Print out the state of 32 GPIOs with a single read that reads all these
+	// pins all at once.
+	bits := PinsRead0To31()
+	fmt.Printf("bits: %#x\n", bits)
+	suffixes := []string{"   ", "\n"}
+	for i := uint(0); i < 32; i++ {
+		fmt.Printf("GPIO%-2d: %d%s", i, (bits>>i)&1, suffixes[(i%4)/3])
 	}
+	// Output:
+	// bits: 0x80011010
+	// GPIO0 : 0   GPIO1 : 0   GPIO2 : 0   GPIO3 : 0
+	// GPIO4 : 1   GPIO5 : 0   GPIO6 : 0   GPIO7 : 0
+	// GPIO8 : 0   GPIO9 : 0   GPIO10: 0   GPIO11: 0
+	// GPIO12: 1   GPIO13: 0   GPIO14: 0   GPIO15: 0
+	// GPIO16: 1   GPIO17: 0   GPIO18: 0   GPIO19: 0
+	// GPIO20: 0   GPIO21: 0   GPIO22: 0   GPIO23: 0
+	// GPIO24: 0   GPIO25: 0   GPIO26: 0   GPIO27: 0
+	// GPIO28: 0   GPIO29: 0   GPIO30: 0   GPIO31: 1
+}
+
+func ExamplePinsRead32To46() {
+	// Print out the state of 15 GPIOs with a single read that reads all these
+	// pins all at once.
+	bits := PinsRead32To46()
+	fmt.Printf("bits: %#x\n", bits)
+	suffixes := []string{"   ", "\n"}
+	for i := uint(0); i < (47 - 32); i++ {
+		fmt.Printf("GPIO%d: %d%s", i+32, (bits>>i)&1, suffixes[(i%4)/3])
+	}
+	// Output:
+	// bits: 0x4101
+	// GPIO32: 1   GPIO33: 0   GPIO34: 0   GPIO35: 0
+	// GPIO36: 0   GPIO37: 0   GPIO38: 0   GPIO39: 0
+	// GPIO40: 1   GPIO41: 0   GPIO42: 0   GPIO43: 0
+	// GPIO44: 0   GPIO45: 0   GPIO46: 1
+}
+
+func ExamplePinsClear0To31() {
+	// Simultaneously clears GPIO4 and GPIO16 to gpio.Low.
+	PinsClear0To31(1<<16 | 1<<4)
+}
+
+func ExamplePinsSet0To31() {
+	// Simultaneously sets GPIO4 and GPIO16 to gpio.High.
+	PinsClear0To31(1<<16 | 1<<4)
+}
+
+func TestPresent(t *testing.T) {
+	// It may return true or false, depending on hardware but it shouldn't crash.
+	Present()
 }
 
 func TestPin(t *testing.T) {
+	// Using Pin without the driver being initialized doesn't crash.
+	defer resetGPIOMemory()
+	gpioMemory = nil
 	p := Pin{name: "Foo", number: 42, defaultPull: gpio.PullDown}
 
 	if s := p.String(); s != "Foo" {
@@ -35,6 +85,7 @@ func TestPin(t *testing.T) {
 	if d := p.DefaultPull(); d != gpio.PullDown {
 		t.Fatal(d)
 	}
+	// When unitialized, Pin.function() returs alt5.
 	if s := p.Function(); s != "UART1_RTS" {
 		t.Fatal(s)
 	}
@@ -54,11 +105,7 @@ func TestPin(t *testing.T) {
 		t.Fatal("not initialized")
 	}
 
-	defer func() {
-		gpioMemory = nil
-	}()
 	gpioMemory = &gpioMap{}
-
 	if err := p.In(gpio.PullDown, gpio.NoEdge); err != nil {
 		t.Fatal(err)
 	}
@@ -142,10 +189,11 @@ func TestPin(t *testing.T) {
 func TestPinPWM(t *testing.T) {
 	defer func() {
 		clockMemory = nil
-		gpioMemory = nil
 		pwmMemory = nil
 		dmaMemory = nil
 	}()
+	defer resetGPIOMemory()
+	gpioMemory = nil
 
 	p := Pin{name: "C1", number: 4, defaultPull: gpio.PullDown}
 	if err := p.PWM(gpio.DutyHalf, 500*time.Nanosecond); err == nil || err.Error() != "bcm283x-gpio (C1): subsystem not initialized" {
@@ -191,5 +239,15 @@ func init() {
 	dmaBufAllocator = func(s int) (*videocore.Mem, error) {
 		buf := make([]byte, s)
 		return &videocore.Mem{View: &pmem.View{Slice: buf}}, nil
+	}
+	// gpioMemory is initialized so the examples are more interesting.
+	resetGPIOMemory()
+}
+
+// resetGPIOMemory resets so GPIO4, GPIO12, GPIO16, GPIO31, GPIO32, GPIO40 and
+// GPIO46 are set.
+func resetGPIOMemory() {
+	gpioMemory = &gpioMap{
+		level: [2]uint32{0x80011010, 0x4101},
 	}
 }


### PR DESCRIPTION
These CPU specific functions permits to read or change multiple GPIOs at once.