### PR TITLE
cmd: make flag processing more coherent

### DIFF
--- a/cmd/bmxx80/main.go
+++ b/cmd/bmxx80/main.go
@@ -90,6 +90,9 @@ func mainImpl() error {
 		log.SetOutput(ioutil.Discard)
 	}
 	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
 
 	s := bmxx80.O4x
 	if *sample1x {

--- a/cmd/gpio-list/main.go
+++ b/cmd/gpio-list/main.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -72,13 +73,15 @@ func mainImpl() error {
 	aliases := flag.Bool("l", false, "print aliases pins (e.g. I2C1_SCL)")
 	gpios := flag.Bool("g", false, "print GPIO pins (e.g. GPIO1) (default)")
 	invalid := flag.Bool("n", false, "show not connected/INVALID pins")
-	verbose := flag.Bool("v", false, "enable verbose logs")
+	verbose := flag.Bool("v", false, "verbose mode")
 	flag.Parse()
-
 	if !*verbose {
 		log.SetOutput(ioutil.Discard)
 	}
-	log.SetFlags(0)
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
 
 	if *all {
 		*aliases = true

--- a/cmd/gpio-read/main.go
+++ b/cmd/gpio-read/main.go
@@ -31,9 +31,8 @@ func mainImpl() error {
 	pullUp := flag.Bool("u", false, "pull up")
 	pullDown := flag.Bool("d", false, "pull down")
 	edges := flag.Bool("e", false, "wait for edges")
-	verbose := flag.Bool("v", false, "enable verbose logs")
+	verbose := flag.Bool("v", false, "verbose mode")
 	flag.Parse()
-
 	if !*verbose {
 		log.SetOutput(ioutil.Discard)
 	}

--- a/cmd/gpio-write/main.go
+++ b/cmd/gpio-write/main.go
@@ -7,7 +7,10 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"periph.io/x/periph/conn/gpio"
@@ -16,12 +19,19 @@ import (
 )
 
 func mainImpl() error {
-	if len(os.Args) != 3 {
+	verbose := flag.Bool("v", false, "verbose mode")
+	flag.Parse()
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 2 {
 		return errors.New("specify GPIO pin to write to and its level (0 or 1)")
 	}
 
+	args := flag.Args()
 	l := gpio.Low
-	switch os.Args[2] {
+	switch args[1] {
 	case "0":
 	case "1":
 		l = gpio.High
@@ -33,7 +43,7 @@ func mainImpl() error {
 		return err
 	}
 
-	p := gpioreg.ByName(os.Args[1])
+	p := gpioreg.ByName(args[0])
 	if p == nil {
 		return errors.New("invalid GPIO pin number")
 	}

--- a/cmd/headers-list/main.go
+++ b/cmd/headers-list/main.go
@@ -90,13 +90,16 @@ func printHardware(invalid bool, all map[string][][]pin.Pin) {
 
 func mainImpl() error {
 	invalid := flag.Bool("n", false, "show not connected/INVALID pins")
-	verbose := flag.Bool("v", false, "enable verbose logs")
+	verbose := flag.Bool("v", false, "verbose mode")
 	flag.Parse()
-
 	if !*verbose {
 		log.SetOutput(ioutil.Discard)
 	}
-	log.SetFlags(0)
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
+
 	state, err := host.Init()
 	if err != nil {
 		return err

--- a/cmd/i2c-io/main.go
+++ b/cmd/i2c-io/main.go
@@ -33,6 +33,9 @@ func mainImpl() error {
 		log.SetOutput(ioutil.Discard)
 	}
 	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
 
 	if *addr < 0 || *addr >= 1<<9 {
 		return fmt.Errorf("-a is required and must be between 0 and %d", 1<<9-1)

--- a/cmd/i2c-list/main.go
+++ b/cmd/i2c-list/main.go
@@ -6,7 +6,11 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"periph.io/x/periph/conn/i2c"
@@ -26,6 +30,16 @@ func printPin(fn string, p pin.Pin) {
 }
 
 func mainImpl() error {
+	verbose := flag.Bool("v", false, "verbose mode")
+	flag.Parse()
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
+
 	if _, err := host.Init(); err != nil {
 		return err
 	}

--- a/cmd/led/main.go
+++ b/cmd/led/main.go
@@ -6,8 +6,11 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"periph.io/x/periph/host"
@@ -15,7 +18,16 @@ import (
 )
 
 func mainImpl() error {
+	verbose := flag.Bool("v", false, "verbose mode")
 	flag.Parse()
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
+
 	if _, err := host.Init(); err != nil {
 		return err
 	}

--- a/cmd/lepton/main.go
+++ b/cmd/lepton/main.go
@@ -397,7 +397,7 @@ func mainImpl() error {
 	}
 	log.SetFlags(log.Lmicroseconds)
 	if flag.NArg() != 0 {
-		return errors.New("unsupported arguments")
+		return errors.New("unexpected argument, try -help")
 	}
 	hasOutput := len(*output) != 0
 	if hasOutput && *ffc {

--- a/cmd/onewire-list/main.go
+++ b/cmd/onewire-list/main.go
@@ -6,7 +6,11 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"periph.io/x/periph/conn/onewire"
@@ -16,6 +20,16 @@ import (
 )
 
 func mainImpl() error {
+	verbose := flag.Bool("v", false, "verbose mode")
+	flag.Parse()
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
+
 	if _, err := host.Init(); err != nil {
 		return err
 	}

--- a/cmd/periph-info/main.go
+++ b/cmd/periph-info/main.go
@@ -6,7 +6,11 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"periph.io/x/periph"
@@ -30,6 +34,16 @@ func printDrivers(drivers []periph.DriverFailure) {
 }
 
 func mainImpl() error {
+	verbose := flag.Bool("v", false, "verbose mode")
+	flag.Parse()
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
+
 	state, err := host.Init()
 	if err != nil {
 		return err

--- a/cmd/spi-list/main.go
+++ b/cmd/spi-list/main.go
@@ -6,7 +6,11 @@
 package main
 
 import (
+	"errors"
+	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"periph.io/x/periph/conn/pin"
@@ -26,6 +30,16 @@ func printPin(fn string, p pin.Pin) {
 }
 
 func mainImpl() error {
+	verbose := flag.Bool("v", false, "verbose mode")
+	flag.Parse()
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
+
 	if _, err := host.Init(); err != nil {
 		return err
 	}

--- a/cmd/thermal/main.go
+++ b/cmd/thermal/main.go
@@ -6,8 +6,11 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 
 	"periph.io/x/periph/devices"
@@ -16,7 +19,16 @@ import (
 )
 
 func mainImpl() error {
+	verbose := flag.Bool("v", false, "verbose mode")
 	flag.Parse()
+	if !*verbose {
+		log.SetOutput(ioutil.Discard)
+	}
+	log.SetFlags(log.Lmicroseconds)
+	if flag.NArg() != 0 {
+		return errors.New("unexpected argument, try -help")
+	}
+
 	if _, err := host.Init(); err != nil {
 		return err
 	}


### PR DESCRIPTION
There's value in having tools in cmd/... all behave similarly. Change flag
processing to be slightly more similar.