### PR TITLE
Fixed MFRC522 trailing sector overflow

### DIFF
--- a/experimental/cmd/mfrc522/main.go
+++ b/experimental/cmd/mfrc522/main.go
@@ -44,15 +44,13 @@ func mainImpl() error {
 		return err
 	}
 
-	currentAccessKey := mfrc522.DefaultKey
+	var currentAccessKey [6]byte
 
 	if *key != "" {
 		keyBytes := strings.SplitN(*key, ",", 6)
 		if len(keyBytes) != 6 {
 			return errors.New("key should consist of 6 decimal numbers")
 		}
-		currentAccessKey = make([]byte, 6)
-
 		for i, v := range keyBytes {
 			intV, err := strconv.ParseUint(v, 10, 8)
 			if err != nil {
@@ -60,6 +58,8 @@ func mainImpl() error {
 			}
 			currentAccessKey[i] = byte(intV)
 		}
+	} else {
+		copy(currentAccessKey[:], mfrc522.DefaultKey[:])
 	}
 
 	currentAccessMethod := byte(commands.PICC_AUTHENT1B)

--- a/experimental/devices/hd44780/hd44780.go
+++ b/experimental/devices/hd44780/hd44780.go
@@ -38,7 +38,7 @@ type Dev struct {
 //	e - strobe pin
 func New(data []gpio.PinOut, rs, e gpio.PinOut) (*Dev, error) {
 	if len(data) != 4 {
-		return nil, fmt.Errorf("expected 4 data pins, passed %s", len(data))
+		return nil, fmt.Errorf("expected 4 data pins, passed %d", len(data))
 	}
 	dev := &Dev{
 		dataPins:  data,

--- a/experimental/devices/mfrc522/mfrc522.go
+++ b/experimental/devices/mfrc522/mfrc522.go
@@ -497,7 +497,6 @@ func (r *Dev) WriteSectorTrail(auth byte, sector int, keyA [6]byte, keyB [6]byte
 	accessData := CalculateBlockAccess(access)
 	copy(data[6:], accessData[:4])
 	copy(data[10:], keyB[:])
-	fmt.Printf("Data bytes %v\n", data)
 	return r.write(calcBlockAddress(sector&0xFF, 3), data[:])
 }
 

--- a/experimental/devices/mfrc522/mfrc522_test.go
+++ b/experimental/devices/mfrc522/mfrc522_test.go
@@ -11,6 +11,26 @@ import (
 	"testing"
 )
 
+func fromBitString(t *testing.T, s string) (res byte) {
+	d, err := strconv.ParseUint(s, 2, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res = byte(d & 0xFF)
+	return
+}
+
+/*
+   C1 C2 C3
+3 : 1  0  0
+2 : 0  0  1
+1 : 1  0  1
+0 : 1  1  0
+
+1 1 1 0 0 1 0 0
+1 0 1 1 1 0 0 1
+0 1 1 0 0 0 0 1
+*/
 func TestBitCalc(t *testing.T) {
 
 	ba := BlocksAccess{
@@ -22,35 +42,57 @@ func TestBitCalc(t *testing.T) {
 
 	access := CalculateBlockAccess(&ba)
 
-	reader := func(s string) (res byte) {
-		d, err := strconv.ParseUint(s, 2, 8)
-		if err != nil {
-			t.Fatal(err)
-		}
-		res = byte(d & 0xFF)
-		return
-	}
-
-	if reader("0110") != ba.getBits(1) {
-		t.Fatalf("0110 is not equal to %d", ba.getBits(1))
+	if fromBitString(t, "1011") != ba.getBits(1) {
+		t.Fatalf("1011 is not equal to %d", ba.getBits(1))
 	}
 
 	expected := []byte{
-		reader("11101001"),
-		reader("01100100"),
-		reader("10110001"),
+		fromBitString(t, "11100100"),
+		fromBitString(t, "10111001"),
+		fromBitString(t, "01100001"),
 		0,
 	}
 
 	expected[3] = expected[0] ^ expected[1] ^ expected[2]
 
 	if !bytes.Equal(expected, access) {
-		t.Fatal("Access is incorrect")
+		t.Fatalf("Access is incorrect: %v != %v", expected, access)
 	}
 
 	parsedAccess := ParseBlockAccess(access)
 
 	if !reflect.DeepEqual(ba, *parsedAccess) {
-		t.Fatal("Parsed access mismatch")
+		t.Fatalf("Parsed access mismatch %s != %s", ba.String(), (*parsedAccess).String())
+	}
+}
+
+/*
+   C1 C2 C3
+3 : 0  0  1
+2 : 0  0  0
+1 : 0  0  0
+0 : 0  0  0
+
+
+1 1 1 1 1 1 1 1
+0 0 0 0 0 1 1 1
+1 0 0 0 0 0 0 0
+*/
+func TestByteArrayDecipher(t *testing.T) {
+	bitsData := [...]byte{
+		fromBitString(t, "11111111"),
+		fromBitString(t, "00000111"),
+		fromBitString(t, "10000000"),
+		fromBitString(t, "01111000"),
+	}
+	ba := BlocksAccess{
+		B0: AnyKeyRWID,
+		B1: AnyKeyRWID,
+		B2: AnyKeyRWID,
+		B3: KeyA_RN_WA_BITS_RA_WA_KeyB_RA_WA,
+	}
+	access := CalculateBlockAccess(&ba)
+	if !reflect.DeepEqual(bitsData[:], access) {
+		t.Fatalf("Wrong access calculation: %v != %v", bitsData, access)
 	}
 }


### PR DESCRIPTION
If the passed key is longer than 6 bytes, it will corrupt the access
bits for the traling sector.

Fixed the bit calculation, updates tests.

Changed signatures to accept 6-byte long arrays instead of slices.

Minor typo for HD44780

Signed-off-by: Eugene Dzhurinsky <jdevelop@gmail.com>