### PR TITLE
updated beagle/black Present() check

### DIFF
--- a/experimental/host/beagle/black/black.go
+++ b/experimental/host/beagle/black/black.go
@@ -5,13 +5,12 @@
 package black
 
 import (
-	"bytes"
 	"errors"
-	"io/ioutil"
 
 	"periph.io/x/periph"
 	"periph.io/x/periph/conn/pin"
 	"periph.io/x/periph/conn/pin/pinreg"
+	"periph.io/x/periph/host/distro"
 	"periph.io/x/periph/host/sysfs"
 )
 
@@ -98,15 +97,7 @@ var (
 // Beagleboard present.
 func Present() bool {
 	if isArm {
-		buf, err := ioutil.ReadFile("/sys/firmware/devicetree/base/model")
-
-		if err != nil {
-			return false
-		}
-		// last byte of buf is a NULL character
-		str := string(bytes.Trim(buf, "\x00"))
-
-		return str == "TI AM335x BeagleBone Black"
+		return distro.DTModel() == "TI AM335x BeagleBone Black"
 	}
 	return false
 }

--- a/experimental/host/beagle/black/black.go
+++ b/experimental/host/beagle/black/black.go
@@ -5,8 +5,9 @@
 package black
 
 import (
+	"bytes"
 	"errors"
-	"os"
+	"io/ioutil"
 
 	"periph.io/x/periph"
 	"periph.io/x/periph/conn/pin"
@@ -97,10 +98,15 @@ var (
 // Beagleboard present.
 func Present() bool {
 	if isArm {
-		// TODO: check for beaglebone black in particular
-		_, err := os.Stat("/sys/firmware/devicetree/base/bone_capemgr")
+		buf, err := ioutil.ReadFile("/sys/firmware/devicetree/base/model")
 
-		return err == nil
+		if err != nil {
+			return false
+		}
+		// last byte of buf is a NULL character
+		str := string(bytes.Trim(buf, "\x00"))
+
+		return str == "TI AM335x BeagleBone Black"
 	}
 	return false
 }


### PR DESCRIPTION
Works on `Linux beaglebone 4.4.113-ti-r147` (official debian-stretch image), however cannot confirm if this works on older versions.

It may make sense to define the values I check as constants or even (assuming this works universally) do this check automatically for different platforms, thus a platform would only have to provide a model string to validate against.