### PR TITLE
apa102: refactor benchmarks

### DIFF
--- a/devices/apa102/apa102_test.go
+++ b/devices/apa102/apa102_test.go
@@ -636,120 +636,46 @@ func TestInit(t *testing.T) {
 
 //
 
-func BenchmarkWriteWhite(b *testing.B) {
-	b.ReportAllocs()
-	pixels := [150 * 3]byte{}
-	for i := range pixels {
-		pixels[i] = 0xFF
+type fn func(int) byte
+
+func benchmarkWrite(b *testing.B, o Opts, length int, f fn) {
+	var pixels []byte
+	for i := 0; i < length; i++ {
+		pixels = append(pixels, f(i))
 	}
-	o := DefaultOpts
-	o.NumPixels = len(pixels) / 3
-	o.Intensity = 250
+	o.NumPixels = length / 3
+	b.ReportAllocs()
 	d, _ := New(spitest.NewRecordRaw(ioutil.Discard), &o)
 	_, _ = d.Write(pixels[:])
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = d.Write(pixels[:])
 	}
+}
+
+func BenchmarkWriteWhite(b *testing.B) {
+	o := DefaultOpts
+	o.Intensity = 250
+	benchmarkWrite(b, o, 150*3, func(i int) byte { return 0xFF })
 }
 
 func BenchmarkWriteDim(b *testing.B) {
-	b.ReportAllocs()
-	pixels := [150 * 3]byte{}
-	for i := range pixels {
-		pixels[i] = 1
-	}
 	o := DefaultOpts
-	o.NumPixels = len(pixels) / 3
 	o.Intensity = 250
-	d, _ := New(spitest.NewRecordRaw(ioutil.Discard), &o)
-	_, _ = d.Write(pixels[:])
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = d.Write(pixels[:])
-	}
+	benchmarkWrite(b, o, 150*3, func(i int) byte { return 0x01 })
 }
 
 func BenchmarkWriteBlack(b *testing.B) {
-	b.ReportAllocs()
-	pixels := [150 * 3]byte{}
 	o := DefaultOpts
-	o.NumPixels = len(pixels) / 3
 	o.Intensity = 250
-	d, _ := New(spitest.NewRecordRaw(ioutil.Discard), &o)
-	_, _ = d.Write(pixels[:])
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = d.Write(pixels[:])
-	}
+	benchmarkWrite(b, o, 150*3, func(i int) byte { return 0x0 })
 }
 
 func BenchmarkWriteColorful(b *testing.B) {
-	b.ReportAllocs()
-	pixels := [150 * 3]byte{}
-	for i := range pixels {
-		pixels[i] = uint8(i) + uint8(i>>8)
-	}
 	o := DefaultOpts
-	o.NumPixels = len(pixels) / 3
 	o.Intensity = 250
 	o.Temperature = 5000
-	d, _ := New(spitest.NewRecordRaw(ioutil.Discard), &o)
-	_, _ = d.Write(pixels[:])
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_, _ = d.Write(pixels[:])
-	}
-}
-
-func BenchmarkDrawNRGBAColorful(b *testing.B) {
-	// Takes the fast path.
-	b.ReportAllocs()
-	img := image.NewNRGBA(image.Rect(0, 0, 150, 1))
-	for i := range img.Pix {
-		img.Pix[i] = uint8(i) + uint8(i>>8)
-	}
-	o := DefaultOpts
-	o.NumPixels = img.Bounds().Max.X
-	o.Intensity = 250
-	o.Temperature = 5000
-	d, _ := New(spitest.NewRecordRaw(ioutil.Discard), &o)
-	r := d.Bounds()
-	p := image.Point{}
-	if err := d.Draw(r, img, p); err != nil {
-		b.Fatal(err)
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := d.Draw(r, img, p); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-
-func BenchmarkDrawRGBAColorful(b *testing.B) {
-	// Takes the slow path.
-	b.ReportAllocs()
-	img := image.NewRGBA(image.Rect(0, 0, 256, 1))
-	for i := range img.Pix {
-		img.Pix[i] = uint8(i) + uint8(i>>8)
-	}
-	o := DefaultOpts
-	o.NumPixels = img.Bounds().Max.X
-	o.Intensity = 250
-	o.Temperature = 5000
-	d, _ := New(spitest.NewRecordRaw(ioutil.Discard), &o)
-	r := d.Bounds()
-	p := image.Point{}
-	if err := d.Draw(r, img, p); err != nil {
-		b.Fatal(err)
-	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		if err := d.Draw(r, img, p); err != nil {
-			b.Fatal(err)
-		}
-	}
+	benchmarkWrite(b, o, 150*3, func(i int) byte { return uint8(i) + uint8(i>>8) })
 }
 
 func BenchmarkWriteColorfulVariation(b *testing.B) {
@@ -771,6 +697,47 @@ func BenchmarkWriteColorfulVariation(b *testing.B) {
 		d.Temperature = uint16((3000 + i) & 0x1FFF)
 		_, _ = d.Write(pixels[:])
 	}
+}
+
+func benchmarkDraw(b *testing.B, o Opts, img image.Image, f fn) {
+	switch im := img.(type) {
+	case *image.NRGBA:
+		for i := range im.Pix {
+			im.Pix[i] = f(i)
+		}
+	case *image.RGBA:
+		for i := range im.Pix {
+			im.Pix[i] = f(i)
+		}
+	}
+	o.NumPixels = img.Bounds().Max.X
+	b.ReportAllocs()
+	d, _ := New(spitest.NewRecordRaw(ioutil.Discard), &o)
+	r := d.Bounds()
+	p := image.Point{}
+	if err := d.Draw(r, img, p); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := d.Draw(r, img, p); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkDrawNRGBAColorful(b *testing.B) {
+	o := DefaultOpts
+	o.Intensity = 250
+	o.Temperature = 5000
+	benchmarkDraw(b, o, image.NewNRGBA(image.Rect(0, 0, 150, 1)), func(i int) byte { return uint8(i) + uint8(i>>8) })
+}
+
+func BenchmarkDrawRGBAColorful(b *testing.B) {
+	o := DefaultOpts
+	o.Intensity = 250
+	o.Temperature = 5000
+	benchmarkDraw(b, o, image.NewRGBA(image.Rect(0, 0, 256, 1)), func(i int) byte { return uint8(i) + uint8(i>>8) })
 }
 
 func BenchmarkHalt(b *testing.B) {


### PR DESCRIPTION
Should be a no-op.  Benchmark runs look roughly the same as head on my machine.