### PR TITLE
apa102: change from RawColors to DisableGlobalPWM

### DIFF
--- a/cmd/apa102/main.go
+++ b/cmd/apa102/main.go
@@ -116,8 +116,9 @@ func mainImpl() error {
 	spiID := flag.String("spi", "", "SPI port to use")
 
 	numPixels := flag.Int("n", apa102.DefaultOpts.NumPixels, "number of pixels on the strip")
-	intensity := flag.Int("l", int(apa102.DefaultOpts.Intensity), "light intensity [1-255]")
-	temperature := flag.Int("t", int(apa102.DefaultOpts.Temperature), "light temperature in Kelvin [3500-7500]")
+	intensity := flag.Int("l", int(apa102.DefaultOpts.Intensity), "light intensity [1-255]; 255 is full intensity")
+	temperature := flag.Int("t", int(apa102.DefaultOpts.Temperature), "light temperature in Kelvin [3500-7500]; 6500 is neutral")
+	globalPWM := flag.Bool("g", false, "disable the global PWM and perceptual mapping")
 	hz := flag.Int("hz", 0, "SPI port speed")
 	color := flag.String("color", "208020", "hex encoded color to show")
 	imgName := flag.String("img", "", "image to load")
@@ -161,6 +162,7 @@ func mainImpl() error {
 	o.NumPixels = *numPixels
 	o.Intensity = uint8(*intensity)
 	o.Temperature = uint16(*temperature)
+	o.DisableGlobalPWM = *globalPWM
 	disp, err := apa102.New(s, &o)
 	if err != nil {
 		return err

--- a/devices/apa102/example_test.go
+++ b/devices/apa102/example_test.go
@@ -35,13 +35,37 @@ func Example() {
 	o.Temperature = 3500
 	dev, err := apa102.New(p, &o)
 	if err != nil {
-		log.Fatalf("failed to open apa102: %v", err)
+		log.Fatalf("failed to open: %v", err)
 	}
 	img := image.NewNRGBA(image.Rect(0, 0, dev.Bounds().Dy(), 1))
 	for x := 0; x < img.Rect.Max.X; x++ {
 		img.SetNRGBA(x, 0, color.NRGBA{uint8(x), uint8(255 - x), 0, 255})
 	}
 	if err := dev.Draw(dev.Bounds(), img, image.Point{}); err != nil {
+		log.Fatalf("failed to draw: %v", err)
+	}
+}
+
+func ExampleToRGB() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
 		log.Fatal(err)
+	}
+
+	// Use spireg SPI port registry to find the first available SPI bus.
+	p, err := spireg.Open("")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer p.Close()
+
+	o := apa102.PassThruOpts
+	o.NumPixels = 2
+	dev, err := apa102.New(p, &o)
+	if err != nil {
+		log.Fatalf("failed to open: %v", err)
+	}
+	if _, err = dev.Write(apa102.ToRGB([]color.NRGBA{{R: 0xFF, G: 0xFF, B: 0xFF}, {R: 0x80, G: 0x80, B: 0x80}})); err != nil {
+		log.Fatalf("failed to draw: %v", err)
 	}
 }


### PR DESCRIPTION
The rationale is that temperature correction can still be used with 8 bits
resolution, but perceptual mapping can't. Tweak the code to enable this, and
make the documentation clearer about the implications.