### PR TITLE
fs: add support for GOARCH=mips/mipsle on GOOS=linux

### DIFF
--- a/host/fs/fs.go
+++ b/host/fs/fs.go
@@ -16,6 +16,10 @@ import (
 
 // Ioctler is a file handle that supports ioctl calls.
 type Ioctler interface {
+	// Ioctl sends a linux ioctl on the file handle. op is effectively a uint32.
+	//
+	// The op is expected to be encoded in the format on x64. ARM happens to
+	// share the same format.
 	Ioctl(op uint, data uintptr) error
 }
 
@@ -58,6 +62,12 @@ type File struct {
 
 // Ioctl sends an ioctl to the file handle.
 func (f *File) Ioctl(op uint, data uintptr) error {
+	if isMIPS {
+		var err error
+		if op, err = translateOpMIPS(op); err != nil {
+			return err
+		}
+	}
 	return ioctl(f.Fd(), op, data)
 }
 
@@ -94,3 +104,27 @@ var (
 	inhibited bool
 	used      bool
 )
+
+func translateOpMIPS(op uint) (uint, error) {
+	// Decode the arm/x64 encoding and reencode as MIPS specific linux ioctl.
+	// arm/x64: DIR(2), SIZE(14), TYPE(8), NR(8)
+	// mips:    DIR(3), SIZE(13), TYPE(8), NR(8)
+	// Check for size overflow.
+	if (op & (1 << (13 + 8 + 8))) != 0 {
+		return 0, errors.New("fs: op code size is too large")
+	}
+	const mask = (1 << (13 + 8 + 8)) - 1
+	out := op & mask
+	// Convert dir.
+	switch op >> (14 + 8 + 8) {
+	case 0: // none
+		out |= 1 << (13 + 8 + 8)
+	case 1: // write
+		out |= 4 << (13 + 8 + 8)
+	case 2: // read
+		out |= 2 << (13 + 8 + 8)
+	default:
+		return 0, errors.New("fs: op code dir is invalid")
+	}
+	return out, nil
+}

--- a/host/fs/fs_test.go
+++ b/host/fs/fs_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package fs
+
+import "testing"
+
+func TestTranslateOpMIPS(t *testing.T) {
+	// input, expected
+	data := [][2]uint{
+		// Dir = 0 Size = 0x2000, Type = 0x10, NR = 0x20
+		{0<<(14+8+8) | 0x1000<<(8+8) | 0x10<<8 | 0x20, 0x30001020},
+		// Dir = 1, Size = 0x2000, Type = 0x10, NR = 0x20
+		{1<<(14+8+8) | 0x1000<<(8+8) | 0x10<<8 | 0x20, 0x90001020},
+		// Dir = 2, Size = 0x2000, Type = 0x10, NR = 0x20
+		{2<<(14+8+8) | 0x1000<<(8+8) | 0x10<<8 | 0x20, 0x50001020},
+		// Dir = 0, Size = 0x0000, Type = 0x00, NR = 0x00
+		{0 << (14 + 8 + 8), 0x20000000},
+		// Dir = 1, Size = 0x0000, Type = 0x00, NR = 0x00
+		{1 << (14 + 8 + 8), 0x80000000},
+		// Dir = 2, Size = 0x0000, Type = 0x00, NR = 0x00
+		{2 << (14 + 8 + 8), 0x40000000},
+	}
+	for i, line := range data {
+		if actual, err := translateOpMIPS(line[0]); err != nil {
+			t.Fatalf("#%d: error: %v", i, err)
+		} else if line[1] != actual {
+			t.Fatalf("#%d: expected %#x, got %#x", i, line[1], actual)
+		}
+	}
+}
+
+func TestTranslateOpMIPS_Error(t *testing.T) {
+	// 14 bit size.
+	if _, err := translateOpMIPS(1 << (13 + 8 + 8)); err == nil {
+		t.Fatal("size")
+	}
+	if _, err := translateOpMIPS(3 << (14 + 8 + 8)); err == nil {
+		t.Fatal("dir")
+	}
+}

--- a/host/fs/ioctl_mips_like.go
+++ b/host/fs/ioctl_mips_like.go
@@ -1,0 +1,9 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// +build mips mipsle
+
+package fs
+
+const isMIPS = true

--- a/host/fs/ioctl_other.go
+++ b/host/fs/ioctl_other.go
@@ -1,0 +1,9 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// +build !mips,!mipsle
+
+package fs
+
+const isMIPS = false


### PR DESCRIPTION
It uses a slightly different linux opcode encoding. Just shuffle the bits as it
goes.

Tested with:
  GOARCH=mipsle go build ./...
  GOARCH=mips go build ./...
  go test ./...