### PR TITLE
pin: add PinFunc

### DIFF
--- a/conn/pin/example_test.go
+++ b/conn/pin/example_test.go
@@ -6,7 +6,9 @@ package pin_test
 
 import (
 	"fmt"
+	"log"
 
+	"periph.io/x/periph/conn/gpio/gpioreg"
 	"periph.io/x/periph/conn/pin"
 )
 
@@ -17,4 +19,46 @@ func ExampleBasicPin() {
 
 	// Output:
 	// Exotic
+}
+
+func ExampleFunc_Specialize() {
+	// Specializes both bus and line.
+	fmt.Println(pin.Func("SPI_CS").Specialize(1, 2))
+	// Specializes only bus.
+	fmt.Println(pin.Func("SPI_MOSI").Specialize(1, -1))
+	// Specializes only line.
+	fmt.Println(pin.Func("CSI_D").Specialize(-1, 3))
+	// Specializes neither.
+	fmt.Println(pin.Func("INVALID").Specialize(-1, -1))
+	// Output:
+	// SPI1_CS2
+	// SPI1_MOSI
+	// CSI_D3
+	// INVALID
+}
+
+func ExampleFunc_Generalize() {
+	fmt.Println(pin.Func("SPI1_CS2").Generalize())
+	fmt.Println(pin.Func("SPI1_MOSI").Generalize())
+	fmt.Println(pin.Func("CSI_D3").Generalize())
+	fmt.Println(pin.Func("INVALID").Generalize())
+	// Output:
+	// SPI_CS
+	// SPI_MOSI
+	// CSI_D
+	// INVALID
+}
+
+func ExamplePinFunc() {
+	p := gpioreg.ByName("GPIO14")
+	if p == nil {
+		log.Fatal("not running on a raspberry pi")
+	}
+	pf, ok := p.(pin.PinFunc)
+	if !ok {
+		log.Fatal("pin.PinFunc is not implemented")
+	}
+	if err := pf.SetFunc(pin.Func("UART1_TX")); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/conn/pin/func.go
+++ b/conn/pin/func.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package pin
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Func is a pin function.
+//
+// The Func format must be "[A-Z]+", "[A-Z]+_[A-Z]+" or exceptionally
+// "(In|Out)/(Low|High)".
+type Func string
+
+// FuncNone is returned by PinFunc.Func() for a Pin without an active
+// functionality.
+const FuncNone Func = ""
+
+// Specialize converts a "BUS_LINE" function and appends the bug number and
+// line number, to look like "BUS0_LINE1".
+//
+// Use -1 to not add a bus or line number.
+func (f Func) Specialize(b, l int) Func {
+	if f == FuncNone {
+		return FuncNone
+	}
+	if b != -1 {
+		parts := strings.SplitN(string(f), "_", 2)
+		if len(parts) == 1 {
+			return FuncNone
+		}
+		f = Func(parts[0] + strconv.Itoa(b) + "_" + parts[1])
+	}
+	if l != -1 {
+		f += Func(strconv.Itoa(l))
+	}
+	return f
+}
+
+// Generalize is the reverse of Specialize().
+func (f Func) Generalize() Func {
+	parts := strings.SplitN(string(f), "_", 2)
+	f = Func(strings.TrimRightFunc(parts[0], isNum))
+	if len(parts) == 2 {
+		f += "_"
+		f += Func(strings.TrimRightFunc(parts[1], isNum))
+	}
+	return f
+}
+
+//
+
+func isNum(r rune) bool {
+	return r >= '0' && r <= '9'
+}

--- a/conn/pin/func_test.go
+++ b/conn/pin/func_test.go
@@ -1,0 +1,27 @@
+// Copyright 2016 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package pin
+
+import (
+	"testing"
+)
+
+func TestFunc(t *testing.T) {
+	if v := FuncNone.Specialize(-1, -1); v != FuncNone {
+		t.Fatal(v)
+	}
+	if v := FuncNone.Specialize(1, -1); v != FuncNone {
+		t.Fatal(v)
+	}
+	if v := FuncNone.Specialize(-1, 1); v != FuncNone {
+		t.Fatal(v)
+	}
+	if v := Func("A").Specialize(-1, 1); v != Func("A1") {
+		t.Fatal(v)
+	}
+	if v := Func("A").Specialize(1, -1); v != FuncNone {
+		t.Fatal(v)
+	}
+}

--- a/conn/pin/pin.go
+++ b/conn/pin/pin.go
@@ -9,7 +9,11 @@
 // While not a protocol strictly speaking, these are "well known constants".
 package pin
 
-import "periph.io/x/periph/conn"
+import (
+	"errors"
+
+	"periph.io/x/periph/conn"
+)
 
 // These are well known pins.
 var (
@@ -35,12 +39,39 @@ type Pin interface {
 	// Function returns a user readable string representation of what the pin is
 	// configured to do. Common case is In and Out but it can be bus specific pin
 	// name.
+	//
+	// Deprecated: Use PinFunc.Func. Will be removed in v4.
 	Function() string
+}
+
+// PinFunc is a supplementary interface that enables specifically querying for
+// the pin function.
+//
+// TODO(maruel): It will be merged into interface Pin for v4.
+type PinFunc interface {
+	// Func returns the pin's current function.
+	//
+	// The returned value may be specialized or generalized, depending on the
+	// actual port. For example it will likely be generalized for ports served
+	// over USB (like a FT232H with D0 set as SPI_MOSI) but specialized for
+	// ports on the base board (like a RPi3 with GPIO10 set as SPI0_MOSI).
+	Func() Func
+	// SupportedFuncs returns the possible functions this pin support.
+	//
+	// Do not mutate the returned slice.
+	SupportedFuncs() []Func
+	// SetFunc sets the pin function.
+	//
+	// Example use is to reallocate a RPi3's GPIO14 active function between
+	// UART0_TX and UART1_TX.
+	SetFunc(f Func) error
 }
 
 //
 
 // BasicPin implements Pin as a static pin.
+//
+// It doesn't have a usable functionality.
 type BasicPin struct {
 	N string
 }
@@ -62,25 +93,47 @@ func (b *BasicPin) Name() string {
 
 // Number implements Pin.
 //
-// It returns -1 as pin number.
+// Returns -1 as pin number.
 func (b *BasicPin) Number() int {
 	return -1
 }
 
 // Function implements Pin.
 //
-// It returns "" as pin function.
+// Returns "" as pin function.
 func (b *BasicPin) Function() string {
 	return ""
+}
+
+// Func implements PinFunc.
+//
+// Returns FuncNone as pin function.
+func (b *BasicPin) Func() Func {
+	return FuncNone
+}
+
+// SupportedFuncs implements PinFunc.
+//
+// Returns nil.
+func (b *BasicPin) SupportedFuncs() []Func {
+	return nil
+}
+
+// SetFunc implements PinFunc.
+func (b *BasicPin) SetFunc(f Func) error {
+	return errors.New("pin: can't change static pin function")
 }
 
 func init() {
 	INVALID = &BasicPin{N: "INVALID"}
 	GROUND = &BasicPin{N: "GROUND"}
-	V1_8 = &BasicPin{N: "V1_8"}
-	V2_8 = &BasicPin{N: "V2_8"}
-	V3_3 = &BasicPin{N: "V3_3"}
-	V5 = &BasicPin{N: "V5"}
+	V1_8 = &BasicPin{N: "1.8V"}
+	V2_8 = &BasicPin{N: "2.8V"}
+	V3_3 = &BasicPin{N: "3.3V"}
+	V5 = &BasicPin{N: "5V"}
 	DC_IN = &BasicPin{N: "DC_IN"}
-	BAT_PLUS = &BasicPin{N: "BAT_PLUS"}
+	BAT_PLUS = &BasicPin{N: "BAT+"}
 }
+
+var _ Pin = INVALID
+var _ PinFunc = INVALID

--- a/conn/pin/pin_test.go
+++ b/conn/pin/pin_test.go
@@ -19,6 +19,9 @@ func TestBasicPin(t *testing.T) {
 	if s := b.String(); s != "Pin1" {
 		t.Fatal(s)
 	}
+	if err := b.Halt(); err != nil {
+		t.Fatal(err)
+	}
 	if s := b.Name(); s != "Pin1" {
 		t.Fatal(s)
 	}
@@ -27,5 +30,23 @@ func TestBasicPin(t *testing.T) {
 	}
 	if s := b.Function(); s != "" {
 		t.Fatal(s)
+	}
+	if f := b.Func(); f != FuncNone {
+		t.Fatal(f)
+	}
+	if f := b.SupportedFuncs(); len(f) != 0 {
+		t.Fatal(f)
+	}
+	if err := b.SetFunc(Func("Out/Low")); err == nil {
+		t.Fatal("expected failure")
+	}
+}
+
+func TestV3_3(t *testing.T) {
+	if f := V3_3.Func(); f != FuncNone {
+		t.Fatal(f)
+	}
+	if f := V3_3.SupportedFuncs(); len(f) != 0 {
+		t.Fatal(f)
 	}
 }


### PR DESCRIPTION
- This will eventually be implemented by all pin.Pin implementations and merged
  back into pin.Pin for v4.
- The pin.Func const in other conn/ packages and host/ implementation is in a
  follow up.