### PR TITLE
sysfs-gpio: always reset edge detection to 'none' after starting epoll

### DIFF
--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -167,19 +167,22 @@ func (p *Pin) In(pull gpio.Pull, edge gpio.Edge) error {
 				return p.wrap(err)
 			}
 		}
-		if p.edge != edge {
-			var b []byte
-			switch edge {
-			case gpio.RisingEdge:
-				b = bRising
-			case gpio.FallingEdge:
-				b = bFalling
-			case gpio.BothEdges:
-				b = bBoth
-			}
-			if err := seekWrite(p.fEdge, b); err != nil {
-				return p.wrap(err)
-			}
+		// Always reset the edge detection mode to none after starting the epoll,
+		// otherwise edges are not always delivered.
+		if err := seekWrite(p.fEdge, bNone); err != nil {
+			return p.wrap(err)
+		}
+		var b []byte
+		switch edge {
+		case gpio.RisingEdge:
+			b = bRising
+		case gpio.FallingEdge:
+			b = bFalling
+		case gpio.BothEdges:
+			b = bBoth
+		}
+		if err := seekWrite(p.fEdge, b); err != nil {
+			return p.wrap(err)
 		}
 	}
 	p.edge = edge

--- a/host/sysfs/gpio.go
+++ b/host/sysfs/gpio.go
@@ -167,8 +167,9 @@ func (p *Pin) In(pull gpio.Pull, edge gpio.Edge) error {
 				return p.wrap(err)
 			}
 		}
-		// Always reset the edge detection mode to none after starting the epoll,
-		// otherwise edges are not always delivered.
+		// Always reset the edge detection mode to none after starting the epoll
+		// otherwise edges are not always delivered, as observed on an Allwinner A20
+		// running kernel 4.14.14.
 		if err := seekWrite(p.fEdge, bNone); err != nil {
 			return p.wrap(err)
 		}


### PR DESCRIPTION
Without this edges are never delivered for me.  *shrug*