### PR TITLE
epd: add ePaper display support

### DIFF
--- a/experimental/devices/epd/doc.go
+++ b/experimental/devices/epd/doc.go
@@ -2,15 +2,17 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// Package epd controls Waveshare e-paper series displays
+// Package epd controls Waveshare e-paper series displays.
 //
 // More details
 //
-// See https://periph.io/device/epd/ for more details about the device.
+// Datasheets
 //
-// Based on https://github.com/soonuse/epd-library-python
+// https://www.waveshare.com/w/upload/e/e6/2.13inch_e-Paper_Datasheet.pdf
 //
 // Product page:
-// https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT
-// https://www.waveshare.com/wiki/1.54inch_e-Paper_Module
+//
+// 2.13 Inch version: https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT
+//
+// 1.54 inch version: https://www.waveshare.com/wiki/1.54inch_e-Paper_Module
 package epd

--- a/experimental/devices/epd/doc.go
+++ b/experimental/devices/epd/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package epd controls Waveshare e-paper series displays
+//
+// More details
+//
+// See https://periph.io/device/epd/ for more details about the device.
+//
+// Based on https://github.com/soonuse/epd-library-python
+//
+// Product page:
+// https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT
+// https://www.waveshare.com/wiki/1.54inch_e-Paper_Module
+package epd

--- a/experimental/devices/epd/epd.go
+++ b/experimental/devices/epd/epd.go
@@ -1,0 +1,463 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package epd
+
+import (
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"time"
+
+	"periph.io/x/periph/conn"
+	"periph.io/x/periph/conn/display"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpioreg"
+	"periph.io/x/periph/conn/physic"
+	"periph.io/x/periph/conn/spi"
+	"periph.io/x/periph/devices/ssd1306/image1bit"
+)
+
+// Raspberry pi hat pins
+const (
+	ResetPin       = "17"
+	DataCommandPin = "25"
+	ChipSelectPin  = "8"
+	BusyStatePin   = "24"
+)
+
+// EPD commands
+const (
+	DriverOutputControl            = 0x01
+	BoosterSoftStartControl        = 0x0C
+	GateScanStartPosition          = 0x0F
+	DeepSleepMode                  = 0x10
+	DataEntryModeSetting           = 0x11
+	SwReset                        = 0x12
+	TemperatureSensorControl       = 0x1A
+	MasterActivation               = 0x20
+	DisplayUpdateControl1          = 0x21
+	DisplayUpdateControl2          = 0x22
+	WriteRAM                       = 0x24
+	WriteVcomRegister              = 0x2C
+	WriteLutRegister               = 0x32
+	SetDummyLinePeriod             = 0x3A
+	SetGateTime                    = 0x3B
+	BorderWaveformControl          = 0x3C
+	SetRAMXAddressStartEndPosition = 0x44
+	SetRAMYAddressStartEndPosition = 0x45
+	SetRAMXAddressCounter          = 0x4E
+	SetRAMYAddressCounter          = 0x4F
+	TerminateFrameReadWrite        = 0xFF
+)
+
+// LUT contains the display specific waveform for the pixel programming of the display.
+type LUT []byte
+
+// LUTType full or partial display update
+type LUTType int
+
+const (
+	// Full LUT config to update all the display
+	Full LUTType = iota
+	// Partial LUT config only a part of the display
+	Partial
+)
+
+// EPD2in13 is the config for the 2.13 inch display.
+var EPD2in13 = DisplayConfig{
+	W: 128,
+	H: 250,
+	FullUpdate: LUT{
+		0x22, 0x55, 0xAA, 0x55, 0xAA, 0x55, 0xAA, 0x11,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x1E, 0x1E, 0x1E, 0x1E, 0x1E, 0x1E, 0x1E, 0x1E,
+		0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+	},
+	PartialUpdate: LUT{
+		0x18, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x0F, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	},
+}
+
+// EPD1in54 is the config for the 1.54 inch display.
+var EPD1in54 = DisplayConfig{
+	W: 200,
+	H: 200,
+	FullUpdate: LUT{
+		0x02, 0x02, 0x01, 0x11, 0x12, 0x12, 0x22, 0x22,
+		0x66, 0x69, 0x69, 0x59, 0x58, 0x99, 0x99, 0x88,
+		0x00, 0x00, 0x00, 0x00, 0xF8, 0xB4, 0x13, 0x51,
+		0x35, 0x51, 0x51, 0x19, 0x01, 0x00,
+	},
+	PartialUpdate: LUT{
+		0x10, 0x18, 0x18, 0x08, 0x18, 0x18, 0x08, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x13, 0x14, 0x44, 0x12,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	},
+}
+
+// DisplayConfig defines the options for the ePaper Device.
+type DisplayConfig struct {
+	W             int
+	H             int
+	FullUpdate    LUT
+	PartialUpdate LUT
+}
+
+// NewSPI returns a Dev object that communicates over SPI to a E-Paper display controller.
+func NewSPI(p spi.Port, dc, cs, rst gpio.PinOut, busy gpio.PinIO, config *DisplayConfig) (*Dev, error) {
+	if dc == gpio.INVALID {
+		return nil, errors.New("epd: use nil for dc to use 3-wire mode, do not use gpio.INVALID")
+	}
+
+	if err := dc.Out(gpio.Low); err != nil {
+		return nil, err
+	}
+
+	c, err := p.Connect(2*physic.MegaHertz, spi.Mode0, 8)
+	if err != nil {
+		return nil, err
+	}
+
+	d := &Dev{
+		c:      c,
+		dc:     dc,
+		cs:     cs,
+		rst:    rst,
+		busy:   busy,
+		lt:     Full,
+		config: config,
+		rect:   image.Rect(0, 0, config.W, config.H),
+	}
+
+	d.reset()
+
+	if err := d.sendCommand([]byte{byte(DriverOutputControl)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte((config.H - 1) & 0xFF)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(((config.H - 1) >> 8) & 0xFF)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0x00)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendCommand([]byte{byte(BoosterSoftStartControl)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0xD7)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0xD6)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0x9D)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendCommand([]byte{byte(WriteVcomRegister)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0xA8)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendCommand([]byte{byte(SetDummyLinePeriod)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0x1A)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendCommand([]byte{byte(SetGateTime)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0x08)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendCommand([]byte{byte(DataEntryModeSetting)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.sendData([]byte{byte(0x03)}); err != nil {
+		return nil, err
+	}
+
+	if err := d.setLut(Full); err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+// NewSPIHat returns a Dev object that communicates over SPI
+// and have the default config for the e-paper hat for raspberry pi
+func NewSPIHat(p spi.Port, config *DisplayConfig) (*Dev, error) {
+	dc := gpioreg.ByName(DataCommandPin)
+	cs := gpioreg.ByName(ChipSelectPin)
+	rst := gpioreg.ByName(ResetPin)
+	busy := gpioreg.ByName(BusyStatePin)
+	return NewSPI(p, dc, cs, rst, busy, config)
+}
+
+// Dev is an open handle to the display controller.
+type Dev struct {
+	// Communication
+	c    conn.Conn
+	dc   gpio.PinOut
+	cs   gpio.PinOut
+	rst  gpio.PinOut
+	busy gpio.PinIO
+
+	// Display size controlled by the e-paper display.
+	rect image.Rectangle
+
+	lt     LUTType
+	config *DisplayConfig
+}
+
+func (d *Dev) String() string {
+	return fmt.Sprintf("epd.Dev{%s, %s, %s}", d.c, d.dc, d.rect.Max)
+}
+
+// ColorModel implements display.Drawer.
+// It is a one bit color model, as implemented by image1bit.Bit.
+func (d *Dev) ColorModel() color.Model {
+	return image1bit.BitModel
+}
+
+// Bounds implements display.Drawer. Min is guaranteed to be {0, 0}.
+func (d *Dev) Bounds() image.Rectangle {
+	return d.rect
+}
+
+// Draw implements display.Drawer.
+func (d *Dev) Draw(r image.Rectangle, src image.Image, sp image.Point) error {
+	xStart := sp.X
+	yStart := sp.Y
+	imageW := r.Dx() & 0xF8
+	imageH := r.Dy()
+	w := d.rect.Dx()
+	h := d.rect.Dy()
+
+	xEnd := xStart + imageW - 1
+	if xStart+imageW >= w {
+		xEnd = w - 1
+	}
+
+	yEnd := yStart + imageH - 1
+	if yStart+imageH >= h {
+		yEnd = h - 1
+	}
+
+	d.setMemoryArea(xStart, yStart, xEnd, yEnd)
+
+	next := image1bit.NewVerticalLSB(d.rect)
+	draw.Src.Draw(next, r, src, sp)
+	var byteToSend byte = 0x00
+	for y := yStart; y < yEnd+1; y++ {
+		d.setMemoryPointer(xStart, y)
+		if err := d.sendCommand([]byte{byte(WriteRAM)}); err != nil {
+			return err
+		}
+		for x := xStart; x < xEnd+1; x++ {
+			bit := next.BitAt(x-xStart, y-yStart)
+			if bit {
+				byteToSend |= 0x80 >> (uint32(x) % 8)
+			}
+			if x%8 == 7 {
+				if err := d.sendData([]byte{byte(byteToSend)}); err != nil {
+					return err
+				}
+				byteToSend = 0x00
+			}
+		}
+	}
+
+	return nil
+}
+
+// ClearFrameMemory clear the frame memory with the specified color.
+// this won't update the display.
+func (d *Dev) ClearFrameMemory(color byte) error {
+	w := d.rect.Dx()
+	h := d.rect.Dy()
+	d.setMemoryArea(0, 0, w-1, h-1)
+	d.setMemoryPointer(0, 0)
+	if err := d.sendCommand([]byte{byte(WriteRAM)}); err != nil {
+		return err
+	}
+	// send the color data
+	for i := 0; i < (w / 8 * h); i++ {
+		if err := d.sendData([]byte{color}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// DisplayFrame update the display
+// there are 2 memory areas embedded in the e-paper display
+// but once this function is called,
+// the next action of SetFrameMemory or ClearFrame will
+// set the other memory area.
+func (d *Dev) DisplayFrame() error {
+	if err := d.sendCommand([]byte{byte(DisplayUpdateControl2)}); err != nil {
+		return err
+	}
+
+	if err := d.sendData([]byte{byte(0xC4)}); err != nil {
+		return err
+	}
+
+	if err := d.sendCommand([]byte{byte(MasterActivation)}); err != nil {
+		return err
+	}
+
+	if err := d.sendCommand([]byte{byte(TerminateFrameReadWrite)}); err != nil {
+		return err
+	}
+
+	d.waitUntilIdle()
+	return nil
+}
+
+// Halt turns off the display.
+func (d *Dev) Halt() error {
+	return d.Sleep()
+}
+
+// Sleep After this command is transmitted, the chip would enter the
+// deep-sleep mode to save power.
+// The deep sleep mode would return to standby by hardware reset.
+// You can use reset() to awaken or init() to initialize
+func (d *Dev) Sleep() error {
+	if err := d.sendCommand([]byte{DeepSleepMode}); err != nil {
+		return err
+	}
+
+	d.waitUntilIdle()
+	return nil
+}
+
+func (d *Dev) reset() {
+	d.rst.Out(gpio.Low)
+	time.Sleep(200 * time.Millisecond)
+	d.rst.Out(gpio.High)
+	time.Sleep(200 * time.Millisecond)
+}
+
+func (d *Dev) setMemoryPointer(x, y int) error {
+	if err := d.sendCommand([]byte{SetRAMXAddressCounter}); err != nil {
+		return err
+	}
+
+	// x point must be the multiple of 8 or the last 3 bits will be ignored
+	if err := d.sendData([]byte{byte((x >> 3) & 0xFF)}); err != nil {
+		return err
+	}
+
+	if err := d.sendCommand([]byte{byte(SetRAMYAddressCounter)}); err != nil {
+		return err
+	}
+	if err := d.sendData([]byte{byte(y & 0xFF)}); err != nil {
+		return err
+	}
+	if err := d.sendData([]byte{byte((y >> 8) & 0xFF)}); err != nil {
+		return err
+	}
+
+	d.waitUntilIdle()
+
+	return nil
+}
+
+func (d *Dev) waitUntilIdle() {
+	for d.busy.Read() == gpio.High {
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+func (d *Dev) setMemoryArea(xStart, yStart, xEnd, yEnd int) error {
+	if err := d.sendCommand([]byte{SetRAMXAddressStartEndPosition}); err != nil {
+		return err
+	}
+
+	if err := d.sendData([]byte{byte((xStart >> 3) & 0xFF)}); err != nil {
+		return err
+	}
+	if err := d.sendData([]byte{byte((xEnd >> 3) & 0xFF)}); err != nil {
+		return err
+	}
+
+	if err := d.sendCommand([]byte{byte(SetRAMYAddressStartEndPosition)}); err != nil {
+		return err
+	}
+	if err := d.sendData([]byte{byte(yStart & 0xFF)}); err != nil {
+		return err
+	}
+	if err := d.sendData([]byte{byte((yStart >> 8) & 0xFF)}); err != nil {
+		return err
+	}
+	if err := d.sendData([]byte{byte(yEnd & 0xFF)}); err != nil {
+		return err
+	}
+	if err := d.sendData([]byte{byte((yEnd >> 8) & 0xFF)}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Dev) setLut(lt LUTType) error {
+	d.lt = lt
+	lut := d.config.FullUpdate
+	if lt == Partial {
+		lut = d.config.PartialUpdate
+	}
+
+	if err := d.sendCommand([]byte{WriteLutRegister}); err != nil {
+		return err
+	}
+
+	for i := range lut {
+		d.sendData([]byte{lut[i]})
+	}
+	return nil
+}
+
+func (d *Dev) sendData(c []byte) error {
+	if err := d.dc.Out(gpio.High); err != nil {
+		return err
+	}
+	return d.c.Tx(c, nil)
+}
+
+func (d *Dev) sendCommand(c []byte) error {
+	if err := d.dc.Out(gpio.Low); err != nil {
+		return err
+	}
+	return d.c.Tx(c, nil)
+}
+
+var _ display.Drawer = &Dev{}

--- a/experimental/devices/epd/epd.go
+++ b/experimental/devices/epd/epd.go
@@ -12,21 +12,14 @@ import (
 	"image/draw"
 	"time"
 
+	"periph.io/x/periph/host/rpi"
+
 	"periph.io/x/periph/conn"
 	"periph.io/x/periph/conn/display"
 	"periph.io/x/periph/conn/gpio"
-	"periph.io/x/periph/conn/gpio/gpioreg"
 	"periph.io/x/periph/conn/physic"
 	"periph.io/x/periph/conn/spi"
 	"periph.io/x/periph/devices/ssd1306/image1bit"
-)
-
-// Raspberry pi hat pins
-const (
-	ResetPin       = "17"
-	DataCommandPin = "25"
-	ChipSelectPin  = "8"
-	BusyStatePin   = "24"
 )
 
 // EPD commands
@@ -213,10 +206,10 @@ func NewSPI(p spi.Port, dc, cs, rst gpio.PinOut, busy gpio.PinIO, config *Displa
 // NewSPIHat returns a Dev object that communicates over SPI
 // and have the default config for the e-paper hat for raspberry pi
 func NewSPIHat(p spi.Port, config *DisplayConfig) (*Dev, error) {
-	dc := gpioreg.ByName(DataCommandPin)
-	cs := gpioreg.ByName(ChipSelectPin)
-	rst := gpioreg.ByName(ResetPin)
-	busy := gpioreg.ByName(BusyStatePin)
+	dc := rpi.P1_22
+	cs := rpi.P1_24
+	rst := rpi.P1_11
+	busy := rpi.P1_18
 	return NewSPI(p, dc, cs, rst, busy, config)
 }
 

--- a/experimental/devices/epd/epd.go
+++ b/experimental/devices/epd/epd.go
@@ -114,7 +114,7 @@ func NewSPI(p spi.Port, dc, cs, rst gpio.PinOut, busy gpio.PinIO, opts *Opts) (*
 		return nil, err
 	}
 
-	c, err := p.Connect(2*physic.MegaHertz, spi.Mode0, 8)
+	c, err := p.Connect(5*physic.MegaHertz, spi.Mode0, 8)
 	if err != nil {
 		return nil, err
 	}

--- a/experimental/devices/epd/epd.go
+++ b/experimental/devices/epd/epd.go
@@ -50,7 +50,7 @@ const (
 // LUT contains the display specific waveform for the pixel programming of the display.
 type LUT []byte
 
-// PartialUpdate display update is full or partial
+// PartialUpdate represents if updates to the display should be full or partial.
 type PartialUpdate bool
 
 const (
@@ -245,11 +245,11 @@ func (d *Dev) ClearFrameMemory(color byte) error {
 	return nil
 }
 
-// DisplayFrame update the display
-// there are 2 memory areas embedded in the e-paper display
-// but once this function is called,
-// the next action of SetFrameMemory or ClearFrame will
-// set the other memory area.
+// DisplayFrame update the display.
+//
+// There are 2 memory areas embedded in the e-paper display but once
+// this function is called, the next action of SetFrameMemory or ClearFrame
+// will set the other memory area.
 func (d *Dev) DisplayFrame() error {
 	if err := d.sendCommand([]byte{displayUpdateControl2}); err != nil {
 		return err
@@ -276,10 +276,11 @@ func (d *Dev) Halt() error {
 	return d.ClearFrameMemory(0xFF)
 }
 
-// Sleep After this command is transmitted, the chip would enter the
+// Sleep after this command is transmitted, the chip would enter the
 // deep-sleep mode to save power.
+//
 // The deep sleep mode would return to standby by hardware reset.
-// You can use Reset() to awaken or Init to initialize
+// You can use Reset() to awaken and Init to re-initialize the device.
 func (d *Dev) Sleep() error {
 	if err := d.sendCommand([]byte{deepSleepMode}); err != nil {
 		return err
@@ -289,7 +290,10 @@ func (d *Dev) Sleep() error {
 	return nil
 }
 
-// Init initialize the display
+// Init initialize the display config. This method is already called when creating
+// a device using NewSPI and NewSPIHat methods.
+//
+// It should be only used when you put the device to sleep and need to re-init the device.
 func (d *Dev) Init() error {
 	if err := d.sendCommand([]byte{driverOutputControl}); err != nil {
 		return err

--- a/experimental/devices/epd/example_test.go
+++ b/experimental/devices/epd/example_test.go
@@ -1,0 +1,101 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package epd_test
+
+import (
+	"image"
+	"log"
+
+	"periph.io/x/periph/experimental/devices/epd"
+
+	"periph.io/x/periph/conn/spi/spireg"
+
+	"periph.io/x/periph/devices/ssd1306/image1bit"
+	"periph.io/x/periph/host"
+)
+
+func Example() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Use spireg SPI bus registry to find the first available SPI bus.
+	b, err := spireg.Open("")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer b.Close()
+
+	dev, err := epd.NewSPIHat(b, &epd.EPD2in13) // Display config and size
+	if err != nil {
+		log.Fatalf("failed to initialize epd: %v", err)
+	}
+
+	// Draw on it.
+	img := image1bit.NewVerticalLSB(dev.Bounds())
+	// [start of example 1]
+	// Note: this code is commented out so periph does not depend on:
+	//    "golang.org/x/image/font"
+	//    "golang.org/x/image/font/basicfont"
+	//    "golang.org/x/image/math/fixed"
+	//
+	// f := basicfont.Face7x13
+	// drawer := font.Drawer{
+	// 	Dst:  img,
+	// 	Src:  &image.Uniform{image1bit.On},
+	// 	Face: f,
+	// 	Dot:  fixed.P(0, img.Bounds().Dy()-1-f.Descent),
+	// }
+	// drawer.DrawString("Hello from periph!")
+	// [end of example 1]
+
+	// [start of example 2]
+	// Note: this code is commented out so periph does not depend on:
+	//    "github.com/fogleman/gg"
+	//    "github.com/golang/freetype/truetype"
+	//    "golang.org/x/image/font/gofont/goregular"
+	//
+	// bounds := dev.Bounds()
+	// w := bounds.Dx()
+	// h := bounds.Dy()
+	// dc := gg.NewContext(w, h)
+	// im, err := gg.LoadPNG("gopher.png")
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// dc.SetRGB(1, 1, 1)
+	// dc.Clear()
+	// dc.SetRGB(0, 0, 0)
+	// dc.Rotate(gg.Radians(90))
+	// dc.Translate(0.0, -float64(h/2))
+	// font, err := truetype.Parse(goregular.TTF)
+	// if err != nil {
+	// 	panic(err)
+	// }
+	// face := truetype.NewFace(font, &truetype.Options{
+	// 	Size: 16,
+	// })
+	// dc.SetFontFace(face)
+	// text := "Hello from periph!"
+	// tw, th := dc.MeasureString(text)
+	// dc.DrawImage(im, 120, 30)
+	// padding := 8.0
+	// dc.DrawRoundedRectangle(padding*2, padding*2, tw+padding*2, th+padding, 10)
+	// dc.Stroke()
+	// dc.DrawString(text, padding*3, padding*2+th)
+	// for i := 0; i < 10; i++ {
+	// 	dc.DrawCircle(float64(30+(10*i)), 100, 5)
+	// }
+	// for i := 0; i < 10; i++ {
+	// 	dc.DrawRectangle(float64(30+(10*i)), 80, 5, 5)
+	// }
+	// dc.Fill()
+	// [end of example 2]
+	if err := dev.Draw(dev.Bounds(), img, image.Point{}); err != nil {
+		log.Fatal(err)
+	}
+	dev.DisplayFrame() // After drawing on the display, you have to show the frame
+}

--- a/experimental/devices/epd/example_test.go
+++ b/experimental/devices/epd/example_test.go
@@ -36,7 +36,6 @@ func Example() {
 
 	// Draw on it.
 	img := image1bit.NewVerticalLSB(dev.Bounds())
-	// [start of example 1]
 	// Note: this code is commented out so periph does not depend on:
 	//    "golang.org/x/image/font"
 	//    "golang.org/x/image/font/basicfont"
@@ -50,9 +49,32 @@ func Example() {
 	// 	Dot:  fixed.P(0, img.Bounds().Dy()-1-f.Descent),
 	// }
 	// drawer.DrawString("Hello from periph!")
-	// [end of example 1]
 
-	// [start of example 2]
+	if err := dev.Draw(dev.Bounds(), img, image.Point{}); err != nil {
+		log.Fatal(err)
+	}
+	dev.DisplayFrame() // After drawing on the display, you have to show the frame
+}
+
+func Example_other() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Use spireg SPI bus registry to find the first available SPI bus.
+	b, err := spireg.Open("")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer b.Close()
+
+	dev, err := epd.NewSPIHat(b, &epd.EPD2in13) // Display config and size
+	if err != nil {
+		log.Fatalf("failed to initialize epd: %v", err)
+	}
+
+	var img image.Image
 	// Note: this code is commented out so periph does not depend on:
 	//    "github.com/fogleman/gg"
 	//    "github.com/golang/freetype/truetype"
@@ -93,7 +115,7 @@ func Example() {
 	// 	dc.DrawRectangle(float64(30+(10*i)), 80, 5, 5)
 	// }
 	// dc.Fill()
-	// [end of example 2]
+	// img = dc.Image()
 	if err := dev.Draw(dev.Bounds(), img, image.Point{}); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Initial ePaper display support for the Waveshare family of displays. I have the 2.13inch model, that is also a Raspberry Pi Hat. 
Product: https://www.waveshare.com/wiki/2.13inch_e-Paper_HAT

I almost ported from this implementation in Python:
https://github.com/soonuse/epd-library-python

![img_5129](https://user-images.githubusercontent.com/1615543/47610688-9306a280-da29-11e8-9eba-931f4b0be356.JPG)
