### PR TITLE
[feat] Add support for pca9685 pwm module

### DIFF
--- a/experimental/devices/pca9685/doc.go
+++ b/experimental/devices/pca9685/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package pca9685 includes utilities to controls pca9685 module and servo motors.
+// More details
+//
+// See https://periph.io/device/pca9685/ for more details about the device.
+//
+// Based on https://github.com/wintersandroid/Android-Things-PCA9685
+//
+// Datasheets:
+// https://cdn-shop.adafruit.com/datasheets/PCA9685.pdf
+//
+// Product page:
+// https://www.adafruit.com/product/815
+package pca9685

--- a/experimental/devices/pca9685/doc.go
+++ b/experimental/devices/pca9685/doc.go
@@ -3,15 +3,14 @@
 // that can be found in the LICENSE file.
 
 // Package pca9685 includes utilities to controls pca9685 module and servo motors.
+//
 // More details
 //
-// See https://periph.io/device/pca9685/ for more details about the device.
+// Datasheet
 //
-// Based on https://github.com/wintersandroid/Android-Things-PCA9685
-//
-// Datasheets:
-// https://cdn-shop.adafruit.com/datasheets/PCA9685.pdf
+// https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf
 //
 // Product page:
-// https://www.adafruit.com/product/815
+//
+// https://www.nxp.com/products/analog/interfaces/ic-bus/ic-led-controllers/16-channel-12-bit-pwm-fm-plus-ic-bus-led-controller:PCA9685
 package pca9685

--- a/experimental/devices/pca9685/example_test.go
+++ b/experimental/devices/pca9685/example_test.go
@@ -1,0 +1,50 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+package pca9685_test
+
+import (
+	"log"
+
+	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/experimental/devices/pca9685"
+
+	"periph.io/x/periph/host"
+)
+
+func Example() {
+	_, err := host.Init()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bus, err := i2creg.Open("")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pca, err := pca9685.NewI2C(bus)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pca.SetPwmFreq(50)
+	pca.SetAllPwm(0, 0)
+	servos := pca9685.NewServoGroup(pca, 50, 650, 0, 180)
+
+	// This is an example of using with an Me Arm robot arm
+	gripServo := servos.GetServo(0)
+	baseServo := servos.GetServo(1)
+	elbowServo := servos.GetServo(2)
+	shoulderServo := servos.GetServo(3)
+
+	gripServo.SetMinMaxAngle(15, 120)
+	elbowServo.SetMinMaxAngle(50, 110)    // Set limit of the robot arm
+	shoulderServo.SetMinMaxAngle(60, 140) // Set limit of the robot arm
+
+	// Set all in the middle in a MeArm robot arm
+	gripServo.SetAngle(90)
+	baseServo.SetAngle(90)
+	elbowServo.SetAngle(90)
+	shoulderServo.SetAngle(90)
+}

--- a/experimental/devices/pca9685/example_test.go
+++ b/experimental/devices/pca9685/example_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 
 	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/conn/physic"
 	"periph.io/x/periph/experimental/devices/pca9685"
 	"periph.io/x/periph/host"
 )
@@ -28,7 +29,7 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	if err := pca.SetPwmFreq(50); err != nil {
+	if err := pca.SetPwmFreq(50 * physic.Hertz); err != nil {
 		log.Fatal(err)
 	}
 	if err := pca.SetAllPwm(0, 0); err != nil {

--- a/experimental/devices/pca9685/example_test.go
+++ b/experimental/devices/pca9685/example_test.go
@@ -1,6 +1,7 @@
 // Copyright 2018 The Periph Authors. All rights reserved.
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
+
 package pca9685_test
 
 import (
@@ -8,7 +9,6 @@ import (
 
 	"periph.io/x/periph/conn/i2c/i2creg"
 	"periph.io/x/periph/experimental/devices/pca9685"
-
 	"periph.io/x/periph/host"
 )
 
@@ -23,13 +23,17 @@ func Example() {
 		log.Fatal(err)
 	}
 
-	pca, err := pca9685.NewI2C(bus)
+	pca, err := pca9685.NewI2C(bus, pca9685.I2CAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	pca.SetPwmFreq(50)
-	pca.SetAllPwm(0, 0)
+	if err := pca.SetPwmFreq(50); err != nil {
+		log.Fatal(err)
+	}
+	if err := pca.SetAllPwm(0, 0); err != nil {
+		log.Fatal(err)
+	}
 	servos := pca9685.NewServoGroup(pca, 50, 650, 0, 180)
 
 	// This is an example of using with an Me Arm robot arm
@@ -43,8 +47,16 @@ func Example() {
 	shoulderServo.SetMinMaxAngle(60, 140) // Set limit of the robot arm
 
 	// Set all in the middle in a MeArm robot arm
-	gripServo.SetAngle(90)
-	baseServo.SetAngle(90)
-	elbowServo.SetAngle(90)
-	shoulderServo.SetAngle(90)
+	if err := gripServo.SetAngle(90); err != nil {
+		log.Fatal(err)
+	}
+	if err := baseServo.SetAngle(90); err != nil {
+		log.Fatal(err)
+	}
+	if err := elbowServo.SetAngle(90); err != nil {
+		log.Fatal(err)
+	}
+	if err := shoulderServo.SetAngle(90); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/experimental/devices/pca9685/pca9685.go
+++ b/experimental/devices/pca9685/pca9685.go
@@ -13,32 +13,32 @@ import (
 	"periph.io/x/periph/conn/i2c"
 )
 
-// PCA9685Address i2c default address
-const PCA9685Address uint16 = 0x40
+// I2CAddr i2c default address.
+const I2CAddr uint16 = 0x40
 
 // PCA9685 Commands
 const (
-	Mode1      byte = 0x00
-	Mode2      byte = 0x01
-	SubAdr1    byte = 0x02
-	SubAdr2    byte = 0x03
-	SubAdr3    byte = 0x04
-	Prescale   byte = 0xFE
-	Led0OnL    byte = 0x06
-	Led0OnH    byte = 0x07
-	Led0OffL   byte = 0x08
-	Led0OffH   byte = 0x09
-	AllLedOnL  byte = 0xFA
-	AllLedOnH  byte = 0xFB
-	AllLedOffL byte = 0xFC
-	AllLedOffH byte = 0xFD
+	mode1      byte = 0x00
+	mode2      byte = 0x01
+	subAdr1    byte = 0x02
+	subAdr2    byte = 0x03
+	subAdr3    byte = 0x04
+	prescale   byte = 0xFE
+	led0OnL    byte = 0x06
+	led0OnH    byte = 0x07
+	led0OffL   byte = 0x08
+	led0OffH   byte = 0x09
+	allLedOnL  byte = 0xFA
+	allLedOnH  byte = 0xFB
+	allLedOffL byte = 0xFC
+	allLedOffH byte = 0xFD
 
 	// Bits
-	Restart byte = 0x80
-	Sleep   byte = 0x10
-	AllCall byte = 0x01
-	Invrt   byte = 0x10
-	OutDrv  byte = 0x04
+	restart byte = 0x80
+	sleep   byte = 0x10
+	allCall byte = 0x01
+	invrt   byte = 0x10
+	outDrv  byte = 0x04
 )
 
 // Dev is a handler to pca9685 controller
@@ -46,82 +46,121 @@ type Dev struct {
 	dev *i2c.Dev
 }
 
-// NewI2CAddress returns a Dev object that communicates over I2C on a alternate address
-func NewI2CAddress(bus i2c.Bus, address uint16) (*Dev, error) {
+// NewI2C returns a Dev object that communicates over I2C.
+//
+// To use on the default address, pca9685.I2CAddr must be passed as argument.
+func NewI2C(bus i2c.Bus, address uint16) (*Dev, error) {
 	dev := &Dev{
 		dev: &i2c.Dev{Bus: bus, Addr: address},
 	}
 	err := dev.init()
-	return dev, err
-}
+	if err != nil {
+		return nil, err
+	}
 
-// NewI2C returns a Dev object that communicates over I2C on the default address
-func NewI2C(bus i2c.Bus) (*Dev, error) {
-	return NewI2CAddress(bus, PCA9685Address)
+	return dev, nil
 }
 
 func (d *Dev) init() error {
-	d.SetAllPwm(0, 0)
-	d.dev.Write([]byte{Mode2, OutDrv})
-	d.dev.Write([]byte{Mode1, AllCall})
+	if err := d.SetAllPwm(0, 0); err != nil {
+		return err
+	}
+
+	if _, err := d.dev.Write([]byte{mode2, outDrv}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{mode1, allCall}); err != nil {
+		return err
+	}
 
 	time.Sleep(100 * time.Millisecond)
 
-	var mode1 byte
-	err := d.dev.Tx([]byte{Mode1}, []byte{mode1})
+	var modeRead []byte
+	modeRead = make([]byte, 1)
+	err := d.dev.Tx([]byte{mode1}, modeRead)
 
 	if err != nil {
 		return err
 	}
 
-	mode1 = mode1 & ^Sleep
-	d.dev.Write([]byte{Mode1, mode1 & 0xFF})
+	mode := modeRead[0]
+	mode = mode & ^sleep
+	if _, err := d.dev.Write([]byte{mode1, mode & 0xFF}); err != nil {
+		return err
+	}
 
 	time.Sleep(5 * time.Millisecond)
 
-	err = d.SetPwmFreq(50)
-	return err
+	return d.SetPwmFreq(50 * physic.Hertz)
 }
 
 // SetPwmFreq set the pwm frequency
-func (d *Dev) SetPwmFreq(freqHz float32) error {
-	prescaleval := float32(25 * physic.MegaHertz)
-	prescaleval /= 4096.0 //# 12-bit
-	prescaleval /= (freqHz * float32(physic.Hertz))
-	prescaleval -= 1.0
+func (d *Dev) SetPwmFreq(freqHz physic.Frequency) error {
+	prescaleVal := float32(25 * physic.MegaHertz)
+	prescaleVal /= 4096.0 //# 12-bit
+	prescaleVal /= float32(freqHz)
+	prescaleVal -= 1.0
 
-	prescale := int(math.Floor(float64(prescaleval + 0.5)))
+	prescaleToSend := int(math.Floor(float64(prescaleVal + 0.5)))
 
-	var oldmode byte
-	err := d.dev.Tx([]byte{Mode1}, []byte{oldmode})
+	var modeRead []byte
+	modeRead = make([]byte, 1)
+	err := d.dev.Tx([]byte{mode1}, modeRead)
 
 	if err != nil {
 		return err
 	}
 
-	newmode := (byte)((oldmode & 0x7F) | 0x10) // sleep
-	d.dev.Write([]byte{Mode1, newmode})        // go to sleep
-	d.dev.Write([]byte{Prescale, byte(prescale)})
-	d.dev.Write([]byte{Mode1, oldmode})
+	oldmode := modeRead[0]
+	newmode := (byte)((oldmode & 0x7F) | 0x10)                     // sleep
+	if _, err := d.dev.Write([]byte{mode1, newmode}); err != nil { // go to sleep;
+		return err
+	}
+	if _, err := d.dev.Write([]byte{prescale, byte(prescaleToSend)}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{mode1, oldmode}); err != nil {
+		return err
+	}
 
 	time.Sleep(100 * time.Millisecond)
 
-	d.dev.Write([]byte{Mode1, (byte)(oldmode | 0x80)})
+	if _, err := d.dev.Write([]byte{mode1, (byte)(oldmode | 0x80)}); err != nil {
+		return err
+	}
 	return nil
 }
 
 // SetAllPwm set a pwm value for all outputs
-func (d *Dev) SetAllPwm(on uint16, off uint16) {
-	d.dev.Write([]byte{AllLedOnL, byte(on) & 0xFF})
-	d.dev.Write([]byte{AllLedOnH, byte(on >> 8)})
-	d.dev.Write([]byte{AllLedOffL, byte(off) & 0xFF})
-	d.dev.Write([]byte{AllLedOffH, byte(off >> 8)})
+func (d *Dev) SetAllPwm(on uint16, off uint16) error {
+	if _, err := d.dev.Write([]byte{allLedOnL, byte(on) & 0xFF}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{allLedOnH, byte(on >> 8)}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{allLedOffL, byte(off) & 0xFF}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{allLedOffH, byte(off >> 8)}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // SetPwm set a pwm value for given pca9685 channel
-func (d *Dev) SetPwm(channel int, on uint16, off uint16) {
-	d.dev.Write([]byte{Led0OnL + byte(4*channel), byte(on) & 0xFF})
-	d.dev.Write([]byte{Led0OnH + byte(4*channel), byte(on >> 8)})
-	d.dev.Write([]byte{Led0OffL + byte(4*channel), byte(off) & 0xFF})
-	d.dev.Write([]byte{Led0OffH + byte(4*channel), byte(off >> 8)})
+func (d *Dev) SetPwm(channel int, on uint16, off uint16) error {
+	if _, err := d.dev.Write([]byte{led0OnL + byte(4*channel), byte(on) & 0xFF}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{led0OnH + byte(4*channel), byte(on >> 8)}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{led0OffL + byte(4*channel), byte(off) & 0xFF}); err != nil {
+		return err
+	}
+	if _, err := d.dev.Write([]byte{led0OffH + byte(4*channel), byte(off >> 8)}); err != nil {
+		return err
+	}
+	return nil
 }

--- a/experimental/devices/pca9685/pca9685.go
+++ b/experimental/devices/pca9685/pca9685.go
@@ -1,0 +1,127 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package pca9685
+
+import (
+	"math"
+	"time"
+
+	"periph.io/x/periph/conn/physic"
+
+	"periph.io/x/periph/conn/i2c"
+)
+
+// PCA9685Address i2c default address
+const PCA9685Address uint16 = 0x40
+
+// PCA9685 Commands
+const (
+	Mode1      byte = 0x00
+	Mode2      byte = 0x01
+	SubAdr1    byte = 0x02
+	SubAdr2    byte = 0x03
+	SubAdr3    byte = 0x04
+	Prescale   byte = 0xFE
+	Led0OnL    byte = 0x06
+	Led0OnH    byte = 0x07
+	Led0OffL   byte = 0x08
+	Led0OffH   byte = 0x09
+	AllLedOnL  byte = 0xFA
+	AllLedOnH  byte = 0xFB
+	AllLedOffL byte = 0xFC
+	AllLedOffH byte = 0xFD
+
+	// Bits
+	Restart byte = 0x80
+	Sleep   byte = 0x10
+	AllCall byte = 0x01
+	Invrt   byte = 0x10
+	OutDrv  byte = 0x04
+)
+
+// Dev is a handler to pca9685 controller
+type Dev struct {
+	dev *i2c.Dev
+}
+
+// NewI2CAddress returns a Dev object that communicates over I2C on a alternate address
+func NewI2CAddress(bus i2c.Bus, address uint16) (*Dev, error) {
+	dev := &Dev{
+		dev: &i2c.Dev{Bus: bus, Addr: address},
+	}
+	err := dev.init()
+	return dev, err
+}
+
+// NewI2C returns a Dev object that communicates over I2C on the default address
+func NewI2C(bus i2c.Bus) (*Dev, error) {
+	return NewI2CAddress(bus, PCA9685Address)
+}
+
+func (d *Dev) init() error {
+	d.SetAllPwm(0, 0)
+	d.dev.Write([]byte{Mode2, OutDrv})
+	d.dev.Write([]byte{Mode1, AllCall})
+
+	time.Sleep(100 * time.Millisecond)
+
+	var mode1 byte
+	err := d.dev.Tx([]byte{Mode1}, []byte{mode1})
+
+	if err != nil {
+		return err
+	}
+
+	mode1 = mode1 & ^Sleep
+	d.dev.Write([]byte{Mode1, mode1 & 0xFF})
+
+	time.Sleep(5 * time.Millisecond)
+
+	err = d.SetPwmFreq(50)
+	return err
+}
+
+// SetPwmFreq set the pwm frequency
+func (d *Dev) SetPwmFreq(freqHz float32) error {
+	prescaleval := float32(25 * physic.MegaHertz)
+	prescaleval /= 4096.0 //# 12-bit
+	prescaleval /= (freqHz * float32(physic.Hertz))
+	prescaleval -= 1.0
+
+	prescale := int(math.Floor(float64(prescaleval + 0.5)))
+
+	var oldmode byte
+	err := d.dev.Tx([]byte{Mode1}, []byte{oldmode})
+
+	if err != nil {
+		return err
+	}
+
+	newmode := (byte)((oldmode & 0x7F) | 0x10) // sleep
+	d.dev.Write([]byte{Mode1, newmode})        // go to sleep
+	d.dev.Write([]byte{Prescale, byte(prescale)})
+	d.dev.Write([]byte{Mode1, oldmode})
+
+	time.Sleep(100 * time.Millisecond)
+
+	d.dev.Write([]byte{Mode1, (byte)(oldmode | 0x80)})
+	return nil
+}
+
+// SetAllPwm set a pwm value for all outputs
+func (d *Dev) SetAllPwm(on uint16, off uint16) {
+	d.dev.Write([]byte{AllLedOnL, byte(on) & 0xFF})
+	d.dev.Write([]byte{AllLedOnH, byte(on >> 8)})
+	d.dev.Write([]byte{AllLedOffL, byte(off) & 0xFF})
+	d.dev.Write([]byte{AllLedOffH, byte(off >> 8)})
+}
+
+// SetPwm set a pwm value for given pca9685 channel
+func (d *Dev) SetPwm(channel int, on uint16, off uint16) {
+	d.dev.Write([]byte{Led0OnL + byte(4*channel), byte(on) & 0xFF})
+	d.dev.Write([]byte{Led0OnH + byte(4*channel), byte(on >> 8)})
+	d.dev.Write([]byte{Led0OffL + byte(4*channel), byte(off) & 0xFF})
+	d.dev.Write([]byte{Led0OffH + byte(4*channel), byte(off >> 8)})
+}

--- a/experimental/devices/pca9685/pca9685.go
+++ b/experimental/devices/pca9685/pca9685.go
@@ -7,6 +7,7 @@ package pca9685
 import (
 	"time"
 
+	"periph.io/x/periph/conn/gpio"
 	"periph.io/x/periph/conn/i2c"
 	"periph.io/x/periph/conn/physic"
 )
@@ -115,7 +116,7 @@ func (d *Dev) SetPwmFreq(freqHz physic.Frequency) error {
 }
 
 // SetAllPwm set a pwm value for all outputs
-func (d *Dev) SetAllPwm(on uint16, off uint16) error {
+func (d *Dev) SetAllPwm(on, off gpio.Duty) error {
 	if _, err := d.dev.Write([]byte{allLedOnL, byte(on)}); err != nil {
 		return err
 	}
@@ -132,7 +133,7 @@ func (d *Dev) SetAllPwm(on uint16, off uint16) error {
 }
 
 // SetPwm set a pwm value for given pca9685 channel
-func (d *Dev) SetPwm(channel int, on uint16, off uint16) error {
+func (d *Dev) SetPwm(channel int, on, off gpio.Duty) error {
 	if _, err := d.dev.Write([]byte{led0OnL + byte(4*channel), byte(on)}); err != nil {
 		return err
 	}

--- a/experimental/devices/pca9685/servo.go
+++ b/experimental/devices/pca9685/servo.go
@@ -1,0 +1,85 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package pca9685
+
+// ServoGroup a group of servos connected to a pca9685 module
+type ServoGroup struct {
+	*Dev
+	minPwm   int
+	maxPwm   int
+	minAngle int
+	maxAngle int
+}
+
+// Servo individual servo from a group of servos connected to a pca9685 module
+type Servo struct {
+	group    *ServoGroup
+	channel  int
+	minAngle int
+	maxAngle int
+}
+
+// NewServoGroup returns a servo group connected throught the pca9685 module
+// some pwm and angle limits can be set
+func NewServoGroup(dev *Dev, minPwm, maxPwm, minAngle, maxAngle int) *ServoGroup {
+	return &ServoGroup{
+		Dev:      dev,
+		minPwm:   minPwm,
+		maxPwm:   maxPwm,
+		minAngle: minAngle,
+		maxAngle: maxAngle,
+	}
+}
+
+// SetMinMaxPwm change pwm and angle limits
+func (s *ServoGroup) SetMinMaxPwm(minAngle, maxAngle, minPwm, maxPwm int) {
+	s.maxPwm = maxPwm
+	s.minPwm = minPwm
+	s.minAngle = minAngle
+	s.maxAngle = maxAngle
+}
+
+// SetAngle set an angle in a given channel of the servo group
+func (s *ServoGroup) SetAngle(channel, angle int) {
+	value := mapValue(angle, s.minAngle, s.maxAngle, s.minPwm, s.maxPwm)
+	s.Dev.SetPwm(channel, 0, uint16(value))
+}
+
+// GetServo returns a individual Servo to be controlled
+func (s *ServoGroup) GetServo(channel int) *Servo {
+	return &Servo{
+		group:    s,
+		channel:  channel,
+		minAngle: s.minAngle,
+		maxAngle: s.maxAngle,
+	}
+}
+
+// SetMinMaxAngle change angle limits for the servo
+func (s *Servo) SetMinMaxAngle(min, max int) {
+	s.minAngle = min
+	s.maxAngle = max
+}
+
+// SetAngle set an angle on the servo
+// will consider the angle limits set
+func (s *Servo) SetAngle(angle int) {
+	if angle < s.minAngle {
+		angle = s.minAngle
+	}
+	if angle > s.maxAngle {
+		angle = s.maxAngle
+	}
+	s.group.SetAngle(s.channel, angle)
+}
+
+// SetPwm set an pmw value to the servo
+func (s *Servo) SetPwm(pwm uint16) {
+	s.group.SetPwm(s.channel, 0, pwm)
+}
+
+func mapValue(x, inMin, inMax, outMin, outMax int) int {
+	return (x-inMin)*(outMax-outMin)/(inMax-inMin) + outMin
+}

--- a/experimental/devices/pca9685/servo.go
+++ b/experimental/devices/pca9685/servo.go
@@ -5,14 +5,15 @@
 package pca9685
 
 import (
+	"periph.io/x/periph/conn/gpio"
 	"periph.io/x/periph/conn/physic"
 )
 
 // ServoGroup a group of servos connected to a pca9685 module
 type ServoGroup struct {
 	*Dev
-	minPwm   int
-	maxPwm   int
+	minPwm   gpio.Duty
+	maxPwm   gpio.Duty
 	minAngle physic.Angle
 	maxAngle physic.Angle
 }
@@ -27,7 +28,7 @@ type Servo struct {
 
 // NewServoGroup returns a servo group connected throught the pca9685 module
 // some pwm and angle limits can be set
-func NewServoGroup(dev *Dev, minPwm, maxPwm int, minAngle, maxAngle physic.Angle) *ServoGroup {
+func NewServoGroup(dev *Dev, minPwm, maxPwm gpio.Duty, minAngle, maxAngle physic.Angle) *ServoGroup {
 	return &ServoGroup{
 		Dev:      dev,
 		minPwm:   minPwm,
@@ -38,7 +39,7 @@ func NewServoGroup(dev *Dev, minPwm, maxPwm int, minAngle, maxAngle physic.Angle
 }
 
 // SetMinMaxPwm change pwm and angle limits
-func (s *ServoGroup) SetMinMaxPwm(minAngle, maxAngle physic.Angle, minPwm, maxPwm int) {
+func (s *ServoGroup) SetMinMaxPwm(minAngle, maxAngle physic.Angle, minPwm, maxPwm gpio.Duty) {
 	s.maxPwm = maxPwm
 	s.minPwm = minPwm
 	s.minAngle = minAngle
@@ -47,8 +48,8 @@ func (s *ServoGroup) SetMinMaxPwm(minAngle, maxAngle physic.Angle, minPwm, maxPw
 
 // SetAngle set an angle in a given channel of the servo group
 func (s *ServoGroup) SetAngle(channel int, angle physic.Angle) error {
-	value := mapValue(int(angle), int(s.minAngle), int(s.maxAngle), s.minPwm, s.maxPwm)
-	return s.Dev.SetPwm(channel, 0, uint16(value))
+	value := mapValue(int(angle), int(s.minAngle), int(s.maxAngle), int(s.minPwm), int(s.maxPwm))
+	return s.Dev.SetPwm(channel, 0, gpio.Duty(value))
 }
 
 // GetServo returns a individual Servo to be controlled
@@ -80,7 +81,7 @@ func (s *Servo) SetAngle(angle physic.Angle) error {
 }
 
 // SetPwm set an pmw value to the servo
-func (s *Servo) SetPwm(pwm uint16) error {
+func (s *Servo) SetPwm(pwm gpio.Duty) error {
 	return s.group.SetPwm(s.channel, 0, pwm)
 }
 


### PR DESCRIPTION
Add support for the PCA9685 16 channel PWM module. I create this for a demo on Gophercon Brazil talking about embedded development with Golang and one of the demos was a robot arm (MeArm) controlled through Google Assistant, Cloud IoT Core and Golang running on an Orange Pi Zero. So I extracted the code for controlling the pca9685 module and I'm sending this PR.

Code for the project: https://github.com/alvarowolfx/golang-voice-iot
Demo of it working: https://youtu.be/Xep6dZ3xOYA

Based on https://github.com/wintersandroid/Android-Things-PCA9685
Datasheets: https://cdn-shop.adafruit.com/datasheets/PCA9685.pdf
Product page: https://www.adafruit.com/product/815

![img_4752](https://user-images.githubusercontent.com/1615543/47610830-fa722180-da2c-11e8-8e4e-86aa649d0b34.JPG)