### PR TITLE
ht16k33: add support for LED alphanumeric display

### DIFF
--- a/experimental/devices/ht16k33/alphanum.go
+++ b/experimental/devices/ht16k33/alphanum.go
@@ -1,0 +1,185 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ht16k33
+
+import (
+	"fmt"
+	"strconv"
+
+	"periph.io/x/periph/conn/i2c"
+)
+
+var digitValues = map[rune]uint16{
+	' ':  0x0,
+	'!':  0x6,
+	'"':  0x220,
+	'#':  0x12ce,
+	'$':  0x12ed,
+	'%':  0xc24,
+	'&':  0x235d,
+	'\'': 0x400,
+	'(':  0x2400,
+	')':  0x900,
+	'*':  0x3fc0,
+	'+':  0x12c0,
+	',':  0x800,
+	'-':  0xc0,
+	'.':  0x4000,
+	'/':  0xc00,
+	'0':  0xc3f,
+	'1':  0x6,
+	'2':  0xdb,
+	'3':  0x8f,
+	'4':  0xe6,
+	'5':  0x2069,
+	'6':  0xfd,
+	'7':  0x7,
+	'8':  0xff,
+	'9':  0xef,
+	':':  0x1200,
+	';':  0xa00,
+	'<':  0x2400,
+	'=':  0xc8,
+	'>':  0x900,
+	'?':  0x1083,
+	'@':  0x2bb,
+	'A':  0xf7,
+	'B':  0x128f,
+	'C':  0x39,
+	'D':  0x120f,
+	'E':  0xf9,
+	'F':  0x71,
+	'G':  0xbd,
+	'H':  0xf6,
+	'I':  0x1200,
+	'J':  0x1e,
+	'K':  0x2470,
+	'L':  0x38,
+	'M':  0x536,
+	'N':  0x2136,
+	'O':  0x3f,
+	'P':  0xf3,
+	'Q':  0x203f,
+	'R':  0x20f3,
+	'S':  0xed,
+	'T':  0x1201,
+	'U':  0x3e,
+	'V':  0xc30,
+	'W':  0x2836,
+	'X':  0x2d00,
+	'Y':  0x1500,
+	'Z':  0xc09,
+	'[':  0x39,
+	'\\': 0x2100,
+	']':  0xf,
+	'^':  0xc03,
+	'_':  0x8,
+	'`':  0x100,
+	'a':  0x1058,
+	'b':  0x2078,
+	'c':  0xd8,
+	'd':  0x88e,
+	'e':  0x858,
+	'f':  0x71,
+	'g':  0x48e,
+	'h':  0x1070,
+	'i':  0x1000,
+	'j':  0xe,
+	'k':  0x3600,
+	'l':  0x30,
+	'm':  0x10d4,
+	'n':  0x1050,
+	'o':  0xdc,
+	'p':  0x170,
+	'q':  0x486,
+	'r':  0x50,
+	's':  0x2088,
+	't':  0x78,
+	'u':  0x1c,
+	'v':  0x2004,
+	'w':  0x2814,
+	'x':  0x28c0,
+	'y':  0x200c,
+	'z':  0x848,
+	'{':  0x949,
+	'|':  0x1200,
+	'}':  0x2489,
+	'~':  0x520,
+}
+
+// Display is a handler to control an alphanumeric display based on ht16k33.
+type Display struct {
+	dev *Dev
+}
+
+// NewAlphaNumericDisplay returns a Display object that communicates over I2C to ht16k33.
+//
+// To use on the default address, ht16k33.I2CAddr must be passed as argument.
+func NewAlphaNumericDisplay(bus i2c.Bus, address uint16) (*Display, error) {
+	dev, err := NewI2C(bus, address)
+	if err != nil {
+		return nil, err
+	}
+
+	display := &Display{dev: dev}
+	return display, nil
+}
+
+// SetDigit at position to provided value.
+func (d *Display) SetDigit(pos int, digit rune, decimal bool) error {
+	val := digitValues[digit]
+	if decimal {
+		val |= digitValues['.']
+	}
+	return d.dev.WriteColumn(pos, val)
+}
+
+// DisplayString print string of values to the display.
+//
+// Characters in the string should be any ASCII value 32 to 127 (printable ASCII).
+func (d *Display) DisplayString(value string, justifyRight bool) error {
+	err := d.dev.Clear()
+	if err != nil {
+		return err
+	}
+	// Calculate starting position of digits based on justification.
+	pos := (4 - len(value))
+	if !justifyRight || pos < 0 {
+		pos = 0
+	}
+	// Go through each character and print it on the display.
+	for _, ch := range value {
+		if ch == '.' {
+			// Print decimal points on the previous digit.
+			c := rune(value[pos-1])
+			if err := d.SetDigit(pos-1, c, true); err != nil {
+				return err
+			}
+		} else {
+			if err := d.SetDigit(pos, ch, false); err != nil {
+				return err
+			}
+			pos++
+		}
+	}
+	return nil
+}
+
+// DisplayInt print a string of numeric values to the display.
+func (d *Display) DisplayInt(value int, justifyRight bool) error {
+	str := strconv.Itoa(value)
+	return d.DisplayString(str, justifyRight)
+}
+
+// DisplayFloat print a string of numeric values to the display.
+func (d *Display) DisplayFloat(value float64, justifyRight bool) error {
+	str := fmt.Sprintf("%5f", value)
+	return d.DisplayString(str, justifyRight)
+}
+
+// Halt clear all the display.
+func (d *Display) Halt() error {
+	return d.dev.Clear()
+}

--- a/experimental/devices/ht16k33/doc.go
+++ b/experimental/devices/ht16k33/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package ht16k33 implements interfacing code to Holtek HT16K33 Alphanumeric 16x8 LED driver.
+//
+// More Details
+//
+// Datasheets
+//
+// http://www.holtek.com/documents/10179/116711/HT16K33v120.pdf
+//
+// Product Page
+//
+// http://www.holtek.com/productdetail/-/vg/HT16K33
+package ht16k33

--- a/experimental/devices/ht16k33/example_test.go
+++ b/experimental/devices/ht16k33/example_test.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+package ht16k33_test
+
+import (
+	"log"
+	"time"
+
+	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/experimental/devices/ht16k33"
+
+	"periph.io/x/periph/host"
+)
+
+func Example() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	bus, err := i2creg.Open("")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer bus.Close()
+
+	display, err := ht16k33.NewAlphaNumericDisplay(bus, ht16k33.I2CAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer display.Halt()
+
+	display.DisplayString("ABCD", true)
+	time.Sleep(1 * time.Second)
+
+	display.DisplayString("GO", true)
+	time.Sleep(1 * time.Second)
+
+	display.DisplayInt(1234, true)
+	time.Sleep(1 * time.Second)
+
+	display.DisplayInt(60, true)
+	time.Sleep(1 * time.Second)
+
+	display.DisplayFloat(23.99, true)
+	time.Sleep(1 * time.Second)
+
+	display.DisplayFloat(1.45, true)
+	time.Sleep(1 * time.Second)
+}

--- a/experimental/devices/ht16k33/example_test.go
+++ b/experimental/devices/ht16k33/example_test.go
@@ -4,12 +4,12 @@
 package ht16k33_test
 
 import (
+	"fmt"
 	"log"
 	"time"
 
 	"periph.io/x/periph/conn/i2c/i2creg"
 	"periph.io/x/periph/experimental/devices/ht16k33"
-
 	"periph.io/x/periph/host"
 )
 
@@ -31,21 +31,33 @@ func Example() {
 	}
 	defer display.Halt()
 
-	display.DisplayString("ABCD", true)
+	if _, err := display.WriteString("ABCD"); err != nil {
+		log.Fatal(err)
+	}
 	time.Sleep(1 * time.Second)
 
-	display.DisplayString("GO", true)
+	if _, err := display.WriteString("GO"); err != nil {
+		log.Fatal(err)
+	}
 	time.Sleep(1 * time.Second)
 
-	display.DisplayInt(1234, true)
+	if _, err := display.WriteString(fmt.Sprintf("%d", 1234)); err != nil {
+		log.Fatal(err)
+	}
 	time.Sleep(1 * time.Second)
 
-	display.DisplayInt(60, true)
+	if _, err := display.WriteString(fmt.Sprintf("%d", 60)); err != nil {
+		log.Fatal(err)
+	}
 	time.Sleep(1 * time.Second)
 
-	display.DisplayFloat(23.99, true)
+	if _, err := display.WriteString(fmt.Sprintf("%5f", 23.99)); err != nil {
+		log.Fatal(err)
+	}
 	time.Sleep(1 * time.Second)
 
-	display.DisplayFloat(1.45, true)
+	if _, err := display.WriteString(fmt.Sprintf("%5f", 1.45)); err != nil {
+		log.Fatal(err)
+	}
 	time.Sleep(1 * time.Second)
 }

--- a/experimental/devices/ht16k33/ht16k33.go
+++ b/experimental/devices/ht16k33/ht16k33.go
@@ -1,0 +1,119 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package ht16k33
+
+import (
+	"errors"
+
+	"periph.io/x/periph/conn/i2c"
+)
+
+// I2CAddr i2c default address.
+const I2CAddr uint16 = 0x70
+
+const (
+	cmdRAM        = 0x00
+	cmdKeys       = 0x40
+	displaySetup  = 0x80
+	displayOff    = 0x00
+	displayOn     = 0x01
+	systemSetup   = 0x20
+	oscillatorOff = 0x00
+	oscillatorOn  = 0x01
+	cmdBrightness = 0xE0
+)
+
+// BlinkFrequency display frequency must be a value allowed by the HT16K33.
+type BlinkFrequency byte
+
+// Note that frequency must be a value allowed by the HT16K33, specifically one of:
+const (
+	BlinkOff    = 0x00
+	Blink2Hz    = 0x02
+	Blink1Hz    = 0x04
+	BlinkHalfHz = 0x06
+)
+
+// Dev is a handler to ht16k33 controller
+type Dev struct {
+	dev *i2c.Dev
+}
+
+// NewI2C returns a Dev object that communicates over I2C.
+//
+// To use on the default address, ht16k33.I2CAddr must be passed as argument.
+func NewI2C(bus i2c.Bus, address uint16) (*Dev, error) {
+	dev := &Dev{
+		dev: &i2c.Dev{Bus: bus, Addr: address},
+	}
+	err := dev.init()
+	if err != nil {
+		return nil, err
+	}
+
+	return dev, nil
+}
+
+func (d *Dev) init() error {
+	// Turn on the oscillator.
+	if _, err := d.dev.Write([]byte{systemSetup | oscillatorOn}); err != nil {
+		return err
+	}
+
+	// Turn on display
+	if _, err := d.dev.Write([]byte{displaySetup | displayOn}); err != nil {
+		return err
+	}
+
+	// Set no blinking.
+	if err := d.SetBlink(BlinkOff); err != nil {
+		return err
+	}
+
+	// Set display to full brightness.
+	if err := d.SetBrightness(15); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetBlink Blink display at specified frequency.
+func (d *Dev) SetBlink(freq BlinkFrequency) error {
+	if _, err := d.dev.Write([]byte{displaySetup | displayOn | byte(freq)}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// SetBrightness of entire display to specified value.
+//
+// Supports 16 levels, from 0 to 15.
+func (d *Dev) SetBrightness(brightness int) error {
+	if brightness < 0 || brightness > 15 {
+		return errors.New("Brightness must be a value of 0 to 15")
+	}
+	if _, err := d.dev.Write([]byte{cmdBrightness | byte(brightness)}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WriteColumn oie
+func (d *Dev) WriteColumn(column int, data uint16) error {
+	if _, err := d.dev.Write([]byte{byte(column * 2), byte(data & 0xFF), byte(data >> 8)}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Clear contents of display buffer.
+func (d *Dev) Clear() error {
+	for i := 0; i < 4; i++ {
+		if err := d.WriteColumn(i, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/experimental/devices/rainbowhat/doc.go
+++ b/experimental/devices/rainbowhat/doc.go
@@ -19,4 +19,10 @@
 // Piezo Buzzer (PWM)
 //
 // Servo header (PWM)
+//
+// More details
+//
+// Product Page
+//
+// https://shop.pimoroni.com/products/rainbow-hat-for-android-things
 package rainbowhat

--- a/experimental/devices/rainbowhat/doc.go
+++ b/experimental/devices/rainbowhat/doc.go
@@ -1,0 +1,22 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package rainbowhat implements interfacing code to Pimoroni's Rainbow hat.
+//
+// This driver provides easy access to the peripherals available on the Rainbow Hat for Android Things:
+//
+// BMP280 temperature and pressure sensor (I2C)
+//
+// HT16K33 segment display (I2C)
+//
+// Capacitive buttons (GPIO)
+//
+// LEDs (GPIO)
+//
+// APA102 RGB LEDs (SPI)
+//
+// Piezo Buzzer (PWM)
+//
+// Servo header (PWM)
+package rainbowhat

--- a/experimental/devices/rainbowhat/example_test.go
+++ b/experimental/devices/rainbowhat/example_test.go
@@ -17,7 +17,7 @@ import (
 	"periph.io/x/periph/host"
 )
 
-func Example() {
+func main() {
 	// Make sure periph is initialized.
 	if _, err := host.Init(); err != nil {
 		log.Fatal(err)
@@ -49,15 +49,20 @@ func Example() {
 		log.Fatalf("failed to draw: %v", err)
 	}
 
+	display := hat.GetDisplay()
 	sensor := hat.GetBmp280()
+	count := 0
 	go func() {
 		for {
 			var envi physic.Env
 			sensor.Sense(&envi)
 
+			temp := fmt.Sprintf("%5s", envi.Temperature)
 			fmt.Printf("Pressure %8s \n", envi.Pressure)
 			fmt.Printf("Temperature %8s \n", envi.Temperature)
 
+			display.DisplayString(temp, true)
+			count++
 			time.Sleep(3 * time.Second)
 		}
 	}()

--- a/experimental/devices/rainbowhat/example_test.go
+++ b/experimental/devices/rainbowhat/example_test.go
@@ -1,0 +1,92 @@
+package rainbowhat_test
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/physic"
+	"periph.io/x/periph/experimental/devices/rainbowhat"
+
+	"periph.io/x/periph/host"
+)
+
+func Example() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	hat, err := rainbowhat.NewRainbowHat()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer hat.Close()
+
+	go handleButton(hat.GetButtonA(), hat.GetLedR())
+	go handleButton(hat.GetButtonB(), hat.GetLedG())
+	go handleButton(hat.GetButtonC(), hat.GetLedB())
+
+	ledstrip := hat.GetLedStrip()
+	ledstrip.Intensity = 50
+
+	img := image.NewNRGBA(image.Rect(0, 0, ledstrip.Bounds().Dx(), 1))
+	img.SetNRGBA(0, 0, color.NRGBA{148, 0, 211, 255})
+	img.SetNRGBA(1, 0, color.NRGBA{75, 0, 130, 255})
+	img.SetNRGBA(2, 0, color.NRGBA{0, 0, 255, 255})
+	img.SetNRGBA(3, 0, color.NRGBA{0, 255, 0, 255})
+	img.SetNRGBA(4, 0, color.NRGBA{255, 255, 0, 255})
+	img.SetNRGBA(5, 0, color.NRGBA{255, 127, 0, 255})
+	img.SetNRGBA(6, 0, color.NRGBA{255, 0, 0, 255})
+
+	if err := ledstrip.Draw(ledstrip.Bounds(), img, image.Point{}); err != nil {
+		log.Fatalf("failed to draw: %v", err)
+	}
+
+	sensor := hat.GetBmp280()
+	go func() {
+		for {
+			var envi physic.Env
+			sensor.Sense(&envi)
+
+			fmt.Printf("Pressure %8s \n", envi.Pressure)
+			fmt.Printf("Temperature %8s \n", envi.Temperature)
+
+			time.Sleep(3 * time.Second)
+		}
+	}()
+
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigs // Wait for signal
+		log.Println(sig)
+		done <- true
+	}()
+
+	log.Println("Press ctrl+c to stop...")
+	<-done // Wait
+}
+
+func handleButton(btn gpio.PinIn, led gpio.PinOut) {
+	ledState := false
+	led.Out(gpio.Low)
+	for {
+		btn.WaitForEdge(-1)
+		if ledState {
+			led.Out(gpio.High)
+		} else {
+			led.Out(gpio.Low)
+		}
+		ledState = !ledState
+	}
+}

--- a/experimental/devices/rainbowhat/rainbowhat.go
+++ b/experimental/devices/rainbowhat/rainbowhat.go
@@ -1,0 +1,152 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package rainbowhat
+
+import (
+	"periph.io/x/periph/conn/spi/spireg"
+	"periph.io/x/periph/devices/apa102"
+	"periph.io/x/periph/devices/bmxx80"
+	"periph.io/x/periph/host/rpi"
+
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/i2c/i2creg"
+)
+
+const (
+	numPixels  = 7
+	bmp280Addr = 0x77
+)
+
+// Dev represents a Rainbow HAT  (https://shop.pimoroni.com/products/rainbow-hat-for-android-things)
+type Dev struct {
+	ledstrip *apa102.Dev
+	bmp280   *bmxx80.Dev
+	buttonA  gpio.PinIn
+	buttonB  gpio.PinIn
+	buttonC  gpio.PinIn
+	ledR     gpio.PinOut
+	ledG     gpio.PinOut
+	ledB     gpio.PinOut
+	buzzer   gpio.PinOut
+	servo    gpio.PinOut
+	// TODO: Add support for HT16K33 display
+}
+
+// NewRainbowHat returns a rainbowhat driver.
+func NewRainbowHat() (*Dev, error) {
+	i2cPort, err := i2creg.Open("")
+	if err != nil {
+		return nil, err
+	}
+
+	spiPort, err := spireg.Open("")
+	if err != nil {
+		return nil, err
+	}
+
+	bmp280, err := bmxx80.NewI2C(i2cPort, bmp280Addr, &bmxx80.DefaultOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	opts := apa102.DefaultOpts
+	opts.NumPixels = numPixels
+	ledstrip, err := apa102.New(spiPort, &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	dev := &Dev{
+		ledstrip: ledstrip,
+		bmp280:   bmp280,
+		buttonA:  rpi.P1_40, // GPIO21
+		buttonB:  rpi.P1_38, // GPIO20
+		buttonC:  rpi.P1_36, // GPIO16
+		ledR:     rpi.P1_31, // GPIO06
+		ledG:     rpi.P1_35, // GPIO19
+		ledB:     rpi.P1_37, // GPIO26
+		buzzer:   rpi.P1_33, // PWM1
+		servo:    rpi.P1_32, // PWM0
+	}
+
+	if err := dev.buttonA.In(gpio.PullUp, gpio.FallingEdge); err != nil {
+		return nil, err
+	}
+
+	if err := dev.buttonB.In(gpio.PullUp, gpio.FallingEdge); err != nil {
+		return nil, err
+	}
+
+	if err := dev.buttonC.In(gpio.PullUp, gpio.FallingEdge); err != nil {
+		return nil, err
+	}
+
+	return dev, nil
+}
+
+// GetLedStrip returns apa102.Dev seven addressable led strip.
+func (d *Dev) GetLedStrip() *apa102.Dev {
+	return d.ledstrip
+}
+
+// GetBmp280 returns bmxx80.Dev handler.
+func (d *Dev) GetBmp280() *bmxx80.Dev {
+	return d.bmp280
+}
+
+// GetButtonA returns gpio.PinIn corresponding to the A capacitive button.
+func (d *Dev) GetButtonA() gpio.PinIn {
+	return d.buttonA
+}
+
+// GetButtonB returns gpio.PinIn corresponding to the B capacitive button.
+func (d *Dev) GetButtonB() gpio.PinIn {
+	return d.buttonB
+}
+
+// GetButtonC returns gpio.PinIn corresponding to the C capacitive button.
+func (d *Dev) GetButtonC() gpio.PinIn {
+	return d.buttonC
+}
+
+// GetLedR returns gpio.PinOut corresponding to the red LED.
+func (d *Dev) GetLedR() gpio.PinOut {
+	return d.ledR
+}
+
+// GetLedG returns gpio.PinOut corresponding to the green LED.
+func (d *Dev) GetLedG() gpio.PinOut {
+	return d.ledG
+}
+
+// GetLedB returns gpio.PinOut corresponding to the blue LED.
+func (d *Dev) GetLedB() gpio.PinOut {
+	return d.ledB
+}
+
+// GetBuzzer returns gpio.PinOut corresponding to the buzzer pin.
+func (d *Dev) GetBuzzer() gpio.PinOut {
+	return d.buzzer
+}
+
+// GetServo returns gpio.PinOut corresponding to the servo pin.
+func (d *Dev) GetServo() gpio.PinOut {
+	return d.servo
+}
+
+// Close halt all devices.
+func (d *Dev) Close() error {
+	err := d.bmp280.Halt()
+	if err != nil {
+		return err
+	}
+
+	err = d.ledstrip.Halt()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Add support for the Pimoroni's Rainbow HAT with a lot of peripherals. I also created the driver for the HT16K33 that drives the Alphanumeric display on the hat.

Product page: https://shop.pimoroni.com/products/rainbow-hat-for-android-things
![img_5133 trim 2018-10-28 22_59_36](https://user-images.githubusercontent.com/1615543/47627215-2bbe2080-db05-11e8-974e-3cf6153a0cfe.gif)
