### PR TITLE
hx711: add experimental driver.

### DIFF
--- a/experimental/cmd/hx711/main.go
+++ b/experimental/cmd/hx711/main.go
@@ -31,16 +31,11 @@ func mainFunc() error {
 		return err
 	}
 
-	const pinPattern = "no %s pin specified. Please provide the pin via '%s' flag, for example '%s'"
-
 	if *clkPin == "" {
-		return fmt.Errorf(pinPattern, "clock", "-clk", "-clk 25")
+		return fmt.Errorf("-clk is required")
 	}
 	if *dataPin == "" {
-		return fmt.Errorf(pinPattern, "data", "-data", "-data 26")
-	}
-	if *gain != 128 && *gain != 64 && *gain != 32 {
-		return fmt.Errorf("invalid gain '%d', must be either 128, 64 or 32", *gain)
+		return fmt.Errorf("-data is required")
 	}
 	if *cont && *samples != 0 {
 		return fmt.Errorf("-cont and -samples can't be used together")
@@ -48,24 +43,27 @@ func mainFunc() error {
 
 	clkPinReg := gpioreg.ByName(*clkPin)
 	if clkPinReg == nil {
-		return fmt.Errorf("Clock pin %s can not be found", *clkPin)
+		return fmt.Errorf("clock pin %s can not be found", *clkPin)
 	}
 	dataPinReg := gpioreg.ByName(*dataPin)
 	if dataPin == nil {
-		return fmt.Errorf("Data pin %s can not be found", *dataPin)
+		return fmt.Errorf("data pin %s can not be found", *dataPin)
 	}
 
 	dev, err := hx711.New(clkPinReg, dataPinReg)
 	if err != nil {
 		return err
 	}
+
 	switch *gain {
 	case 128:
-		dev.InputMode = hx711.CHANNEL_A_GAIN_128
+		dev.SetInputMode(hx711.CHANNEL_A_GAIN_128)
 	case 64:
-		dev.InputMode = hx711.CHANNEL_A_GAIN_64
+		dev.SetInputMode(hx711.CHANNEL_A_GAIN_64)
 	case 32:
-		dev.InputMode = hx711.CHANNEL_B_GAIN_32
+		dev.SetInputMode(hx711.CHANNEL_B_GAIN_32)
+	default:
+		return fmt.Errorf("invalid gain '%d', must be either 128, 64 or 32", *gain)
 	}
 
 	if *cont {

--- a/experimental/cmd/hx711/main.go
+++ b/experimental/cmd/hx711/main.go
@@ -1,0 +1,97 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"periph.io/x/periph/conn/gpio/gpioreg"
+	"periph.io/x/periph/experimental/devices/hx711"
+	"periph.io/x/periph/host"
+)
+
+const timeout = time.Second
+
+func mainFunc() error {
+	clkPin := flag.String("clk", "", "Clock pin")
+	dataPin := flag.String("data", "", "Data pin")
+	gain := flag.Int("gain", 128,
+		"Voltage gain. Must be one of 128, 64 or 32. Using 32 selects Channel B")
+	cont := flag.Bool("cont", false, "Reads continuously from the ADC")
+	samples := flag.Int("samples", 0,
+		"Reads several samples from the ADC and outputs the average value")
+	flag.Parse()
+
+	if _, err := host.Init(); err != nil {
+		return err
+	}
+
+	const pinPattern = "no %s pin specified. Please provide the pin via '%s' flag, for example '%s'"
+
+	if *clkPin == "" {
+		return fmt.Errorf(pinPattern, "clock", "-clk", "-clk 25")
+	}
+	if *dataPin == "" {
+		return fmt.Errorf(pinPattern, "data", "-data", "-data 26")
+	}
+	if *gain != 128 && *gain != 64 && *gain != 32 {
+		return fmt.Errorf("invalid gain '%d', must be either 128, 64 or 32")
+	}
+	if *cont && *samples != 0 {
+		return fmt.Errorf("-cont and -samples can't be used together")
+	}
+
+	clkPinReg := gpioreg.ByName(*clkPin)
+	if clkPinReg == nil {
+		return fmt.Errorf("Clock pin %s can not be found", *clkPin)
+	}
+	dataPinReg := gpioreg.ByName(*dataPin)
+	if dataPin == nil {
+		return fmt.Errorf("Data pin %s can not be found", *dataPin)
+	}
+
+	dev, err := hx711.New(clkPinReg, dataPinReg)
+	if err != nil {
+		return err
+	}
+	switch *gain {
+	case 128:
+		dev.InputMode = hx711.CHANNEL_A_GAIN_128
+	case 64:
+		dev.InputMode = hx711.CHANNEL_A_GAIN_64
+	case 32:
+		dev.InputMode = hx711.CHANNEL_B_GAIN_32
+	}
+
+	if *cont {
+		ch := dev.StartContinuousRead()
+		for {
+			fmt.Println(<-ch)
+		}
+	} else if *samples != 0 {
+		value, err := dev.ReadAveraged(timeout, *samples)
+		if err != nil {
+			return err
+		}
+		fmt.Println(value)
+	} else {
+		value, err := dev.Read(timeout)
+		if err != nil {
+			return err
+		}
+		fmt.Println(value)
+	}
+	return nil
+}
+
+func main() {
+	if err := mainFunc(); err != nil {
+		fmt.Fprintf(os.Stderr, "hx711: %s.\n", err)
+		os.Exit(1)
+	}
+}

--- a/experimental/cmd/hx711/main.go
+++ b/experimental/cmd/hx711/main.go
@@ -40,7 +40,7 @@ func mainFunc() error {
 		return fmt.Errorf(pinPattern, "data", "-data", "-data 26")
 	}
 	if *gain != 128 && *gain != 64 && *gain != 32 {
-		return fmt.Errorf("invalid gain '%d', must be either 128, 64 or 32")
+		return fmt.Errorf("invalid gain '%d', must be either 128, 64 or 32", *gain)
 	}
 	if *cont && *samples != 0 {
 		return fmt.Errorf("-cont and -samples can't be used together")

--- a/experimental/cmd/hx711/main.go
+++ b/experimental/cmd/hx711/main.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"periph.io/x/periph/conn/gpio/gpioreg"
+	"periph.io/x/periph/conn/physic"
+	"periph.io/x/periph/experimental/conn/gpio/gpioutil"
 	"periph.io/x/periph/experimental/devices/hx711"
 	"periph.io/x/periph/host"
 )
@@ -25,6 +27,8 @@ func mainFunc() error {
 	cont := flag.Bool("cont", false, "Reads continuously from the ADC")
 	samples := flag.Int("samples", 0,
 		"Reads several samples from the ADC and outputs the average value")
+	usePollEdge := flag.Bool("poll-edge", false,
+		"Poll the data pin instead of using edge detection")
 	flag.Parse()
 
 	if _, err := host.Init(); err != nil {
@@ -48,6 +52,10 @@ func mainFunc() error {
 	dataPinReg := gpioreg.ByName(*dataPin)
 	if dataPin == nil {
 		return fmt.Errorf("data pin %s can not be found", *dataPin)
+	}
+
+	if *usePollEdge {
+		dataPinReg = gpioutil.PollEdge(dataPinReg, 20*physic.KiloHertz)
 	}
 
 	dev, err := hx711.New(clkPinReg, dataPinReg)

--- a/experimental/devices/hx711/hx711.go
+++ b/experimental/devices/hx711/hx711.go
@@ -114,18 +114,15 @@ func (d *HX711) Read(timeout time.Duration) (int32, error) {
 		}
 	}
 
-	// Convert the 24-bit value to a 32-bit value by moving the MSB and padding
-	// the top byte with 1s if the value was negative.
-	if value&0x00800000 != 0 {
-		value |= 0xFF000000
-	}
+	// Convert the 24-bit 2's compliment value to a 32-bit signed value.
+	var signedValue int32 = int32(value<<8) >> 8
 
 	// Pulse the clock 1-3 more times to set the new ADC mode.
 	for i := 0; i < int(d.InputMode); i++ {
 		d.clk.Out(gpio.High)
 		d.clk.Out(gpio.Low)
 	}
-	return int32(value), nil
+	return signedValue, nil
 }
 
 // StartContinuousRead starts reading values continuously from the ADC.  It

--- a/experimental/devices/hx711/hx711.go
+++ b/experimental/devices/hx711/hx711.go
@@ -1,0 +1,183 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package hx711 implements an interface to the HX711 analog to digital converter.
+//
+// Datasheet: https://www.mouser.com/ds/2/813/hx711_english-1022875.pdf
+package hx711
+
+import (
+	"errors"
+	"time"
+
+	"periph.io/x/periph/conn/gpio"
+)
+
+var (
+	// TimeoutError is returned from Read and ReadAveraged when the ADC took too
+	// long to indicate data was available.
+	TimeoutError = errors.New("timed out waiting for HX711 to become ready")
+)
+
+// InputMode controls the voltage gain and the channel multiplexer on the HX711.
+// Channel A can be used with a gain of 128 or 64, and Channel B can be used
+// with a gain of 32.
+//
+// Changing the InputMode on an HX711 will only take effect *after* the next
+// read.
+type InputMode int
+
+const (
+	CHANNEL_A_GAIN_128 InputMode = 1
+	CHANNEL_A_GAIN_64  InputMode = 3
+	CHANNEL_B_GAIN_32  InputMode = 2
+
+	dataBits         = 24
+	readPollInterval = 50 * time.Millisecond
+)
+
+type HX711 struct {
+	InputMode InputMode
+
+	clk     gpio.PinOut
+	data    gpio.PinIn
+	useEdge bool
+	done    chan struct{}
+}
+
+// New creates a new HX711 device.
+func New(clk gpio.PinOut, data gpio.PinIn) (*HX711, error) {
+	// Try enabling edge detection on the data pin.
+	var useEdge bool
+	if err := data.In(gpio.PullDown, gpio.FallingEdge); err != nil {
+		if err := data.In(gpio.PullDown, gpio.NoEdge); err != nil {
+			return nil, err
+		}
+		useEdge = false
+	} else {
+		useEdge = true
+	}
+
+	clk.Out(gpio.Low)
+
+	return &HX711{
+		InputMode: CHANNEL_A_GAIN_128,
+		clk:       clk,
+		data:      data,
+		useEdge:   useEdge,
+		done:      nil,
+	}, nil
+}
+
+// IsReady returns true if there is data ready to be read from the ADC.
+func (d *HX711) IsReady() bool {
+	return d.data.Read() == gpio.Low
+}
+
+// Read reads a single value from the ADC.  It blocks until the ADC indicates
+// there is data ready for retrieval.  If the ADC doesn't pull its Data pin low
+// to indicate there is data ready before the timeout is reached, TimeoutError
+// is returned.
+func (d *HX711) Read(timeout time.Duration) (int32, error) {
+	if d.useEdge {
+		// If the clock pin supports edge detection, wait for the falling edge that
+		// indicates the ADC has data.
+		if !d.IsReady() {
+			if !d.data.WaitForEdge(timeout) {
+				return 0, TimeoutError
+			}
+		}
+	} else {
+		// If the clock pin doesn't support edge detection just poll every few
+		// milliseconds.
+		startTime := time.Now()
+		for !d.IsReady() {
+			if time.Now().Sub(startTime) > timeout {
+				return 0, TimeoutError
+			}
+			time.Sleep(readPollInterval)
+		}
+	}
+
+	// Shift the 24-bit 2's compliment value.
+	var value uint32
+	for i := 0; i < dataBits; i++ {
+		d.clk.Out(gpio.High)
+		level := d.data.Read()
+		d.clk.Out(gpio.Low)
+
+		if level {
+			value = (value << 1) | 1
+		} else {
+			value = (value << 1)
+		}
+	}
+
+	// Convert the 24-bit value to a 32-bit value by moving the MSB and padding
+	// the top byte with 1s if the value was negative.
+	if value&0x00800000 != 0 {
+		value |= 0xFF000000
+	}
+
+	// Pulse the clock 1-3 more times to set the new ADC mode.
+	for i := 0; i < int(d.InputMode); i++ {
+		d.clk.Out(gpio.High)
+		d.clk.Out(gpio.Low)
+	}
+	return int32(value), nil
+}
+
+// StartContinuousRead starts reading values continuously from the ADC.  It
+// returns a channel that you can use to receive these values.
+//
+// You must call StopContinuousRead to stop reading.
+//
+// Calling StartContinuousRead again before StopContinuousRead is an error,
+// and nil will be returned.
+func (d *HX711) StartContinuousRead() <-chan int32 {
+	if d.done != nil {
+		return nil
+	}
+	done := make(chan struct{})
+	ret := make(chan int32)
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				close(ret)
+				d.done = nil
+				return
+			default:
+				value, err := d.Read(time.Second)
+				if err == nil {
+					ret <- value
+				}
+			}
+		}
+	}()
+
+	d.done = done
+	return ret
+}
+
+// StopContinuousRead stops a continuous read that was started with
+// StartContinuousRead.  This will close the channel that was returned by
+// StartContinuousRead.
+func (d *HX711) StopContinuousRead() {
+	close(d.done)
+}
+
+// ReadAveraged reads several samples from the ADC and returns the mean value.
+func (d *HX711) ReadAveraged(timeout time.Duration, samples int) (int32, error) {
+	var sum int64
+	for i := 0; i < samples; i++ {
+		value, err := d.Read(timeout)
+		if err != nil {
+			return 0, err
+		}
+		sum += int64(value)
+	}
+	return int32(sum / int64(samples)), nil
+}


### PR DESCRIPTION
HX711 is a 24-bit ADC commonly used for weigh scales.