### PR TITLE
pca9548: i2c multiplexer

### DIFF
--- a/experimental/cmd/pca9548/main.go
+++ b/experimental/cmd/pca9548/main.go
@@ -33,14 +33,14 @@ func mainImpl() error {
 	}
 	defer bus.Close()
 
-	// Registers a multiplexer with 8 ports at address 0x70 if no other address
+	// Creates a multiplexer with 8 ports at address 0x70 if no other address
 	// supplied with command line option.
 	mux, err := pca9548.New(bus, &pca9548.Opts{Address: *address})
 	if err != nil {
 		return fmt.Errorf("failed to load new mux: %v", err)
 	}
 
-	// Register all 8 ports
+	// Register all 8 ports.
 	busz := make(map[int]string)
 	for i := 0; i < 8; i++ {
 		name := "mux" + strconv.Itoa(i)
@@ -51,7 +51,7 @@ func mainImpl() error {
 		busz[i] = name
 	}
 
-	// Create a place to store the results from the scan
+	// Create a place to store the results from the scan.
 	results := make(map[string][]uint16)
 	fmt.Println("Starting Scan")
 	// Loop through each bus scanning all addresses for a response.

--- a/experimental/cmd/pca9548/main.go
+++ b/experimental/cmd/pca9548/main.go
@@ -1,0 +1,75 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// pca9548 scans the 8 ports of a pca9548 i2c multiplexer for other i2c devices.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/experimental/devices/pca9548"
+	"periph.io/x/periph/host"
+)
+
+func mainImpl() error {
+	address := flag.Int("address", 0x70, "I²C address")
+	i2cbus := flag.String("bus", "", "I²C bus (/dev/i2c-1)")
+
+	flag.Parse()
+
+	if _, err := host.Init(); err != nil {
+		return err
+	}
+
+	// Open default I²C bus.
+	bus, err := i2creg.Open(*i2cbus)
+	if err != nil {
+		return fmt.Errorf("failed to open I²C: %v", err)
+	}
+	defer bus.Close()
+
+	// Registers a multiplexer with 8 ports at address 0x70 if no other address
+	// supplied with command line option.
+	_, err = pca9548.Register(bus, &pca9548.Opts{Address: *address})
+	if err != nil {
+		return fmt.Errorf("failed to load new mux: %v", err)
+	}
+
+	devices := make(map[string][]uint16)
+	fmt.Println("Starting Scan")
+	for i := 0; i < 8; i++ {
+		busname := fmt.Sprintf("mux-%x-%d", *address, i)
+		mux, err := i2creg.Open(busname)
+		defer mux.Close()
+		rx := []byte{0x00}
+		if err != nil {
+			return err
+		}
+		for addr := uint16(0); addr < 0x77; addr++ {
+			if err := mux.Tx(addr, nil, rx); err == nil {
+				devices[busname] = append(devices[busname], addr)
+			}
+		}
+	}
+
+	fmt.Println("Scan Results:")
+	for bus, addrs := range devices {
+		fmt.Printf("Bus[%s] %d found\n", bus, len(addrs))
+		for _, addr := range addrs {
+			fmt.Printf("\tDevice at %#2x\n", addr)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := mainImpl(); err != nil {
+		fmt.Fprintf(os.Stderr, "pca9548: %s.\n", err)
+		return
+	}
+}

--- a/experimental/cmd/pca9548/main.go
+++ b/experimental/cmd/pca9548/main.go
@@ -40,23 +40,18 @@ func mainImpl() error {
 		return fmt.Errorf("failed to load new mux: %v", err)
 	}
 
-	// Register all 8 ports.
-	busz := make(map[int]string)
-	for i := 0; i < 8; i++ {
-		name := "mux" + strconv.Itoa(i)
-		err = mux.Register(i, name)
-		if err != nil {
-			return err
-		}
-		busz[i] = name
+	if err := mux.RegisterPorts("mux"); err != nil {
+		return fmt.Errorf("failed to register ports: %v", err.Error())
 	}
 
 	// Create a place to store the results from the scan.
 	results := make(map[string][]uint16)
 	fmt.Println("Starting Scan")
+
 	// Loop through each bus scanning all addresses for a response.
 	for i := 0; i < 8; i++ {
-		m, err := i2creg.Open(busz[i])
+		// Open multiplexer port with alias mux0-mux7.
+		m, err := i2creg.Open("mux" + strconv.Itoa(i))
 		if err != nil {
 			return err
 		}
@@ -65,7 +60,7 @@ func mainImpl() error {
 		rx := []byte{0x00}
 		for addr := uint16(1); addr < 0x77; addr++ {
 			if err := m.Tx(addr, nil, rx); err == nil {
-				results[busz[i]] = append(results[busz[i]], addr)
+				results[m.String()] = append(results[m.String()], addr)
 			}
 		}
 	}

--- a/experimental/cmd/pca9548/main.go
+++ b/experimental/cmd/pca9548/main.go
@@ -34,7 +34,7 @@ func mainImpl() error {
 
 	// Creates a multiplexer with 8 ports at address 0x70 if no other address
 	// supplied with command line option.
-	mux, err := pca9548.New(bus, &pca9548.Opts{Address: *address})
+	mux, err := pca9548.New(bus, &pca9548.Opts{Addr: *address})
 	if err != nil {
 		return fmt.Errorf("failed to load new mux: %v", err)
 	}

--- a/experimental/devices/pca9548/doc.go
+++ b/experimental/devices/pca9548/doc.go
@@ -2,22 +2,9 @@
 // Use of this source code is governed under the Apache License, Version 2.0
 // that can be found in the LICENSE file.
 
-// Package pca9548 is a driver for an 8 port I²C multiplexer that is avaliable
-// from multiple venders. The main features of this multiplexer is that its has
+// Package pca9548 is a driver for an 8 port I²C multiplexer that is available
+// from multiple vendors. The main features of this multiplexer is that its has
 // 8 channels and is capable of voltage level translation.
-//
-//
-// Use with other I²C multiplexers
-//
-// Most I²C multiplexers work the same way as
-// the pca9548 so it could be possible to use this driver with a range of other
-// I²C multiplexers inclding 2 and 4 port versions.
-//
-//
-// Limtations
-//
-// Interupts are not enabled. There can not be a conflict with the address of
-// the multiplexer.
 //
 //
 // Adjusting the Bus CLK

--- a/experimental/devices/pca9548/doc.go
+++ b/experimental/devices/pca9548/doc.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package pca9548 is a driver for an 8 port I²C multiplexer that is avaliable
+// from multiple venders. The main features of this multiplexer is that its has
+// 8 channels and is capable of voltage level translation.
+//
+//
+// Use with other I²C multiplexers
+//
+// Most I²C multiplexers work the same way as
+// the pca9548 so it could be possible to use this driver with a range of other
+// I²C multiplexers inclding 2 and 4 port versions.
+//
+//
+// Limtations
+//
+// Interupts are not enabled. There can not be a conflict with the address of
+// the multiplexer.
+//
+//
+// Adjusting the Bus CLK
+//
+// The bus clock is slaved to the master bus clock, different clock for each
+// port is currently not supported.
+//
+//
+// Datasheet
+//
+// https://www.nxp.com/docs/en/data-sheet/PCA9548A.pdf
+package pca9548

--- a/experimental/devices/pca9548/doc.go
+++ b/experimental/devices/pca9548/doc.go
@@ -10,7 +10,7 @@
 // Adjusting the Bus CLK
 //
 // The bus clock is slaved to the master bus clock, different clock for each
-// port is currently not supported.
+// port is currently not supported. The Maximum clock for this device is 400kHz.
 //
 //
 // Datasheet

--- a/experimental/devices/pca9548/pca9548.go
+++ b/experimental/devices/pca9548/pca9548.go
@@ -1,79 +1,149 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
 package pca9548
 
 import (
-	// "periph.io/x/periph/conn/mmr"
 	"errors"
 	"strconv"
 	"sync"
 
 	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2creg"
 	"periph.io/x/periph/conn/physic"
 )
 
 type Dev struct {
 	c       i2c.Bus
 	address uint16
+	names   []string
 	ports   uint8
-	mu      sync.Mutex
-	port    uint8
+	// mu guards port
+	mu   sync.Mutex
+	port uint8
 }
 
-var DefaultOpts = Opts{Address: 0x00}
+var DefaultOpts = Opts{Address: 0x70, Ports: 8}
 
 type Opts struct {
 	Address uint16
+	Ports   uint8
 }
 
-// New creates a new handel to a pca9548 i2c multiplexer.
-func New(bus i2c.Bus, opts *Opts) (*Dev, error) {
-	return &Dev{
+// Register creates a new handel to a pca9548 I²C multiplexer, and registers
+// port names with the host. These ports can then be used as any other i2c.Bus.
+// The registered port names are in the form: i2cmux/mux-ADD-I where ADD is the
+// multiplexer I²C address in hex and I is the port number.
+// example: "i2cmux-70-0" and "mux-70-0".
+func Register(bus i2c.Bus, opts *Opts) (*Dev, error) {
+	d := &Dev{
 		c:       bus,
-		ports:   8,
 		port:    0xFF,
 		address: opts.Address,
-	}, nil
+		ports:   opts.Ports,
+	}
+
+	for i := uint8(0); i < opts.Ports; i++ {
+		portID := strconv.FormatUint(uint64(i), 10)
+		addrStr := strconv.FormatUint(uint64(opts.Address), 16)
+		name := addrStr + "-" + portID
+		opener := newOpener(d, i)
+		if err := i2creg.Register("i2cmux-"+name, []string{"mux-" + name}, int((opts.Address*10)+uint16(i)), opener); err != nil {
+			return nil, err
+		}
+		d.names = append(d.names, "i2cmux-"+name)
+		d.names = append(d.names, "mux-"+name)
+	}
+	return d, nil
 }
 
-// tx wraps the bus tx, it maintains which port that each bus is registered on
-// os that communication from the master is always on the right port.
-func (d *Dev) tx(port Port, address uint16, w, r []byte) error {
+// ListPortNames lists all the port names registered for the multiplexer.
+func (d *Dev) ListPortNames() []string {
+	return d.names
+}
+
+// Scan the channel for i2c devices, returns a slice of i2c addresses
+func (d *Dev) Scan() ScanList {
+	devices := make(map[string][]uint16)
+	rx := []byte{0x00}
+	addrStr := strconv.FormatUint(uint64(d.address), 16)
+	for port := uint8(0); port < d.ports; port++ {
+		portID := strconv.FormatUint(uint64(port), 10)
+		for address := uint16(1); address < 0x77; address++ {
+			err := d.tx(port, address, nil, rx)
+			if err == nil {
+				devs := devices["mux-"+addrStr+"-"+portID]
+				devs = append(devs, address)
+				devices["mux-"+addrStr+"-"+portID] = devs
+			}
+		}
+	}
+	return devices
+}
+
+type ScanList map[string][]uint16
+
+func (l ScanList) String() string {
+	s := "Scan Results:"
+	for port, addresses := range l {
+		s += "\nPort[" + port + "] " + strconv.FormatInt(int64(len(addresses)), 10) + " found"
+		for _, addr := range addresses {
+			s += "\n\tDevice at 0x" + strconv.FormatUint(uint64(addr), 16)
+		}
+	}
+	return s
+}
+
+// newOpener is a helper for creating an opener func.
+func newOpener(d *Dev, portNumber uint8) i2creg.Opener {
+	return func() (i2c.BusCloser, error) {
+		return &port{
+			mux:    d,
+			number: portNumber,
+		}, nil
+	}
+}
+
+// tx wraps the master bus tx, maintains which port that each bus is registered
+// on so that communication from the master is always on the right port.
+func (d *Dev) tx(port uint8, address uint16, w, r []byte) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	if address == d.address {
-		return errors.New("failed to write device address conflicts with mux address")
+		return errors.New("device address conflicts with multiplexer address")
 	}
-	if port.number != d.port {
-		err := d.c.Tx(d.address, []byte{uint8(1 << (port.number))}, nil)
+	// Change active port if needed.
+	if port != d.port {
+		err := d.c.Tx(d.address, []byte{uint8(1 << (port))}, nil)
 		if err != nil {
-			return errors.New("failed to write active channel on mux: " + err.Error())
+			return errors.New("failed to change active port on multiplexer: " + err.Error())
 		}
-		d.port = port.number
+		d.port = port
 	}
 	return d.c.Tx(address, w, r)
 }
 
-// NewBus registers a new i2c bus on the mux.
-func (d *Dev) NewBus(port uint8) (i2c.Bus, error) {
-	if port >= d.ports {
-		return Port{}, errors.New("port number must be between 0 and " + strconv.Itoa(int(d.ports-1)))
-	}
-	return Port{
-		mux:    d,
-		number: port,
-	}, nil
-}
-
 // String gets the port number of the bus on the multiplexer
-func (p Port) String() string { return "Port:" + strconv.Itoa(int(p.number)) }
+func (p *port) String() string { return "Port:" + strconv.Itoa(int(p.number)) }
 
 // SetSpeed is no implemented as the port slaves the master port clock
-func (p Port) SetSpeed(f physic.Frequency) error { return nil }
+func (p *port) SetSpeed(f physic.Frequency) error { return nil }
 
 // Tx does a transaction on the multiplexer port it is register to.
-func (p Port) Tx(addr uint16, w, r []byte) error { return p.mux.tx(p, addr, w, r) }
+func (p *port) Tx(addr uint16, w, r []byte) error { return p.mux.tx(p.number, addr, w, r) }
 
 // Port is a i2c.Bus on the multiplexer
-type Port struct {
-	mux    *Dev
+type port struct {
 	number uint8
+	// mu guards mux
+	mu  sync.Mutex
+	mux *Dev
+}
+
+func (p *port) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.mux = nil
+	return nil
 }

--- a/experimental/devices/pca9548/pca9548.go
+++ b/experimental/devices/pca9548/pca9548.go
@@ -16,14 +16,14 @@ import (
 )
 
 // DefaultOpts is the recommended default options.
-var DefaultOpts = Opts{Address: 0x70}
+var DefaultOpts = Opts{Addr: 0x70}
 
 // Opts is the pca9548 configuration.
 type Opts struct {
-	// Address pca9548 I²C Address. Valid addresses for the NXP pca9548 are 0x70
-	// to 0x77. The address is set by pulling A0~A2 low or high. Please refer
-	// to the datasheet.
-	Address int
+	// Addr is the pca9548 I²C Address. Valid addresses for the NXP pca9548 are
+	// 0x70 to 0x77. The address is set by pulling A0~A2 low or high. Please
+	// refer to the datasheet.
+	Addr int
 }
 
 // Dev is handle to a pca9548 I²C Multiplexer.
@@ -41,18 +41,18 @@ type Dev struct {
 
 // New creates a new handle to a pca9548 I²C multiplexer.
 func New(bus i2c.Bus, opts *Opts) (*Dev, error) {
-	if opts.Address < 0x70 || opts.Address > 0x77 {
+	if opts.Addr < 0x70 || opts.Addr > 0x77 {
 		return nil, errors.New("Address outside valid range of 0x70-0x77")
 	}
 	d := &Dev{
 		c:          bus,
 		activePort: 0xFF,
-		address:    uint16(opts.Address),
+		address:    uint16(opts.Addr),
 		numPorts:   8,
-		name:       "pca9548-" + strconv.FormatUint(uint64(opts.Address), 16),
+		name:       "pca9548-" + strconv.FormatUint(uint64(opts.Addr), 16),
 	}
 	r := make([]byte, 1)
-	err := bus.Tx(uint16(opts.Address), nil, r)
+	err := bus.Tx(uint16(opts.Addr), nil, r)
 	if err != nil {
 		return nil, errors.New("could not establish communicate with multiplexer: " + err.Error())
 	}

--- a/experimental/devices/pca9548/pca9548.go
+++ b/experimental/devices/pca9548/pca9548.go
@@ -9,96 +9,120 @@ import (
 	"strconv"
 	"sync"
 
+	"periph.io/x/periph/conn"
 	"periph.io/x/periph/conn/i2c"
 	"periph.io/x/periph/conn/i2c/i2creg"
 	"periph.io/x/periph/conn/physic"
 )
 
-// Dev is handle to a pca9548 I²C Multiplexer.
-type Dev struct {
-	c       i2c.Bus
-	address uint16
-	names   []string
-	ports   uint8
-	// mu guards port
-	mu   sync.Mutex
-	port uint8
-}
-
 // DefaultOpts is the recommended default options.
-var DefaultOpts = Opts{Address: 0x70, Ports: 8}
+var DefaultOpts = Opts{Address: 0x70}
 
 // Opts is the pca9548 configuration.
 type Opts struct {
 	// Address pca9548 I²C Address.
-	Address uint16
-	// Ports number of physical ports on I²C Multiplexer.
-	Ports uint8
+	Address int
 }
 
-// Register creates a new handel to a pca9548 I²C multiplexer, and registers
+// Dev is handle to a pca9548 I²C Multiplexer.
+type Dev struct {
+	// Immutable.
+	c       i2c.Bus
+	address uint16
+
+	// Mutable.
+	mu   sync.Mutex
+	port uint8
+}
+
+// Register creates a new handle to a pca9548 I²C multiplexer, and registers
 // port names with the host. These ports can then be used as any other i2c.Bus.
-// The registered port names are in the form: i2cmux/mux-ADD-I where ADD is the
+// The registered port names are in the form: pca9548/mux-ADD-I where ADD is the
 // multiplexer I²C address in hex and I is the port number.
-// example: "i2cmux-70-0" and "mux-70-0".
+// example: "pca9548-70-0" and "mux-70-0".
 func Register(bus i2c.Bus, opts *Opts) (*Dev, error) {
 	d := &Dev{
 		c:       bus,
 		port:    0xFF,
-		address: opts.Address,
-		ports:   opts.Ports,
+		address: uint16(opts.Address),
+	}
+	r := make([]byte, 1)
+	err := bus.Tx(uint16(opts.Address), nil, r)
+	if err != nil {
+		return nil, errors.New("could not communicated with multiplexer: " + err.Error())
 	}
 
-	for i := uint8(0); i < opts.Ports; i++ {
+	for i := uint8(0); i < 8; i++ {
 		portID := strconv.FormatUint(uint64(i), 10)
 		addrStr := strconv.FormatUint(uint64(opts.Address), 16)
 		name := addrStr + "-" + portID
 		opener := newOpener(d, i)
-		if err := i2creg.Register("i2cmux-"+name, []string{"mux-" + name}, int((opts.Address*10)+uint16(i)), opener); err != nil {
+		if err := i2creg.Register("pca9548-"+name, []string{"mux-" + name}, int((opts.Address*10 + int(i))), opener); err != nil {
 			return nil, err
 		}
-		d.names = append(d.names, "i2cmux-"+name)
-		d.names = append(d.names, "mux-"+name)
 	}
 	return d, nil
 }
 
-// ListPortNames lists all the port names registered for the multiplexer.
-func (d *Dev) ListPortNames() []string {
-	return d.names
+// Halt does nothing.
+func (d *Dev) Halt() error {
+	// TODO(NeuralSpaz): Find a good way to halt that also can resume.
+	return nil
 }
 
-// Scan scans every port of the multiplexer and every I²C address for devices,
-// returns a map of I²C multiplexer ports names to slice of device I²C address.
-func (d *Dev) Scan() ScanList {
-	devices := make(map[string][]uint16)
-	rx := []byte{0x00}
-	addrStr := strconv.FormatUint(uint64(d.address), 16)
-	for port := uint8(0); port < d.ports; port++ {
-		portID := strconv.FormatUint(uint64(port), 10)
-		for address := uint16(1); address < 0x77; address++ {
-			err := d.tx(port, address, nil, rx)
-			if err == nil {
-				portName := "mux-" + addrStr + "-" + portID
-				devices[portName] = append(devices[portName], address)
-			}
-		}
-	}
-	return devices
+// String returns the bus base name for multiplexer ports.
+func (d *Dev) String() string {
+	return "pca9548-" + strconv.FormatUint(uint64(d.address), 16)
 }
 
-// ScanList is a map of I²C port names and I²C address of discovered devices.
-type ScanList map[string][]uint16
-
-func (l ScanList) String() string {
-	s := "Scan Results:"
-	for port, addresses := range l {
-		s += "\nPort[" + port + "] " + strconv.FormatInt(int64(len(addresses)), 10) + " found"
-		for _, addr := range addresses {
-			s += "\n\tDevice at 0x" + strconv.FormatUint(uint64(addr), 16)
-		}
+// tx wraps the master bus tx, maintains which port that each bus is registered
+// on so that communication from the master is always on the right port.
+func (d *Dev) tx(port uint8, address uint16, w, r []byte) error {
+	if address == d.address {
+		return errors.New("device address conflicts with multiplexer address")
 	}
-	return s
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// Change active port if needed.
+	if port != d.port {
+		err := d.c.Tx(d.address, []byte{uint8(1 << (port))}, nil)
+		if err != nil {
+			return errors.New("failed to change active port on multiplexer: " + err.Error())
+		}
+		d.port = port
+	}
+	return d.c.Tx(address, w, r)
+}
+
+// Port is a i2c.Bus on the multiplexer.
+type port struct {
+	// Immutable.
+	number uint8
+
+	// Mutable.
+	mu  sync.Mutex
+	mux *Dev
+}
+
+// String gets the port number of the bus on the multiplexer.
+func (p *port) String() string { return "Port:" + strconv.Itoa(int(p.number)) }
+
+// SetSpeed is no implemented as the port slaves the master port clock.
+func (p *port) SetSpeed(f physic.Frequency) error { return nil }
+
+// Tx does a transaction on the multiplexer port it is register to.
+func (p *port) Tx(addr uint16, w, r []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.mux == nil {
+		return errors.New("port" + strconv.FormatUint(uint64(p.number), 10) + "has been closed")
+	}
+	return p.mux.tx(p.number, addr, w, r)
+}
+
+func (p *port) Close() error {
+	p.mux = nil
+	return nil
 }
 
 // newOpener is a helper for creating an opener func.
@@ -111,45 +135,5 @@ func newOpener(d *Dev, portNumber uint8) i2creg.Opener {
 	}
 }
 
-// tx wraps the master bus tx, maintains which port that each bus is registered
-// on so that communication from the master is always on the right port.
-func (d *Dev) tx(port uint8, address uint16, w, r []byte) error {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if address == d.address {
-		return errors.New("device address conflicts with multiplexer address")
-	}
-	// Change active port if needed.
-	if port != d.port {
-		err := d.c.Tx(d.address, []byte{uint8(1 << (port))}, nil)
-		if err != nil {
-			return errors.New("failed to change active port on multiplexer: " + err.Error())
-		}
-		d.port = port
-	}
-	return d.c.Tx(address, w, r)
-}
-
-// String gets the port number of the bus on the multiplexer
-func (p *port) String() string { return "Port:" + strconv.Itoa(int(p.number)) }
-
-// SetSpeed is no implemented as the port slaves the master port clock
-func (p *port) SetSpeed(f physic.Frequency) error { return nil }
-
-// Tx does a transaction on the multiplexer port it is register to.
-func (p *port) Tx(addr uint16, w, r []byte) error { return p.mux.tx(p.number, addr, w, r) }
-
-// Port is a i2c.Bus on the multiplexer
-type port struct {
-	number uint8
-	// mu guards mux
-	mu  sync.Mutex
-	mux *Dev
-}
-
-func (p *port) Close() error {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.mux = nil
-	return nil
-}
+var _ conn.Resource = &Dev{}
+var _ i2c.Bus = &port{}

--- a/experimental/devices/pca9548/pca9548.go
+++ b/experimental/devices/pca9548/pca9548.go
@@ -1,0 +1,79 @@
+package pca9548
+
+import (
+	// "periph.io/x/periph/conn/mmr"
+	"errors"
+	"strconv"
+	"sync"
+
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/physic"
+)
+
+type Dev struct {
+	c       i2c.Bus
+	address uint16
+	ports   uint8
+	mu      sync.Mutex
+	port    uint8
+}
+
+var DefaultOpts = Opts{Address: 0x00}
+
+type Opts struct {
+	Address uint16
+}
+
+// New creates a new handel to a pca9548 i2c multiplexer.
+func New(bus i2c.Bus, opts *Opts) (*Dev, error) {
+	return &Dev{
+		c:       bus,
+		ports:   8,
+		port:    0xFF,
+		address: opts.Address,
+	}, nil
+}
+
+// tx wraps the bus tx, it maintains which port that each bus is registered on
+// os that communication from the master is always on the right port.
+func (d *Dev) tx(port Port, address uint16, w, r []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if address == d.address {
+		return errors.New("failed to write device address conflicts with mux address")
+	}
+	if port.number != d.port {
+		err := d.c.Tx(d.address, []byte{uint8(1 << (port.number))}, nil)
+		if err != nil {
+			return errors.New("failed to write active channel on mux: " + err.Error())
+		}
+		d.port = port.number
+	}
+	return d.c.Tx(address, w, r)
+}
+
+// NewBus registers a new i2c bus on the mux.
+func (d *Dev) NewBus(port uint8) (i2c.Bus, error) {
+	if port >= d.ports {
+		return Port{}, errors.New("port number must be between 0 and " + strconv.Itoa(int(d.ports-1)))
+	}
+	return Port{
+		mux:    d,
+		number: port,
+	}, nil
+}
+
+// String gets the port number of the bus on the multiplexer
+func (p Port) String() string { return "Port:" + strconv.Itoa(int(p.number)) }
+
+// SetSpeed is no implemented as the port slaves the master port clock
+func (p Port) SetSpeed(f physic.Frequency) error { return nil }
+
+// Tx does a transaction on the multiplexer port it is register to.
+func (p Port) Tx(addr uint16, w, r []byte) error { return p.mux.tx(p, addr, w, r) }
+
+// Port is a i2c.Bus on the multiplexer
+type Port struct {
+	mux    *Dev
+	number uint8
+}

--- a/experimental/devices/pca9548/pca9548.go
+++ b/experimental/devices/pca9548/pca9548.go
@@ -14,6 +14,7 @@ import (
 	"periph.io/x/periph/conn/physic"
 )
 
+// Dev is handle to a pca9548 I²C Multiplexer.
 type Dev struct {
 	c       i2c.Bus
 	address uint16
@@ -24,11 +25,15 @@ type Dev struct {
 	port uint8
 }
 
+// DefaultOpts is the recommended default options.
 var DefaultOpts = Opts{Address: 0x70, Ports: 8}
 
+// Opts is the pca9548 configuration.
 type Opts struct {
+	// Address pca9548 I²C Address.
 	Address uint16
-	Ports   uint8
+	// Ports number of physical ports on I²C Multiplexer.
+	Ports uint8
 }
 
 // Register creates a new handel to a pca9548 I²C multiplexer, and registers
@@ -63,7 +68,8 @@ func (d *Dev) ListPortNames() []string {
 	return d.names
 }
 
-// Scan the channel for i2c devices, returns a slice of i2c addresses
+// Scan scans every port of the multiplexer and every I²C address for devices,
+// returns a map of I²C multiplexer ports names to slice of device I²C address.
 func (d *Dev) Scan() ScanList {
 	devices := make(map[string][]uint16)
 	rx := []byte{0x00}
@@ -73,15 +79,15 @@ func (d *Dev) Scan() ScanList {
 		for address := uint16(1); address < 0x77; address++ {
 			err := d.tx(port, address, nil, rx)
 			if err == nil {
-				devs := devices["mux-"+addrStr+"-"+portID]
-				devs = append(devs, address)
-				devices["mux-"+addrStr+"-"+portID] = devs
+				portName := "mux-" + addrStr + "-" + portID
+				devices[portName] = append(devices[portName], address)
 			}
 		}
 	}
 	return devices
 }
 
+// ScanList is a map of I²C port names and I²C address of discovered devices.
 type ScanList map[string][]uint16
 
 func (l ScanList) String() string {

--- a/experimental/devices/pca9548/pca9548.go
+++ b/experimental/devices/pca9548/pca9548.go
@@ -78,17 +78,6 @@ func (d *Dev) RegisterPorts(alias string) error {
 	return nil
 }
 
-// newOpener is a helper for creating an opener func.
-func newOpener(d *Dev, portNumber uint8, alias string, name string) i2creg.Opener {
-	return func() (i2c.BusCloser, error) {
-		return &port{
-			name:   name + "(" + alias + ")",
-			mux:    d,
-			number: portNumber,
-		}, nil
-	}
-}
-
 // Halt does nothing.
 func (d *Dev) Halt() error {
 	return nil
@@ -115,6 +104,17 @@ func (d *Dev) tx(port uint8, address uint16, w, r []byte) error {
 		d.activePort = port
 	}
 	return d.c.Tx(address, w, r)
+}
+
+// newOpener is a helper for creating an opener func.
+func newOpener(d *Dev, portNumber uint8, alias string, name string) i2creg.Opener {
+	return func() (i2c.BusCloser, error) {
+		return &port{
+			name:   name + "(" + alias + ")",
+			mux:    d,
+			number: portNumber,
+		}, nil
+	}
 }
 
 // port is a i2c.BusCloser.

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -5,33 +5,41 @@
 package pca9548
 
 import (
+	"strconv"
 	"testing"
-
-	"periph.io/x/periph/conn/physic"
 
 	"periph.io/x/periph/conn/i2c/i2creg"
 	"periph.io/x/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/conn/physic"
 	"periph.io/x/periph/host"
 )
 
 func TestNew(t *testing.T) {
 	tests := []struct {
 		tx      []i2ctest.IO
+		address int
 		wantErr bool
 	}{
 		{
 			tx:      []i2ctest.IO{{Addr: 0x70, W: nil, R: []byte{0xFF}}},
+			address: 0x70,
 			wantErr: false,
 		},
 		{
 			tx:      []i2ctest.IO{{Addr: 0x70, W: nil, R: nil}},
+			address: 0x70,
+			wantErr: true,
+		},
+		{
+			tx:      []i2ctest.IO{{Addr: 0x50, W: nil, R: nil}},
+			address: 0x50,
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		bus := &i2ctest.Playback{Ops: tt.tx, DontPanic: true}
-		_, err := New(bus, &DefaultOpts)
+		_, err := New(bus, &Opts{Address: tt.address})
 
 		if err != nil && !tt.wantErr {
 			t.Errorf("got unexpected error %v", err)
@@ -43,14 +51,24 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestRegister(t *testing.T) {
+func TestRegisterPorts(t *testing.T) {
 	tests := []struct {
-		alias   string
-		port    int
-		wantErr bool
+		alias  string
+		expect []string
 	}{
-		{"mux0", 0, false},
-		{"mux0", -1, true},
+		{
+			"mux",
+			[]string{
+				"playback-pca9548-70-0",
+				"playback-pca9548-70-1",
+				"playback-pca9548-70-2",
+				"playback-pca9548-70-3",
+				"playback-pca9548-70-4",
+				"playback-pca9548-70-5",
+				"playback-pca9548-70-6",
+				"playback-pca9548-70-7",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -67,23 +85,45 @@ func TestRegister(t *testing.T) {
 			t.Fatalf("failed to create I²C mux: %v", err)
 		}
 
-		err = mux.Register(tt.port, tt.alias)
-		if err != nil && !tt.wantErr {
-			t.Errorf("got unexpected error %v", err)
+		if err := mux.RegisterPorts(tt.alias); err != nil {
+			t.Fatalf("failed to create I²C mux: %v", err)
+		}
+		for i, port := range tt.expect {
+			if err := i2creg.Unregister(port); err != nil {
+				t.Errorf("failed to Unregister port %d: %v", i, err)
+			}
+		}
+	}
+	// Failing Case.
+	for _, tt := range tests {
+		bus := &i2ctest.Playback{
+			Ops: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
+			},
+			DontPanic: true,
+		}
+		host.Init()
+
+		mux, err := New(bus, &DefaultOpts)
+		if err != nil {
+			t.Fatalf("failed to create I²C mux: %v", err)
 		}
 
-		if err == nil && tt.wantErr {
-			t.Errorf("expected error but got none")
+		if err := mux.RegisterPorts(tt.alias); err != nil {
+			t.Fatalf("failed to create I²C mux: %v", err)
 		}
-
-		// Cleanup
-		i2creg.Unregister("playback-pca9548-70-0")
-		i2creg.Unregister(tt.alias)
+		if err := mux.RegisterPorts(tt.alias); err == nil {
+			t.Fatal("expected second registraion to fail", err)
+		}
+		for i, port := range tt.expect {
+			if err := i2creg.Unregister(port); err != nil {
+				t.Errorf("failed to Unregister port %d: %v", i, err)
+			}
+		}
 	}
 }
 
 func TestDev_Halt(t *testing.T) {
-	// TODO(neuralSpaz)
 	d := &Dev{}
 	err := d.Halt()
 	if err != nil {
@@ -93,31 +133,49 @@ func TestDev_Halt(t *testing.T) {
 
 func TestDev_String(t *testing.T) {
 	tests := []struct {
-		d    *Dev
-		want string
+		address uint16
+		want    string
 	}{
-		{d: &Dev{address: 0x70}, want: "pca9548-70"},
+		{address: 0x70, want: "pca9548-70"},
+		{address: 0x71, want: "pca9548-71"},
+		{address: 0x72, want: "pca9548-72"},
+		{address: 0x73, want: "pca9548-73"},
+		{address: 0x74, want: "pca9548-74"},
 	}
-
 	for _, tt := range tests {
+		bus := &i2ctest.Playback{
+			Ops: []i2ctest.IO{
+				{Addr: tt.address, W: nil, R: []byte{0xFF}},
+			},
+			DontPanic: false,
+		}
+		host.Init()
 
-		if got := tt.d.String(); got != tt.want {
+		mux, err := New(bus, &Opts{Address: int(tt.address)})
+		if err != nil {
+			t.Fatalf("failed to create I²C mux: %v", err)
+		}
+
+		if got := mux.String(); got != tt.want {
 			t.Errorf("Dev.String() = %v, want %v", got, tt.want)
 		}
 	}
 }
+
 func TestDev_Tx(t *testing.T) {
 	var tests = []struct {
-		alias   string
-		port    int
-		address uint16
-		tx      []i2ctest.IO
-		wantErr bool
+		alias       string
+		openPort    string
+		initialPort int
+		address     uint16
+		tx          []i2ctest.IO
+		wantErr     bool
 	}{
 		{
-			alias:   "mux0",
-			port:    0,
-			address: 0x30,
+			alias:       "mux",
+			openPort:    "mux0",
+			initialPort: 0,
+			address:     0x30,
 			tx: []i2ctest.IO{
 				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x01}, R: []byte{}},
@@ -125,88 +183,22 @@ func TestDev_Tx(t *testing.T) {
 			},
 		},
 		{
-			alias:   "mux1",
-			port:    1,
-			address: 0x30,
+			alias:       "mux",
+			openPort:    "mux0",
+			initialPort: 0,
+			address:     0x70,
 			tx: []i2ctest.IO{
 				{Addr: 0x70, W: nil, R: []byte{0xFF}},
-				{Addr: 0x70, W: []byte{0x02}, R: []byte{}},
-				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
-			},
-		},
-		{
-			alias:   "mux2",
-			port:    2,
-			address: 0x30,
-			tx: []i2ctest.IO{
-				{Addr: 0x70, W: nil, R: []byte{0xFF}},
-				{Addr: 0x70, W: []byte{0x04}, R: []byte{}},
-				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
-			},
-		},
-		{
-			alias:   "mux3",
-			port:    3,
-			address: 0x30,
-			tx: []i2ctest.IO{
-				{Addr: 0x70, W: nil, R: []byte{0xFF}},
-				{Addr: 0x70, W: []byte{0x08}, R: []byte{}},
-				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
-			},
-		},
-		{
-			alias:   "mux4",
-			port:    4,
-			address: 0x30,
-			tx: []i2ctest.IO{
-				{Addr: 0x70, W: nil, R: []byte{0xFF}},
-				{Addr: 0x70, W: []byte{0x10}, R: []byte{}},
-				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
-			},
-		},
-		{
-			alias:   "mux5",
-			port:    5,
-			address: 0x30,
-			tx: []i2ctest.IO{
-				{Addr: 0x70, W: nil, R: []byte{0xFF}},
-				{Addr: 0x70, W: []byte{0x20}, R: []byte{}},
-				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
-			},
-		},
-		{
-			alias:   "mux6",
-			port:    6,
-			address: 0x30,
-			tx: []i2ctest.IO{
-				{Addr: 0x70, W: nil, R: []byte{0xFF}},
-				{Addr: 0x70, W: []byte{0x40}, R: []byte{}},
-				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
-			},
-		},
-		{
-			alias:   "mux7",
-			port:    7,
-			address: 0x30,
-			tx: []i2ctest.IO{
-				{Addr: 0x70, W: nil, R: []byte{0xFF}},
-				{Addr: 0x70, W: []byte{0x80}, R: []byte{}},
-				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
-			},
-		},
-		{
-			alias:   "mux0",
-			port:    0,
-			address: 0x70,
-			tx: []i2ctest.IO{
-				{Addr: 0x70, W: nil, R: []byte{0xFF}},
+				{Addr: 0x70, W: []byte{0x01}, R: []byte{}},
+				{Addr: 0x70, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
 			wantErr: true,
 		},
 		{
-			alias:   "mux0",
-			port:    0,
-			address: 0x30,
+			alias:       "mux",
+			openPort:    "mux0",
+			initialPort: 0,
+			address:     0x30,
 			tx: []i2ctest.IO{
 				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 			},
@@ -226,11 +218,11 @@ func TestDev_Tx(t *testing.T) {
 			t.Fatalf("failed to open I²C: %v", err)
 		}
 
-		err = mux.Register(tt.port, tt.alias)
+		err = mux.RegisterPorts(tt.alias)
 		if err != nil {
 			t.Fatalf("failed to open I²C: %v", err)
 		}
-		muxbus, err := i2creg.Open(tt.alias)
+		muxbus, err := i2creg.Open(tt.openPort)
 		if err != nil {
 			t.Fatalf("failed to open I²C: %v", err)
 		}
@@ -245,22 +237,11 @@ func TestDev_Tx(t *testing.T) {
 		}
 
 		// Cleanup
-		i2creg.Unregister("mux0")
-		i2creg.Unregister("mux1")
-		i2creg.Unregister("mux2")
-		i2creg.Unregister("mux3")
-		i2creg.Unregister("mux4")
-		i2creg.Unregister("mux5")
-		i2creg.Unregister("mux6")
-		i2creg.Unregister("mux7")
-		i2creg.Unregister("playback-pca9548-70-0")
-		i2creg.Unregister("playback-pca9548-70-1")
-		i2creg.Unregister("playback-pca9548-70-2")
-		i2creg.Unregister("playback-pca9548-70-3")
-		i2creg.Unregister("playback-pca9548-70-4")
-		i2creg.Unregister("playback-pca9548-70-5")
-		i2creg.Unregister("playback-pca9548-70-6")
-		i2creg.Unregister("playback-pca9548-70-7")
+		for i := 0; i < 8; i++ {
+			if err := i2creg.Unregister("playback-" + mux.String() + "-" + strconv.Itoa(i)); err != nil {
+				t.Errorf("failed to Unregister port %d: %v", i, err)
+			}
+		}
 	}
 }
 
@@ -274,7 +255,7 @@ func Test_port_Tx(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			p: port{number: 0x6, mux: &Dev{address: 0x70, port: 6,
+			p: port{number: 0x6, mux: &Dev{address: 0x70, activePort: 6,
 				c: &i2ctest.Playback{
 					Ops: []i2ctest.IO{{Addr: 0x1, W: nil, R: nil}},
 				},
@@ -294,26 +275,56 @@ func Test_port_Tx(t *testing.T) {
 			t.Errorf("expected error but got none")
 		}
 	}
+
+	for _, tt := range tests {
+		tt.p.Close()
+		if err := tt.p.Tx(0x01, nil, nil); err == nil {
+			t.Errorf("expected error but got none")
+		}
+	}
+
 }
 
 func Test_port_String(t *testing.T) {
-	p := port{
-		number: 6,
-		name:   "mux0",
+	bus := &i2ctest.Playback{
+		Ops:       []i2ctest.IO{{Addr: 0x70, W: nil, R: []byte{0xFF}}},
+		DontPanic: true,
 	}
-	expected := "Port:mux0 6"
+	host.Init()
 
-	got := p.String()
+	mux, err := New(bus, &DefaultOpts)
+	if err != nil {
+		t.Fatalf("failed to open I²C: %v", err)
+	}
+
+	err = mux.RegisterPorts("mux")
+	if err != nil {
+		t.Fatalf("failed to open I²C: %v", err)
+	}
+
+	muxbus, err := i2creg.Open("mux0")
+	if err != nil {
+		t.Fatalf("failed to open I²C: %v", err)
+	}
+
+	expected := "Port:playback-pca9548-70-0(mux0)"
+	got := muxbus.String()
 	if got != expected {
 		t.Errorf("expected: \n%v but got: \n%v", expected, got)
+	}
+
+	// Cleanup
+	for i := 0; i < 8; i++ {
+		if err := i2creg.Unregister("playback-" + mux.String() + "-" + strconv.Itoa(i)); err != nil {
+			t.Errorf("failed to Unregister port %d: %v", i, err)
+		}
 	}
 }
 
 func Test_port_SetSpeed(t *testing.T) {
-	// TODO(neuralSpaz)
 	p := &port{}
 	err := p.SetSpeed(400 * physic.KiloHertz)
-	if err != nil {
+	if err == nil {
 		t.Errorf("expected error but got none")
 	}
 }

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -1,0 +1,83 @@
+package pca9548
+
+import (
+	"log"
+	"testing"
+
+	"periph.io/x/periph/conn/i2c/i2ctest"
+)
+
+func TestNew(t *testing.T) {
+	bus := &i2ctest.Playback{
+		Ops:       nil,
+		DontPanic: true,
+	}
+	d, err := New(bus, &DefaultOpts)
+
+	if err != nil {
+		t.Errorf("don't know how that happened, there was nothing that could fail")
+	}
+
+	if d.address != DefaultOpts.Address {
+		t.Errorf("expeected address %d, but got %d", DefaultOpts.Address, d.address)
+	}
+}
+
+func TestDev_Tx(t *testing.T) {
+	var tests = []struct {
+		initial uint8
+		port    uint8
+		address uint16
+		tx      []i2ctest.IO
+	}{
+		{
+			initial: 0xFF,
+			port:    0,
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x40, W: []byte{0x01}, R: []byte{}},
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+		{
+			initial: 0,
+			port:    1,
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x40, W: []byte{0x02}, R: []byte{}},
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+		{
+			initial: 0,
+			port:    7,
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x40, W: []byte{0x80}, R: []byte{}},
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+		{
+			initial: 2,
+			port:    2,
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		bus := &i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+		d := &Dev{c: bus, address: 0x40, port: tt.initial}
+		p := Port{d, tt.port}
+
+		err := p.Tx(tt.address, []byte{0xAA}, []byte{0xBB})
+		if err != nil {
+			log.Println(err)
+		}
+
+	}
+}

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -85,11 +85,14 @@ func TestRegisterPorts(t *testing.T) {
 			t.Fatalf("failed to create I²C mux: %v", err)
 		}
 
-		if err := mux.RegisterPorts(tt.alias); err != nil {
+		portNames, err := mux.RegisterPorts(tt.alias)
+		if err != nil {
 			t.Fatalf("failed to create I²C mux: %v", err)
 		}
 		for i, port := range tt.expect {
-			if err := i2creg.Unregister(port); err != nil {
+			if portNames[i] != port {
+				t.Errorf("expected port name %v but got %v", portNames[i], port)
+			} else if err := i2creg.Unregister(port); err != nil {
 				t.Errorf("failed to Unregister port %d: %v", i, err)
 			}
 		}
@@ -109,10 +112,10 @@ func TestRegisterPorts(t *testing.T) {
 			t.Fatalf("failed to create I²C mux: %v", err)
 		}
 
-		if err := mux.RegisterPorts(tt.alias); err != nil {
+		if _, err := mux.RegisterPorts(tt.alias); err != nil {
 			t.Fatalf("failed to create I²C mux: %v", err)
 		}
-		if err := mux.RegisterPorts(tt.alias); err == nil {
+		if _, err := mux.RegisterPorts(tt.alias); err == nil {
 			t.Fatal("expected second registraion to fail", err)
 		}
 		for i, port := range tt.expect {
@@ -218,10 +221,11 @@ func TestDev_Tx(t *testing.T) {
 			t.Fatalf("failed to open I²C: %v", err)
 		}
 
-		err = mux.RegisterPorts(tt.alias)
+		_, err = mux.RegisterPorts(tt.alias)
 		if err != nil {
 			t.Fatalf("failed to open I²C: %v", err)
 		}
+
 		muxbus, err := i2creg.Open(tt.openPort)
 		if err != nil {
 			t.Fatalf("failed to open I²C: %v", err)
@@ -297,7 +301,7 @@ func Test_port_String(t *testing.T) {
 		t.Fatalf("failed to open I²C: %v", err)
 	}
 
-	err = mux.RegisterPorts("mux")
+	_, err = mux.RegisterPorts("mux")
 	if err != nil {
 		t.Fatalf("failed to open I²C: %v", err)
 	}

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -299,8 +299,9 @@ func Test_port_Tx(t *testing.T) {
 func Test_port_String(t *testing.T) {
 	p := port{
 		number: 6,
+		name:   "mux0",
 	}
-	expected := "Port:6"
+	expected := "Port:mux0 6"
 
 	got := p.String()
 	if got != expected {

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -1,10 +1,16 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
 package pca9548
 
 import (
-	"log"
+	"fmt"
 	"testing"
 
+	"periph.io/x/periph/conn/i2c/i2creg"
 	"periph.io/x/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/host"
 )
 
 func TestNew(t *testing.T) {
@@ -12,8 +18,13 @@ func TestNew(t *testing.T) {
 		Ops:       nil,
 		DontPanic: true,
 	}
-	d, err := New(bus, &DefaultOpts)
-
+	d, err := Register(bus, &DefaultOpts)
+	defer func() {
+		ports := d.ListPortNames()
+		for _, port := range ports {
+			i2creg.Unregister(port)
+		}
+	}()
 	if err != nil {
 		t.Errorf("don't know how that happened, there was nothing that could fail")
 	}
@@ -26,58 +37,177 @@ func TestNew(t *testing.T) {
 func TestDev_Tx(t *testing.T) {
 	var tests = []struct {
 		initial uint8
-		port    uint8
+		port    string
 		address uint16
 		tx      []i2ctest.IO
+		wantErr bool
 	}{
 		{
-			initial: 0xFF,
-			port:    0,
+			port:    "mux-70-0",
 			address: 0x30,
 			tx: []i2ctest.IO{
-				{Addr: 0x40, W: []byte{0x01}, R: []byte{}},
+				{Addr: 0x70, W: []byte{0x01}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
 		},
 		{
-			initial: 0,
-			port:    1,
+			port:    "mux-70-1",
 			address: 0x30,
 			tx: []i2ctest.IO{
-				{Addr: 0x40, W: []byte{0x02}, R: []byte{}},
+				{Addr: 0x70, W: []byte{0x02}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
 		},
 		{
-			initial: 0,
-			port:    7,
+			port:    "mux-70-2",
 			address: 0x30,
 			tx: []i2ctest.IO{
-				{Addr: 0x40, W: []byte{0x80}, R: []byte{}},
+				{Addr: 0x70, W: []byte{0x04}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
 		},
 		{
-			initial: 2,
-			port:    2,
+			port:    "mux-70-3",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: []byte{0x08}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
+		},
+		{
+			port:    "mux-70-4",
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x70, W: []byte{0x10}, R: []byte{}},
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+		{
+			port:    "mux-70-5",
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x70, W: []byte{0x20}, R: []byte{}},
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+		{
+			port:    "mux-70-6",
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x70, W: []byte{0x40}, R: []byte{}},
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+		{
+			port:    "mux-70-7",
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x70, W: []byte{0x80}, R: []byte{}},
+				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
+			},
+		},
+		{
+			port:    "mux-70-0",
+			address: 0x70,
+			tx:      []i2ctest.IO{},
+			wantErr: true,
+		},
+		{
+			port:    "mux-70-0",
+			address: 0x30,
+			tx: []i2ctest.IO{
+				{Addr: 0x70, W: []byte{}, R: []byte{}},
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
+
 		bus := &i2ctest.Playback{
 			Ops:       tt.tx,
 			DontPanic: true,
 		}
-		d := &Dev{c: bus, address: 0x40, port: tt.initial}
-		p := Port{d, tt.port}
+		host.Init()
 
-		err := p.Tx(tt.address, []byte{0xAA}, []byte{0xBB})
+		d, err := Register(bus, &DefaultOpts)
 		if err != nil {
-			log.Println(err)
+			t.Errorf("failed to open I²C: %v", err)
 		}
 
+		bus0, err := i2creg.Open(tt.port)
+		if err != nil {
+			t.Errorf("failed to open I²C: %v", err)
+		}
+		defer bus0.Close()
+		err = bus0.Tx(tt.address, []byte{0xAA}, []byte{0xBB})
+
+		if err != nil && !tt.wantErr {
+			t.Errorf("expected no error but got: %v", err)
+		}
+		if err == nil && tt.wantErr {
+			t.Errorf("expected error")
+		}
+		ports := d.ListPortNames()
+		for _, port := range ports {
+			i2creg.Unregister(port)
+		}
 	}
+}
+
+func TestScanList_String(t *testing.T) {
+	var sl ScanList = make(map[string][]uint16)
+	sl["mux-70-1"] = []uint16{0x49}
+
+	expected := "Scan Results:\nPort[mux-70-1] 1 found\n" +
+		"\tDevice at 0x49"
+
+	got := sl.String()
+	if got != expected {
+		t.Errorf("expected: \n%v but got: \n%v", expected, got)
+	}
+}
+
+func Test_port_String(t *testing.T) {
+	p := port{
+		number: 6,
+	}
+	expected := "Port:6"
+
+	got := p.String()
+	if got != expected {
+		t.Errorf("expected: \n%v but got: \n%v", expected, got)
+	}
+}
+
+func TestDev_Scan(t *testing.T) {
+	tx := []i2ctest.IO{
+		{Addr: 0x70, W: []byte{0x01}, R: []byte{}}, // select port
+		{Addr: 0x01, W: []byte{}, R: []byte{0x00}}, // ack
+		{Addr: 0x02, W: []byte{}, R: []byte{0x00}},
+		{Addr: 0x03, W: []byte{}, R: []byte{0x00}},
+		{Addr: 0x04, W: []byte{}, R: []byte{0x00}},
+	}
+	bus := &i2ctest.Playback{
+		Ops:       tx,
+		DontPanic: true,
+	}
+	host.Init()
+
+	d, err := Register(bus, &DefaultOpts)
+	if err != nil {
+		t.Errorf("failed to open I²C: %v", err)
+	}
+
+	sl := d.Scan()
+	fmt.Printf("%+#v", sl)
+
+	if len(sl["mux-70-0"]) == 0 {
+		t.Errorf("expected list not to be empty")
+	}
+
+	ports := d.ListPortNames()
+	for _, port := range ports {
+		i2creg.Unregister(port)
+	}
+
 }

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -5,7 +5,6 @@
 package pca9548
 
 import (
-	"fmt"
 	"testing"
 
 	"periph.io/x/periph/conn/i2c/i2creg"
@@ -15,23 +14,38 @@ import (
 
 func TestNew(t *testing.T) {
 	bus := &i2ctest.Playback{
-		Ops:       nil,
+		Ops: []i2ctest.IO{
+			{Addr: 0x70, W: nil, R: []byte{0xFF}},
+		},
 		DontPanic: true,
 	}
 	d, err := Register(bus, &DefaultOpts)
-	defer func() {
-		ports := d.ListPortNames()
-		for _, port := range ports {
-			i2creg.Unregister(port)
-		}
-	}()
+
 	if err != nil {
-		t.Errorf("don't know how that happened, there was nothing that could fail")
+		t.Errorf("got unexpected error: %v", err)
 	}
 
-	if d.address != DefaultOpts.Address {
+	if d.address != uint16(DefaultOpts.Address) {
 		t.Errorf("expeected address %d, but got %d", DefaultOpts.Address, d.address)
 	}
+
+	// Cleanup.
+	i2creg.Unregister("mux-70-0")
+	i2creg.Unregister("mux-70-1")
+	i2creg.Unregister("mux-70-2")
+	i2creg.Unregister("mux-70-3")
+	i2creg.Unregister("mux-70-4")
+	i2creg.Unregister("mux-70-5")
+	i2creg.Unregister("mux-70-6")
+	i2creg.Unregister("mux-70-7")
+	i2creg.Unregister("pca9548-70-0")
+	i2creg.Unregister("pca9548-70-1")
+	i2creg.Unregister("pca9548-70-2")
+	i2creg.Unregister("pca9548-70-3")
+	i2creg.Unregister("pca9548-70-4")
+	i2creg.Unregister("pca9548-70-5")
+	i2creg.Unregister("pca9548-70-6")
+	i2creg.Unregister("pca9548-70-7")
 }
 
 func TestDev_Tx(t *testing.T) {
@@ -46,6 +60,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-0",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x01}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -54,6 +69,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-1",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x02}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -62,6 +78,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-2",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x04}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -70,6 +87,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-3",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x08}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -78,6 +96,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-4",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x10}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -86,6 +105,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-5",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x20}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -94,6 +114,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-6",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x40}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -102,6 +123,7 @@ func TestDev_Tx(t *testing.T) {
 			port:    "mux-70-7",
 			address: 0x30,
 			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 				{Addr: 0x70, W: []byte{0x80}, R: []byte{}},
 				{Addr: 0x30, W: []byte{0xAA}, R: []byte{0xBB}},
 			},
@@ -109,14 +131,16 @@ func TestDev_Tx(t *testing.T) {
 		{
 			port:    "mux-70-0",
 			address: 0x70,
-			tx:      []i2ctest.IO{},
+			tx: []i2ctest.IO{
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
+			},
 			wantErr: true,
 		},
 		{
 			port:    "mux-70-0",
 			address: 0x30,
 			tx: []i2ctest.IO{
-				{Addr: 0x70, W: []byte{}, R: []byte{}},
+				{Addr: 0x70, W: nil, R: []byte{0xFF}},
 			},
 			wantErr: true,
 		},
@@ -129,7 +153,7 @@ func TestDev_Tx(t *testing.T) {
 		}
 		host.Init()
 
-		d, err := Register(bus, &DefaultOpts)
+		_, err := Register(bus, &DefaultOpts)
 		if err != nil {
 			t.Errorf("failed to open I²C: %v", err)
 		}
@@ -147,23 +171,24 @@ func TestDev_Tx(t *testing.T) {
 		if err == nil && tt.wantErr {
 			t.Errorf("expected error")
 		}
-		ports := d.ListPortNames()
-		for _, port := range ports {
-			i2creg.Unregister(port)
-		}
-	}
-}
 
-func TestScanList_String(t *testing.T) {
-	var sl ScanList = make(map[string][]uint16)
-	sl["mux-70-1"] = []uint16{0x49}
-
-	expected := "Scan Results:\nPort[mux-70-1] 1 found\n" +
-		"\tDevice at 0x49"
-
-	got := sl.String()
-	if got != expected {
-		t.Errorf("expected: \n%v but got: \n%v", expected, got)
+		// Cleanup
+		i2creg.Unregister("mux-70-0")
+		i2creg.Unregister("mux-70-1")
+		i2creg.Unregister("mux-70-2")
+		i2creg.Unregister("mux-70-3")
+		i2creg.Unregister("mux-70-4")
+		i2creg.Unregister("mux-70-5")
+		i2creg.Unregister("mux-70-6")
+		i2creg.Unregister("mux-70-7")
+		i2creg.Unregister("pca9548-70-0")
+		i2creg.Unregister("pca9548-70-1")
+		i2creg.Unregister("pca9548-70-2")
+		i2creg.Unregister("pca9548-70-3")
+		i2creg.Unregister("pca9548-70-4")
+		i2creg.Unregister("pca9548-70-5")
+		i2creg.Unregister("pca9548-70-6")
+		i2creg.Unregister("pca9548-70-7")
 	}
 }
 
@@ -177,37 +202,4 @@ func Test_port_String(t *testing.T) {
 	if got != expected {
 		t.Errorf("expected: \n%v but got: \n%v", expected, got)
 	}
-}
-
-func TestDev_Scan(t *testing.T) {
-	tx := []i2ctest.IO{
-		{Addr: 0x70, W: []byte{0x01}, R: []byte{}}, // select port
-		{Addr: 0x01, W: []byte{}, R: []byte{0x00}}, // ack
-		{Addr: 0x02, W: []byte{}, R: []byte{0x00}},
-		{Addr: 0x03, W: []byte{}, R: []byte{0x00}},
-		{Addr: 0x04, W: []byte{}, R: []byte{0x00}},
-	}
-	bus := &i2ctest.Playback{
-		Ops:       tx,
-		DontPanic: true,
-	}
-	host.Init()
-
-	d, err := Register(bus, &DefaultOpts)
-	if err != nil {
-		t.Errorf("failed to open I²C: %v", err)
-	}
-
-	sl := d.Scan()
-	fmt.Printf("%+#v", sl)
-
-	if len(sl["mux-70-0"]) == 0 {
-		t.Errorf("expected list not to be empty")
-	}
-
-	ports := d.ListPortNames()
-	for _, port := range ports {
-		i2creg.Unregister(port)
-	}
-
 }

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -251,15 +251,15 @@ func TestDev_Tx(t *testing.T) {
 
 func Test_port_Tx(t *testing.T) {
 	tests := []struct {
-		p       port
+		p       *port
 		wantErr bool
 	}{
 		{
-			p:       port{number: 6},
+			p:       &port{number: 6},
 			wantErr: true,
 		},
 		{
-			p: port{number: 0x6, mux: &Dev{address: 0x70, activePort: 6,
+			p: &port{number: 0x6, mux: &Dev{address: 0x70, activePort: 6,
 				c: &i2ctest.Playback{
 					Ops: []i2ctest.IO{{Addr: 0x1, W: nil, R: nil}},
 				},
@@ -268,6 +268,7 @@ func Test_port_Tx(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
 		err := tt.p.Tx(0x01, nil, nil)
 
@@ -280,11 +281,15 @@ func Test_port_Tx(t *testing.T) {
 		}
 	}
 
-	for _, tt := range tests {
-		tt.p.Close()
-		if err := tt.p.Tx(0x01, nil, nil); err == nil {
-			t.Errorf("expected error but got none")
-		}
+}
+
+func Test_port_Close(t *testing.T) {
+
+	p := &port{number: 6}
+
+	p.Close()
+	if err := p.Tx(0x01, nil, nil); err == nil {
+		t.Errorf("expected error but got none")
 	}
 
 }

--- a/experimental/devices/pca9548/pca9548_test.go
+++ b/experimental/devices/pca9548/pca9548_test.go
@@ -39,7 +39,7 @@ func TestNew(t *testing.T) {
 
 	for _, tt := range tests {
 		bus := &i2ctest.Playback{Ops: tt.tx, DontPanic: true}
-		_, err := New(bus, &Opts{Address: tt.address})
+		_, err := New(bus, &Opts{Addr: tt.address})
 
 		if err != nil && !tt.wantErr {
 			t.Errorf("got unexpected error %v", err)
@@ -154,7 +154,7 @@ func TestDev_String(t *testing.T) {
 		}
 		host.Init()
 
-		mux, err := New(bus, &Opts{Address: int(tt.address)})
+		mux, err := New(bus, &Opts{Addr: int(tt.address)})
 		if err != nil {
 			t.Fatalf("failed to create I²C mux: %v", err)
 		}


### PR DESCRIPTION
Adds initial experimental support a i2c multiplexer. Although only tested with NXP pca9548 it should be compatible with many i2c multiplexers IC's. 