### PR TITLE
ads1x15: fix synchronization

### DIFF
--- a/experimental/devices/ads1x15/ads1x15.go
+++ b/experimental/devices/ads1x15/ads1x15.go
@@ -417,16 +417,16 @@ func (p *analogPin) ReadContinuous() <-chan analog.Reading {
 
 	// First release the current continuous reading if there is one
 	if p.stop != nil {
+		p.stop <- struct{}{}
 		close(p.stop)
 		p.stop = nil
 	}
-	reading := make(chan analog.Reading)
+	reading := make(chan analog.Reading, 16)
 	p.stop = make(chan struct{})
 
 	go func() {
 		t := time.NewTicker(p.requestedFrequency.Duration())
 		defer t.Stop()
-		defer p.Halt()
 		defer close(reading)
 
 		for {
@@ -466,6 +466,7 @@ func (p *analogPin) Halt() error {
 	defer p.mu.Unlock()
 
 	if p.stop != nil {
+		p.stop <- struct{}{}
 		close(p.stop)
 		p.stop = nil
 	}

--- a/experimental/devices/ads1x15/ads1x15.go
+++ b/experimental/devices/ads1x15/ads1x15.go
@@ -418,7 +418,6 @@ func (p *analogPin) ReadContinuous() <-chan analog.Reading {
 	// First release the current continuous reading if there is one
 	if p.stop != nil {
 		p.stop <- struct{}{}
-		close(p.stop)
 		p.stop = nil
 	}
 	reading := make(chan analog.Reading, 16)
@@ -467,7 +466,6 @@ func (p *analogPin) Halt() error {
 
 	if p.stop != nil {
 		p.stop <- struct{}{}
-		close(p.stop)
 		p.stop = nil
 	}
 	return nil


### PR DESCRIPTION
I fixed the typo and the lack of mutex when calling Halt() on a pin.
Added unit tests based upon a real device.

Also, I added a convenience String() function on i2ctest.IO, in order to make it easier to write unit tests. Do you think it has value or do you prefer me to remove it?

Last but not least, should I had those devices in the documentation on periph.io? Where is it?

Thanks!