### PR TITLE
physic: Bring forward Frequency inline with Electrical Resistance style improvements.

### DIFF
--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -252,13 +252,9 @@ func (f Frequency) String() string {
 	return microAsString(int64(f)) + "Hz"
 }
 
-const (
-	maxFrequency = 9223372036854775807 * MicroHertz
-	minFrequency = -9223372036854775807 * MicroHertz
-)
-
-// Set sets the Frequency to the value represented by s. Units are to be
-// provided in hertz with optional SI prefixes.
+// Set sets the Frequency to the value represented by s. Units are to
+// be provided in "Hertz" or "Hz" with an optional SI prefix: "p", "n", "u",
+// "µ", "m", "k", "M", "G" or "T".
 func (f *Frequency) Set(s string) error {
 	v, n, err := valueOfUnitString(s, micro)
 	if err != nil {
@@ -266,11 +262,10 @@ func (f *Frequency) Set(s string) error {
 			switch e.err {
 			case errOverflowsInt64:
 				return errors.New("maximum value is " + maxFrequency.String())
-			case errUnderflowsInt64:
+			case errOverflowsInt64Negative:
 				return errors.New("minimum value is " + minFrequency.String())
 			case errNotANumber:
-				found, _ := containsUnitString(s, "Hertz", "Hz")
-				if found != "" {
+				if found, _ := containsUnitString(s, "Hertz", "Hz"); found != "" {
 					return errors.New("does not contain number")
 				}
 				return errors.New("does not contain number or unit \"Hz\"")
@@ -285,9 +280,8 @@ func (f *Frequency) Set(s string) error {
 	case "":
 		return noUnits("Hz")
 	default:
-		found, extra := containsUnitString(s[n:], "Hertz", "Hz")
-		if found != "" {
-			return unknownUnitPrefix(found, extra, "n,p,u,µ,m,k,M,G or T")
+		if found, extra := containsUnitString(s[n:], "Hertz", "Hz"); found != "" {
+			return unknownUnitPrefix(found, extra, "p,n,u,µ,m,k,M,G or T")
 		}
 		return incorrectUnit(s[n:], "physic.Frequency")
 	}
@@ -315,6 +309,9 @@ const (
 	MegaHertz  Frequency = 1000 * KiloHertz
 	GigaHertz  Frequency = 1000 * MegaHertz
 	TeraHertz  Frequency = 1000 * GigaHertz
+
+	maxFrequency = 9223372036854775807 * MicroHertz
+	minFrequency = -9223372036854775807 * MicroHertz
 )
 
 // Mass is a measurement of mass stored as an int64 nano gram.
@@ -861,9 +858,9 @@ const maxInt64 = (1<<63 - 1)
 var maxUint64Str = "9223372036854775807"
 
 var (
-	errOverflowsInt64  = errors.New("exceeds maximum")
-	errUnderflowsInt64 = errors.New("exceeds minimum")
-	errNotANumber      = errors.New("not a number")
+	errOverflowsInt64         = errors.New("exceeds maximum")
+	errOverflowsInt64Negative = errors.New("exceeds minimum")
+	errNotANumber             = errors.New("not a number")
 )
 
 // Converts from decimal to int64, using the decimal.digits character values and
@@ -887,7 +884,7 @@ func dtoi(d decimal, scale int) (int64, error) {
 				if d.neg {
 					return -maxInt64, &parseError{
 						msg: "-" + maxUint64Str,
-						err: errUnderflowsInt64,
+						err: errOverflowsInt64Negative,
 					}
 				}
 				return maxInt64, &parseError{
@@ -908,7 +905,7 @@ func dtoi(d decimal, scale int) (int64, error) {
 	// mag must be positive to use as index in to powerOf10 array.
 	mag := d.exp + scale
 	if mag < 0 {
-		mag *= -1
+		mag = -mag
 	}
 	if mag > 18 {
 		return 0, errors.New("exponent exceeds int64")
@@ -922,7 +919,7 @@ func dtoi(d decimal, scale int) (int64, error) {
 			if d.neg {
 				return -maxInt64, &parseError{
 					msg: "-" + maxUint64Str,
-					err: errUnderflowsInt64,
+					err: errOverflowsInt64Negative,
 				}
 			}
 			return maxInt64, &parseError{
@@ -935,7 +932,7 @@ func dtoi(d decimal, scale int) (int64, error) {
 
 	n := int64(u)
 	if d.neg {
-		n *= -1
+		n = -n
 	}
 	return n, nil
 }

--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -164,7 +164,7 @@ func (f *ElectricResistance) Set(s string) error {
 			switch e.err {
 			case errOverflowsInt64:
 				return errors.New("maximum value is " + maxElectricResistance.String())
-			case errUnderflowsInt64:
+			case errOverflowsInt64Negative:
 				return errors.New("minimum value is " + minElectricResistance.String())
 			case errNotANumber:
 				if found, _ := containsUnitString(s, "Ohm", "Ohms", "Ω"); found != "" {

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -841,10 +841,10 @@ func TestValueOfUnitString(t *testing.T) {
 			t.Errorf("valueOfUnitString(%s,%d) wanted: %v(%d) but got: %v(%d)", tt.in, tt.uintbase, tt.expected, tt.expected, got, got)
 		}
 		if used != tt.usedChars {
-			t.Errorf("valueOfUnitString(%s,%d) used %d chars but should used: %d chars", tt.in, tt.uintbase, used, tt.usedChars)
+			t.Errorf("valueOfUnitString(%s,%d) used %d chars but should use: %d chars", tt.in, tt.uintbase, used, tt.usedChars)
 		}
 		if err != nil {
-			t.Errorf("valueOfUnitString(%s,%d) got unexpected error: %v", tt.in, tt.uintbase, err)
+			t.Errorf("valueOfUnitString(%s,%d) unexpected error: %v", tt.in, tt.uintbase, err)
 		}
 	}
 
@@ -852,7 +852,7 @@ func TestValueOfUnitString(t *testing.T) {
 		_, _, err := valueOfUnitString(tt.in, tt.prefix)
 
 		if err == nil {
-			t.Errorf("valueOfUnitString(%s,%d) got expected error but got none", tt.in, tt.prefix)
+			t.Errorf("valueOfUnitString(%s,%d) expected an error", tt.in, tt.prefix)
 		}
 	}
 }
@@ -1030,15 +1030,15 @@ func TestFrequency_Set(t *testing.T) {
 		},
 		{
 			"10EHz",
-			"contains unknown unit prefix \"E\". valid prefixes for \"Hz\" are n,p,u,µ,m,k,M,G or T",
+			"contains unknown unit prefix \"E\". valid prefixes for \"Hz\" are p,n,u,µ,m,k,M,G or T",
 		},
 		{
 			"10ExaHz",
-			"contains unknown unit prefix \"Exa\". valid prefixes for \"Hz\" are n,p,u,µ,m,k,M,G or T",
+			"contains unknown unit prefix \"Exa\". valid prefixes for \"Hz\" are p,n,u,µ,m,k,M,G or T",
 		},
 		{
 			"10eHzE",
-			"contains unknown unit prefix \"e\". valid prefixes for \"Hz\" are n,p,u,µ,m,k,M,G or T",
+			"contains unknown unit prefix \"e\". valid prefixes for \"Hz\" are p,n,u,µ,m,k,M,G or T",
 		},
 		{
 			"10",
@@ -1100,22 +1100,17 @@ func TestFrequency_Set(t *testing.T) {
 
 	for _, tt := range succeeds {
 		var got Frequency
-		err := got.Set(tt.in)
-
+		if err := got.Set(tt.in); err != nil {
+			t.Errorf("Frequency.Set(%s) unexpected error: %v", tt.in, err)
+		}
 		if got != tt.expected {
 			t.Errorf("Frequency.Set(%s) wanted: %v(%d) but got: %v(%d)", tt.in, tt.expected, tt.expected, got, got)
-		}
-		if err != nil {
-			t.Errorf("Frequency.Set(%s) got unexpected error: %v", tt.in, err)
 		}
 	}
 
 	for _, tt := range fails {
 		var got Frequency
-
-		err := got.Set(tt.in)
-
-		if err.Error() != tt.err {
+		if err := got.Set(tt.in); err.Error() != tt.err {
 			t.Errorf("Frequency.Set(%s) \nexpected: %s\ngot: %s", tt.in, tt.err, err)
 		}
 	}


### PR DESCRIPTION
Brings style improvements from #324 
Minor wording changes in tests.
Changes non exported error name  errerrUnderflowsInt64 to errOverflowsInt64Negative
change dtoi's `mag= -1*mag` to `mag= -mag` and `n= -1*n` to `n= -n` as mentioned in a comment. 

