### PR TITLE
ads1x15: Fixes #334 - Removed extra delay

### DIFF
--- a/experimental/devices/ads1x15/ads1x15.go
+++ b/experimental/devices/ads1x15/ads1x15.go
@@ -226,9 +226,8 @@ func (d *Dev) PinForChannel(c Channel, maxVoltage physic.ElectricPotential, f ph
 	configBytes := [2]byte{}
 	binary.BigEndian.PutUint16(configBytes[:], config)
 
-	// The wait for the ADC sample to finish is based on the sample rate plus a
-	// small offset to be sure (0.1 millisecond).
-	waitTime := time.Second/time.Duration(dataRate) + 100*time.Microsecond
+	// The wait for the ADC sample to finish is based on the sample rate.
+	waitTime := time.Second / time.Duration(dataRate)
 
 	return &analogPin{
 		adc:                d,

--- a/experimental/devices/ads1x15/ads1x15_test.go
+++ b/experimental/devices/ads1x15/ads1x15_test.go
@@ -165,6 +165,7 @@ func TestPinADC_ReadContinous(t *testing.T) {
 				R:    []byte{0x52, 0xc0},
 			},
 		},
+		DontPanic: true,
 	}
 
 	rawValues := []int32{21200, 21184}

--- a/experimental/devices/ads1x15/ads1x15_test.go
+++ b/experimental/devices/ads1x15/ads1x15_test.go
@@ -76,7 +76,7 @@ func TestPinADC_Read(t *testing.T) {
 		Ops: []i2ctest.IO{
 			{
 				Addr: 0x48,
-				W:    []byte{0x1, 0x91, 0xc3},
+				W:    []byte{0x1, 0x91, 0x3},
 				R:    []byte{},
 			},
 			{
@@ -92,7 +92,7 @@ func TestPinADC_Read(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Obtain an analog pin from the ADC
-	pin, err := d.PinForChannel(Channel0Minus3, 5*physic.Volt, 1*physic.Hertz, SaveEnergy)
+	pin, err := d.PinForChannel(Channel0Minus3, 5*physic.Volt, 1*physic.Hertz, BestQuality)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,13 +120,12 @@ func TestPinADC_Read(t *testing.T) {
 	}
 }
 
-/* https://github.com/google/periph/issues/334
 func TestPinADC_ReadContinous(t *testing.T) {
 	b := i2ctest.Playback{
 		Ops: []i2ctest.IO{
 			{
 				Addr: 0x48,
-				W:    []byte{0x1, 0x91, 0x3},
+				W:    []byte{0x1, 0x91, 0xc3},
 				R:    []byte{},
 			},
 			{
@@ -136,7 +135,7 @@ func TestPinADC_ReadContinous(t *testing.T) {
 			},
 			{
 				Addr: 0x48,
-				W:    []byte{0x1, 0x91, 0x3},
+				W:    []byte{0x1, 0x91, 0xc3},
 				R:    []byte{},
 			},
 			{
@@ -144,10 +143,20 @@ func TestPinADC_ReadContinous(t *testing.T) {
 				W:    []byte{0x0},
 				R:    []byte{0x52, 0xc0},
 			},
-			// We add one extra exchange, as halting the polling is not instant
+			// We add 2 extra exchanges, as halting the polling is not instant
 			{
 				Addr: 0x48,
-				W:    []byte{0x1, 0x91, 0x3},
+				W:    []byte{0x1, 0x91, 0xc3},
+				R:    []byte{},
+			},
+			{
+				Addr: 0x48,
+				W:    []byte{0x0},
+				R:    []byte{0x52, 0xc0},
+			},
+			{
+				Addr: 0x48,
+				W:    []byte{0x1, 0x91, 0xc3},
 				R:    []byte{},
 			},
 			{
@@ -166,7 +175,7 @@ func TestPinADC_ReadContinous(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Obtain an analog pin from the ADC
-	pin, err := d.PinForChannel(Channel0Minus3, 5*physic.Volt, 100*physic.Hertz, BestQuality)
+	pin, err := d.PinForChannel(Channel0Minus3, 5*physic.Volt, 100*physic.Hertz, SaveEnergy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,4 +207,3 @@ func TestPinADC_ReadContinous(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-*/


### PR DESCRIPTION
The issue was that the extra delay introduced in the reading made the ticker tick sometimes faster than the reading could read. So when it was in the select for the 2 channels "stop" vs "tick", it randomly chooses which to process. So, with bad luck, it could go on sending I2C queries.
I checked on a real device and that extra delay was useless.
I also added another I2C transaction just in case there is a slowdown during the test. However, in that case, we're still depending on the order of selection of the select statement, which is random.
