### PR TITLE
fs,sysfs: Fix #323

### DIFF
--- a/host/fs/fs.go
+++ b/host/fs/fs.go
@@ -97,6 +97,10 @@ func (e *Event) Wait(timeoutms int) (int, error) {
 	return e.event.wait(timeoutms)
 }
 
+func (e *Event) Delete() error {
+	return e.event.deleteEvent()
+}
+
 //
 
 var (

--- a/host/fs/fs_linux.go
+++ b/host/fs/fs_linux.go
@@ -5,6 +5,9 @@
 package fs
 
 import "syscall"
+import "golang.org/x/sys/unix"
+import "time"
+import "errors"
 
 const isLinux = true
 
@@ -46,12 +49,48 @@ func (e *event) makeEvent(fd uintptr) error {
 	// waiting for an edge. This is generally a bad idea, as we'd instead have
 	// the system to *wake up* when an edge is triggered. Achieving this is
 	// outside the scope of this interface.
-	e.event[0].Events = epollPRI | epollET
+	e.event[0].Events = unix.EPOLLPRI | unix.EPOLLET
 	e.event[0].Fd = int32(e.fd)
 	return syscall.EpollCtl(e.epollFd, epollCTLAdd, e.fd, &e.event[0])
 }
 
 func (e *event) wait(timeoutms int) (int, error) {
 	// http://man7.org/linux/man-pages/man2/epoll_wait.2.html
-	return syscall.EpollWait(e.epollFd, e.event[:], timeoutms)
+	n,err := syscall.EpollWait(e.epollFd, e.event[:], timeoutms)
+
+	// Note: this event occurs only once, so it couldn't be used with multiple calls to WaitForEdge()
+	if e.event[0].Events & unix.EPOLLOUT > 0 {
+		// an out event indicates an abort and is fired by the deleteEvent method (only by modifying epoll_ctl to listen to this event)
+		return n,errors.New("wait aborted")
+	}
+	return n,err
+}
+
+func (e *event) deleteEvent() error {
+	// modifying the epoll event to have EPOLLOUT flag set, seems unlocks a pendin epoll_wait (timeout == -1), because
+	// an event with EPOLLOUT flag enabled is returned, everytime this EPOLL_CTL_MOD call is made (observed on tests
+	// with Raspberry Pi 0)
+	// Thus an event with the EPOLLOUT flag set is used, to indicate an abort condition in the wait() method.
+	// To distinguish between events created EPOLL_CTL_ADD (done by gpio.In() with a call to makeEvent) and EPOLL_CTL_MOD
+	// (donw here, on deletion) the EPOLLOUT flag mustn't be set druing EPOLL_CTL_ADD in makeEvent.
+	e.event[0].Events = unix.EPOLLPRI | unix.EPOLLET | unix.EPOLLOUT
+	e.event[0].Fd = int32(e.fd)
+	syscall.EpollCtl(e.epollFd, unix.EPOLL_CTL_MOD, e.fd, &e.event[0]) //ignore error, couldn't do anything about it
+
+	//fmt.Println("mod err", err)
+
+	// This sleep serves two purposes:
+	// 1) 	The gpio.haltEdge() method calls WaitForEdge(0), which result in an epoll_wait with timeout == 0.
+	// 		If this epoll_wait would be called before a potentially pending epoll_wait with a timeout > 0, it
+	// 		could happen that the generated EPOLLOUT event is consumed by the epoll_wait from haltEdge() and thus
+	//		missed by the pending epoll_wait (could be consumed only once). This ultimately would result in a missed
+	//		abort condition for the pending wait with timeout > 0.
+	//		The delay assures that a pending wait catches the condition first (should run in a seperate go routine).
+	// 2)	If there's no delay between the EPOLL_CTL_MOD and the successive EPOLL_CTL_DEL, a pending epoll_wait will
+	//		miss the EPOLLOUT event (according to tests on Raspberry Pi0)
+	time.Sleep(2*time.Millisecond)
+
+	// aditionally we delete the epoll event, as it is added again with a call to gpio.In(), because gpio.haltEdge()
+	// assures that gpio.fEdge is set to nil after calling this method.
+	return syscall.EpollCtl(e.epollFd, unix.EPOLL_CTL_DEL, e.fd, nil)
 }


### PR DESCRIPTION
Another possible solution to fix #323.

Notes:
- observations and testing have been done on a Rapsberry Pi Zero, with a 4.14.71 kernel (custom)
- instead of using epoll_ctl to add an epoll event for the GPIO sysfs value file only once, the code has been modified to delete the epoll event on every call to `Halt` and recreate it on a call to `In`
- before the epoll event gets deleted, it is modified to trigger on `EPOLLOUT`
- this modification ultimately fires an EPOLLOUT event itself and thus unlocks a pending `epoll_wait`. Unlocking the epoll_wait by this methhod could be distinguished from other methods, as the EPOLLOUT flag is set on the resulting event
- as the implementation of this library doesn't preserve EPOLL events, an event with `EPOLLOUT` flag set could be used as abort condition **only once** --> shouldn't work with concurrent calls to WaitForEdge

Another solution (based on loop interrupted by timeout) to force a pending `WaitForEdge` to return after a call to `Halt()` has been presented in the comments of issue #323.

The solution presented here has to be carefully tested. I have neither found any documentation of the observed behavior (calling EPOLL_CTL_MOD to set EPOLLOUT fires an event with the same flag set, for the same epoll fd), nor am I able to test on other hardware than Raspberry Pi0.