### PR TITLE
physic: non exported change: decimal type internal representation.

### DIFF
--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -1515,7 +1515,7 @@ func atod(s string) (decimal, int, error) {
 		// Find the exponet based on decimal point distance from left and the
 		// length of the number.
 		d.exp = (dp - start) - (end - start)
-		if (dp - start) <= 0 {
+		if dp <= start {
 			// Account for numbers of the form 1 > n < -1 eg 0.0001.
 			d.exp++
 		}

--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -1512,7 +1512,7 @@ func atod(s string) (decimal, int, error) {
 			// Decimal Point is in the middle of a number.
 			end--
 		}
-		// Find the exponet based on decimal point distance from left and the
+		// Find the exponent based on decimal point distance from left and the
 		// length of the number.
 		d.exp = (dp - start) - (end - start)
 		if dp <= start {

--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -95,6 +95,11 @@ func (d *Distance) Set(s string) error {
 					return errors.New("does not contain number")
 				}
 				return errors.New("does not contain number or unit \"Metre\"")
+			case errOverflowsInt64:
+				return errors.New("maximum value is " + maxDistance.String())
+			case errOverflowsInt64Negative:
+				return errors.New("minimum value is " + minDistance.String())
+
 			}
 		}
 		return err
@@ -1270,10 +1275,10 @@ func picoAsString(v int64) string {
 	return sign + strconv.Itoa(base) + "." + prefixZeros(3, frac) + unit
 }
 
-// Decimal is the exact representation of decimal number.
+// Decimal is the representation of decimal number.
 type decimal struct {
-	// digits hold the string representation of the significant decimal digits.
-	digits string
+	// base hold the significant digits.
+	base uint64
 	// exponent is the left or right decimal shift. (powers of ten).
 	exp int
 	// neg it true if the number is negative.
@@ -1312,54 +1317,24 @@ var (
 	errOverflowsInt64         = errors.New("exceeds maximum")
 	errOverflowsInt64Negative = errors.New("exceeds minimum")
 	errNotANumber             = errors.New("not a number")
+	errExponentOverflow       = errors.New("exponent exceeds int64")
 )
 
-// Converts from decimal to int64, using the decimal.digits character values and
-// converting to a intermediate unit64.
+// Converts from decimal to int64.
 // Scale is combined with the decimal exponent to maximise the resolution and is
 // in powers of ten.
 func dtoi(d decimal, scale int) (int64, error) {
-	// Use uint till the last as it allows checks for overflows.
-	var u uint64
-	for i := 0; i < len(d.digits); i++ {
-		// Check that is is a digit.
-		if d.digits[i] >= '0' && d.digits[i] <= '9' {
-			// '0' = 0x30 '1' = 0x31 ...etc.
-			digit := d.digits[i] - '0'
-			// *10 is decimal shift left.
-			u *= 10
-			check := u + uint64(digit)
-			// Check should always be larger than u unless we have overflowed.
-			// Similarly if check > max it will overflow when converted to int64.
-			if check < u || check > maxInt64 {
-				if d.neg {
-					return -maxInt64, &parseError{
-						msg: "-" + maxUint64Str,
-						err: errOverflowsInt64Negative,
-					}
-				}
-				return maxInt64, &parseError{
-					msg: maxUint64Str,
-					err: errOverflowsInt64,
-				}
-			}
-			u = check
-		} else {
-			// Should not get here if used atod to generate the decimal.
-			return 0, &parseError{err: errNotANumber}
-		}
-	}
-
 	// Get the total magnitude of the number.
 	// a^x * b^y = a*b^(x+y) since scale is of the order unity this becomes
 	// 1^x * b^y = b^(x+y).
 	// mag must be positive to use as index in to powerOf10 array.
+	u := d.base
 	mag := d.exp + scale
 	if mag < 0 {
 		mag = -mag
 	}
 	if mag > 18 {
-		return 0, errors.New("exponent exceeds int64")
+		return 0, errExponentOverflow
 	}
 	// Divide is = 10^(-mag)
 	if d.exp+scale < 0 {
@@ -1389,10 +1364,11 @@ func dtoi(d decimal, scale int) (int64, error) {
 }
 
 // Converts a string to a decimal form. The return int is how many bytes of the
-// string are numeric. The string may contain +-0 prefixes and arbitrary
-// suffixes as trailing non number characters are ignored.
-// Significant digits are stored without leading or trailing zeros, rather an
-// exponent is used.
+// string are considered numeric. The string may contain +-0 prefixes and
+// arbitrary suffixes as trailing non number characters are ignored.
+// Significant digits are stored without leading or trailing zeros, rather a
+// base and exponent is used. Significant digits are stored as uint64, max size
+// of significant digits is int64
 func atod(s string) (decimal, int, error) {
 	var d decimal
 	start := 0
@@ -1502,21 +1478,45 @@ func atod(s string) (decimal, int, error) {
 		}
 	}
 
-	if dp > start && dp < end {
-		// Concatenate with out decimal point.
-		d.digits = s[start:dp] + s[dp+1:end]
-	} else {
-		d.digits = s[start:end]
+	for i := start; i < end; i++ {
+
+		// Check that is is a digit.
+		if s[i] >= '0' && s[i] <= '9' {
+			// '0' = 0x30 '1' = 0x31 ...etc.
+			digit := s[i] - '0'
+			// *10 is decimal shift left.
+			d.base *= 10
+			check := d.base + uint64(digit)
+			// Check should always be larger than u unless we have overflowed.
+			// Similarly if check > max it will overflow when converted to int64.
+			if check < d.base || check > maxInt64 {
+				if d.neg {
+					return decimal{}, 0, &parseError{
+						msg: "-" + maxUint64Str,
+						err: errOverflowsInt64Negative,
+					}
+				}
+				return decimal{}, 0, &parseError{
+					msg: maxUint64Str,
+					err: errOverflowsInt64,
+				}
+			}
+			d.base = check
+		} else {
+			if s[i] != '.' {
+				return decimal{}, 0, &parseError{err: errNotANumber}
+			}
+		}
 	}
 	if !isPoint {
 		d.exp = exp
 	} else {
-		ttl := dp - start
-		length := len(d.digits)
-		if ttl > 0 {
-			d.exp = ttl - length
-		} else {
-			d.exp = ttl - length + 1
+		if dp > start && dp < end {
+			end--
+		}
+		d.exp = (dp - start) - (end - start) + 1
+		if (dp - start) > 0 {
+			d.exp--
 		}
 	}
 	return d, last, nil

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -549,35 +549,35 @@ func TestAtod(t *testing.T) {
 		expected decimal
 		n        int
 	}{
-		{"123456789", decimal{"123456789", 0, positive}, 9},
-		{"1nM", decimal{"1", 0, positive}, 1},
-		{"2.2nM", decimal{"22", -1, positive}, 3},
-		{"12.5mA", decimal{"125", -1, positive}, 4},
-		{"-12.5mA", decimal{"125", -1, negative}, 5},
-		{"1ma1", decimal{"1", 0, positive}, 1},
-		{"+1ma1", decimal{"1", 0, positive}, 2},
-		{"-1ma1", decimal{"1", 0, negative}, 2},
-		{"-0.00001%rH", decimal{"1", -5, negative}, 8},
-		{"0.00001%rH", decimal{"1", -5, positive}, 7},
-		{"1.0", decimal{"1", 0, positive}, 3},
-		{"0.10001", decimal{"10001", -5, positive}, 7},
-		{"+0.10001", decimal{"10001", -5, positive}, 8},
-		{"-0.10001", decimal{"10001", -5, negative}, 8},
-		{"1n", decimal{"1", 0, positive}, 1},
-		{"1.n", decimal{"1", 0, positive}, 2},
-		{"-1.n", decimal{"1", 0, negative}, 3},
-		{"200n", decimal{"2", 2, positive}, 3},
-		{".01", decimal{"1", -2, positive}, 3},
-		{"+.01", decimal{"1", -2, positive}, 4},
-		{"-.01", decimal{"1", -2, negative}, 4},
-		{"1-2", decimal{"1", 0, positive}, 1},
-		{"1+2", decimal{"1", 0, positive}, 1},
-		{"-1-2", decimal{"1", 0, negative}, 2},
-		{"-1+2", decimal{"1", 0, negative}, 2},
-		{"+1-2", decimal{"1", 0, positive}, 2},
-		{"+1+2", decimal{"1", 0, positive}, 2},
-		{"010", decimal{"1", 1, positive}, 3},
-		{"001", decimal{"1", 0, positive}, 3},
+		{"123456789", decimal{123456789, 0, positive}, 9},
+		{"1nM", decimal{1, 0, positive}, 1},
+		{"2.2", decimal{22, -1, positive}, 3},
+		{"12.5mA", decimal{125, -1, positive}, 4},
+		{"-12.5mA", decimal{125, -1, negative}, 5},
+		{"1ma1", decimal{1, 0, positive}, 1},
+		{"+1ma1", decimal{1, 0, positive}, 2},
+		{"-1ma1", decimal{1, 0, negative}, 2},
+		{"-0.00001%rH", decimal{1, -5, negative}, 8},
+		{"0.00001%rH", decimal{1, -5, positive}, 7},
+		{"1.0", decimal{1, 0, positive}, 3},
+		{"0.10001", decimal{10001, -5, positive}, 7},
+		{"+0.10001", decimal{10001, -5, positive}, 8},
+		{"-0.10001", decimal{10001, -5, negative}, 8},
+		{"1n", decimal{1, 0, positive}, 1},
+		{"1.n", decimal{1, 0, positive}, 2},
+		{"-1.n", decimal{1, 0, negative}, 3},
+		{"200n", decimal{2, 2, positive}, 3},
+		{".01", decimal{1, -2, positive}, 3},
+		{"+.01", decimal{1, -2, positive}, 4},
+		{"-.01", decimal{1, -2, negative}, 4},
+		{"1-2", decimal{1, 0, positive}, 1},
+		{"1+2", decimal{1, 0, positive}, 1},
+		{"-1-2", decimal{1, 0, negative}, 2},
+		{"-1+2", decimal{1, 0, negative}, 2},
+		{"+1-2", decimal{1, 0, positive}, 2},
+		{"+1+2", decimal{1, 0, positive}, 2},
+		{"010", decimal{1, 1, positive}, 3},
+		{"001", decimal{1, 0, positive}, 3},
 	}
 
 	fails := []struct {
@@ -586,6 +586,7 @@ func TestAtod(t *testing.T) {
 		n        int
 	}{
 		{"1.1.1", decimal{}, 0},
+		{"1a2b3a", decimal{}, 0},
 		{"aba", decimal{}, 0},
 		{"%-0.10001", decimal{}, 0},
 		{"--100ma", decimal{}, 0},
@@ -633,26 +634,26 @@ func TestDoti(t *testing.T) {
 		in       decimal
 		expected int64
 	}{
-		{"123", decimal{"123", 0, positive}, 123},
-		{"-123", decimal{"123", 0, negative}, -123},
-		{"1230", decimal{"123", 1, positive}, 1230},
-		{"-1230", decimal{"123", 1, negative}, -1230},
-		{"12.3", decimal{"123", -1, positive}, 12},
-		{"-12.3", decimal{"123", -1, negative}, -12},
-		{"123n", decimal{"123", 0, positive}, 123},
-		{"max", decimal{"9223372036854775807", 0, positive}, 9223372036854775807},
-		{"rounding(5.6)", decimal{"56", -1, positive}, 6},
-		{"rounding(5.5)", decimal{"55", -1, positive}, 6},
-		{"rounding(5.4)", decimal{"54", -1, positive}, 5},
-		{"rounding(-5.6)", decimal{"56", -1, negative}, -6},
-		{"rounding(-5.5)", decimal{"55", -1, negative}, -6},
-		{"rounding(-5.4)", decimal{"54", -1, negative}, -5},
-		{"rounding(0.6)", decimal{"6", -1, positive}, 1},
-		{"rounding(0.5)", decimal{"5", -1, positive}, 1},
-		{"rounding(0.4)", decimal{"4", -1, positive}, 0},
-		{"rounding(-0.6)", decimal{"6", -1, negative}, -1},
-		{"rounding(-0.5)", decimal{"5", -1, negative}, -1},
-		{"rounding(-0.4)", decimal{"4", -1, negative}, -0},
+		{"123", decimal{123, 0, positive}, 123},
+		{"-123", decimal{123, 0, negative}, -123},
+		{"1230", decimal{123, 1, positive}, 1230},
+		{"-1230", decimal{123, 1, negative}, -1230},
+		{"12.3", decimal{123, -1, positive}, 12},
+		{"-12.3", decimal{123, -1, negative}, -12},
+		{"123n", decimal{123, 0, positive}, 123},
+		{"max", decimal{9223372036854775807, 0, positive}, 9223372036854775807},
+		{"rounding(5.6)", decimal{56, -1, positive}, 6},
+		{"rounding(5.5)", decimal{55, -1, positive}, 6},
+		{"rounding(5.4)", decimal{54, -1, positive}, 5},
+		{"rounding(-5.6)", decimal{56, -1, negative}, -6},
+		{"rounding(-5.5)", decimal{55, -1, negative}, -6},
+		{"rounding(-5.4)", decimal{54, -1, negative}, -5},
+		{"rounding(0.6)", decimal{6, -1, positive}, 1},
+		{"rounding(0.5)", decimal{5, -1, positive}, 1},
+		{"rounding(0.4)", decimal{4, -1, positive}, 0},
+		{"rounding(-0.6)", decimal{6, -1, negative}, -1},
+		{"rounding(-0.5)", decimal{5, -1, negative}, -1},
+		{"rounding(-0.4)", decimal{4, -1, negative}, -0},
 	}
 
 	fails := []struct {
@@ -660,14 +661,14 @@ func TestDoti(t *testing.T) {
 		in       decimal
 		expected int64
 	}{
-		{"max+1", decimal{"9223372036854775808", 0, positive}, 9223372036854775807},
-		{"-max-1", decimal{"9223372036854775808", 0, negative}, -9223372036854775807},
-		{"non digit in decimal.digit)", decimal{"1a", 0, positive}, 0},
-		{"non digit in decimal.digit)", decimal{"2.7b", 0, negative}, 0},
-		{"exponet too large for int64", decimal{"123", 20, positive}, 0},
-		{"exponet too small for int64", decimal{"123", -20, positive}, 0},
-		{"max*10^1", decimal{"9223372036854775807", 1, positive}, 9223372036854775807},
-		{"-max*10^1", decimal{"9223372036854775807", 1, negative}, -9223372036854775807},
+		{"max+1", decimal{9223372036854775808, 0, positive}, 9223372036854775807},
+		{"-max-1", decimal{9223372036854775808, 0, negative}, -9223372036854775807},
+		// {"non digit in decimal.igit)", decimal{1a", 0, positive}, 0},
+		// {"non digit in decimal.igit)", decimal{2.7b", 0, negative}, 0},
+		{"exponet too large for int64", decimal{123, 20, positive}, 0},
+		{"exponet too small for int64", decimal{123, -20, positive}, 0},
+		{"max*10^1", decimal{9223372036854775807, 1, positive}, 9223372036854775807},
+		{"-max*10^1", decimal{9223372036854775807, 1, negative}, -9223372036854775807},
 	}
 
 	for _, tt := range succeeds {
@@ -927,6 +928,14 @@ func TestDistance_Set(t *testing.T) {
 		{
 			"10",
 			"no units provided, need m, Metre, Mile, Inch, Foot or Yard",
+		},
+		{
+			"9.3Gm",
+			"maximum value is 9.223Gm",
+		},
+		{
+			"-9.3Gm",
+			"minimum value is -9.223Gm",
 		},
 		{
 			"9223372036854775808",
@@ -2358,6 +2367,19 @@ func BenchmarkDecimal(b *testing.B) {
 	}
 	b.StopTimer()
 	_ = fmt.Sprintf("%v %d", d, n)
+}
+
+func BenchmarkDecimal2Int(b *testing.B) {
+	d := decimal{1234, 5, false}
+	var err error
+	var v int64
+	for i := 0; i < b.N; i++ {
+		if v, err = dtoi(d, 0); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	_ = fmt.Sprintf("%d", v)
 }
 
 func BenchmarkString2Decimal2Int(b *testing.B) {

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -2427,7 +2427,7 @@ func BenchmarkString2Decimal2IntNeg(b *testing.B) {
 	_ = fmt.Sprintf("%d %d", v, n)
 }
 
-func BenchmarkElectricCurrentSet(b *testing.B) {
+func BenchmarkDistanceSet(b *testing.B) {
 	var err error
 	var d Distance
 	for i := 0; i < b.N; i++ {
@@ -2440,7 +2440,7 @@ func BenchmarkElectricCurrentSet(b *testing.B) {
 	_ = fmt.Sprintf("%d", d)
 }
 
-func BenchmarkDistanceSet(b *testing.B) {
+func BenchmarkElectricCurrentSet(b *testing.B) {
 	var err error
 	var e ElectricCurrent
 	for i := 0; i < b.N; i++ {

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -663,8 +663,6 @@ func TestDoti(t *testing.T) {
 	}{
 		{"max+1", decimal{9223372036854775808, 0, positive}, 9223372036854775807},
 		{"-max-1", decimal{9223372036854775808, 0, negative}, -9223372036854775807},
-		// {"non digit in decimal.igit)", decimal{1a", 0, positive}, 0},
-		// {"non digit in decimal.igit)", decimal{2.7b", 0, negative}, 0},
 		{"exponet too large for int64", decimal{123, 20, positive}, 0},
 		{"exponet too small for int64", decimal{123, -20, positive}, 0},
 		{"max*10^1", decimal{9223372036854775807, 1, positive}, 9223372036854775807},


### PR DESCRIPTION
Change decimal type internal representation of digits from []byte to uint64. 
Moves validation of digits to atod from doti.
Update tests for new decimal literal.
Add new test cases to atod().
Update Decimal Benchmarks.

This is a ~2x faster atod() and ~5x faster dtoi(), and helps with #303 remaining units.