### PR TITLE
physic: decimal overflow fix.

### DIFF
--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -1341,7 +1341,7 @@ func dtoi(d decimal, scale int) (int64, error) {
 		u = (u + powerOf10[mag]/2) / powerOf10[mag]
 	} else {
 		check := u * powerOf10[mag]
-		if check < u || check > maxInt64 {
+		if check/powerOf10[mag] != u || check > maxInt64 {
 			if d.neg {
 				return -maxInt64, &parseError{
 					msg: "-" + maxUint64Str,

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -667,6 +667,7 @@ func TestDoti(t *testing.T) {
 		{"exponet too small for int64", decimal{123, -20, positive}, 0},
 		{"max*10^1", decimal{9223372036854775807, 1, positive}, 9223372036854775807},
 		{"-max*10^1", decimal{9223372036854775807, 1, negative}, -9223372036854775807},
+		{"overflow", decimal{7588728005190, 9, positive}, 9223372036854775807},
 	}
 
 	for _, tt := range succeeds {


### PR DESCRIPTION
Fixes bug in overflow detection in dtoi() when the exponent is large enough that overflow check is passed when it has overflowed and wrapped passed base.
Add fail test case for over overflow.
