### PR TITLE
physic: Adds flag.Value for RelativeHumidity

### DIFF
--- a/conn/physic/example_test.go
+++ b/conn/physic/example_test.go
@@ -401,7 +401,7 @@ func ExampleRelativeHumidity_Set() {
 	}
 	fmt.Println(r)
 
-	if err := r.Set("20%rH"); err != nil {
+	if err := r.Set("20%"); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println(r)

--- a/conn/physic/example_test.go
+++ b/conn/physic/example_test.go
@@ -393,6 +393,30 @@ func ExampleRelativeHumidity() {
 	// 20%rH
 }
 
+func ExampleRelativeHumidity_Set() {
+	var r physic.RelativeHumidity
+
+	if err := r.Set("50.6%rH"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(r)
+
+	if err := r.Set("20%rH"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(r)
+	// Output:
+	// 50.6%rH
+	// 20%rH
+}
+
+func ExampleRelativeHumidity_flag() {
+	var h physic.RelativeHumidity
+
+	flag.Var(&h, "humidity", "green house humidity high alarm level")
+	flag.Parse()
+}
+
 func ExampleSpeed() {
 	fmt.Println(10 * physic.MilliMetrePerSecond)
 	fmt.Println(physic.LightSpeed)

--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -972,8 +972,8 @@ const (
 	MilliRH      RelativeHumidity = 1000 * MicroRH    // 0.1%rH
 	PercentRH    RelativeHumidity = 10 * MilliRH      // 1%rH
 
-	maxRelativeHumidity RelativeHumidity = (1 << 31) - 1
-	minRelativeHumidity RelativeHumidity = -((1 << 31) - 1)
+	maxRelativeHumidity RelativeHumidity = 100 * PercentRH
+	minRelativeHumidity RelativeHumidity = 0
 )
 
 // Speed is a measurement of magnitude of velocity stored as an int64 nano

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -2378,19 +2378,19 @@ func TestRelativeHumidity_Set(t *testing.T) {
 		},
 		{
 			"21474836.48m%rH",
-			"maximum value is 21474.8%rH",
+			"maximum value is 100%rH",
 		},
 		{
 			"-21474836.48m%rH",
-			"minimum value is -21474.8%rH",
+			"minimum value is 0%rH",
 		},
 		{
 			"90224T%rH",
-			"maximum value is 21474.8%rH",
+			"maximum value is 100%rH",
 		},
 		{
 			"-90224T%rH",
-			"minimum value is -21474.8%rH",
+			"minimum value is 0%rH",
 		},
 		{
 			"1random",

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -2341,6 +2341,111 @@ func TestPressure_Set(t *testing.T) {
 	}
 }
 
+func TestRelativeHumidity_Set(t *testing.T) {
+	succeeds := []struct {
+		in       string
+		expected RelativeHumidity
+	}{
+		{"10u%rH", PercentRH / 100000},
+		{"1m%rH", PercentRH / 1000},
+		{"1%rH", PercentRH},
+		{"10%rH", 10 * PercentRH},
+		{"100%rH", 100 * PercentRH},
+		{"10u%", PercentRH / 100000},
+		{"1m%", PercentRH / 1000},
+		{"1%", PercentRH},
+		{"10%", 10 * PercentRH},
+		{"100%", 100 * PercentRH},
+		{fmt.Sprintf("%du%%rH", int64(maxRelativeHumidity)*10), maxRelativeHumidity},
+		{fmt.Sprintf("%du%%rH", int64(minRelativeHumidity)*10), minRelativeHumidity},
+	}
+
+	fails := []struct {
+		in  string
+		err string
+	}{
+		{
+			"1000T%rH",
+			"exponent exceeds int64",
+		},
+		{
+			"10E%rH",
+			"contains unknown unit prefix \"E\". valid prefixes for \"%rH\" are p,n,u,µ,m,k,M,G or T",
+		},
+		{
+			"10",
+			"no units provided, need %rH",
+		},
+		{
+			"21474836.48m%rH",
+			"maximum value is 21474.8%rH",
+		},
+		{
+			"-21474836.48m%rH",
+			"minimum value is -21474.8%rH",
+		},
+		{
+			"90224T%rH",
+			"maximum value is 21474.8%rH",
+		},
+		{
+			"-90224T%rH",
+			"minimum value is -21474.8%rH",
+		},
+		{
+			"1random",
+			"\"random\" is not a valid unit for physic.RelativeHumidity",
+		},
+		{
+			"%rH",
+			"does not contain number",
+		},
+		{
+			"%",
+			"does not contain number",
+		},
+		{
+			"RPM",
+			"does not contain number or unit \"%rH\"",
+		},
+		{
+			"++1%rH",
+			"multiple plus symbols ++1%rH",
+		},
+		{
+			"--1%rH",
+			"multiple minus symbols --1%rH",
+		},
+		{
+			"+-1%rH",
+			"can't contain both plus and minus symbols +-1%rH",
+		},
+		{
+			"1.1.1.1%rH",
+			"multiple decimal points 1.1.1.1%rH",
+		},
+	}
+
+	for _, tt := range succeeds {
+		var got RelativeHumidity
+		if err := got.Set(tt.in); err != nil {
+			t.Errorf("RelativeHumidity.Set(%s) unexpected error: %v", tt.in, err)
+		}
+		if got != tt.expected {
+			t.Errorf("RelativeHumidity.Set(%s) wanted: %v(%d) but got: %v(%d)", tt.in, tt.expected, tt.expected, got, got)
+		}
+	}
+
+	for _, tt := range fails {
+		var got RelativeHumidity
+		if err := got.Set(tt.in); err == nil {
+			t.Errorf("RelativeHumidity.Set(%s) \nexpected: error %v but got none", tt.in, tt.err)
+		} else if err.Error() != tt.err {
+			t.Errorf("RelativeHumidity.Set(%s) \nexpected: %s\ngot: %s", tt.in, tt.err, err)
+		}
+	}
+}
+
 func TestSpeed_Set(t *testing.T) {
 	succeeds := []struct {
 		in       string


### PR DESCRIPTION
This adds support for the flag.Value interface for RelativeHumidity unit type.
Add Set and flag doc examples.
Add Set() for RelativeHumidity.
Add Tests for RelativeHumidity Set().
Add Set() and flag.Value examples for RelativeHumidity.

Helps with #303.