### PR TITLE
sysfs: include thermal sensors from hwmon

### DIFF
--- a/host/sysfs/thermal_sensor.go
+++ b/host/sysfs/thermal_sensor.go
@@ -19,7 +19,9 @@ import (
 	"periph.io/x/periph/conn/physic"
 )
 
-// ThermalSensors is all the sensors discovered on this host via sysfs.
+// ThermalSensors is all the sensors discovered on this host via sysfs.  It
+// includes 'thermal' devices as well as temperature 'hwmon' devices, so
+// pre-configured onewire temperature sensors will be discovered automatically.
 var ThermalSensors []*ThermalSensor
 
 // ThermalSensorByName returns a *ThermalSensor for the sensor name, if any.

--- a/host/sysfs/thermal_sensor_test.go
+++ b/host/sysfs/thermal_sensor_test.go
@@ -75,8 +75,28 @@ func TestThermalSensor_Type_success(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", typeFilename: "type"}
 	if s := d.Type(); s != "dummy" {
+		t.Fatal(s)
+	}
+}
+
+func TestThermalSensor_Type_NotFoundIsUnknown(t *testing.T) {
+	defer resetThermal()
+	fileIOOpen = func(path string, flag int) (fileIO, error) {
+		if flag != os.O_RDONLY {
+			t.Fatal(flag)
+		}
+		switch path {
+		case "//\x00/type":
+			return nil, os.ErrNotExist
+		default:
+			t.Fatalf("unknown %q", path)
+			return nil, errors.New("unknown file")
+		}
+	}
+	d := ThermalSensor{name: "cpu", root: "//\000/", typeFilename: "type"}
+	if s := d.Type(); s != "<unknown>" {
 		t.Fatal(s)
 	}
 }
@@ -95,7 +115,7 @@ func TestThermalSensor_Type_fail_1(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", typeFilename: "type"}
 	if s := d.Type(); s != "sysfs-thermal: not implemented" {
 		t.Fatal(s)
 	}
@@ -115,7 +135,7 @@ func TestThermalSensor_Type_fail_2(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", typeFilename: "type"}
 	if s := d.Type(); s != "<unknown>" {
 		t.Fatal(s)
 	}
@@ -135,7 +155,7 @@ func TestThermalSensor_Sense_success(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", sensorFilename: "temp"}
 	e := physic.Env{}
 	if err := d.Sense(&e); err != nil {
 		t.Fatal(err)
@@ -159,7 +179,7 @@ func TestThermalSensor_Sense_fail_1(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", sensorFilename: "temp"}
 	e := physic.Env{}
 	if err := d.Sense(&e); err == nil || err.Error() != "sysfs-thermal: not implemented" {
 		t.Fatal(err)
@@ -180,7 +200,7 @@ func TestThermalSensor_Sense_fail_2(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", sensorFilename: "temp"}
 	e := physic.Env{}
 	if err := d.Sense(&e); err == nil || err.Error() != "sysfs-thermal: failed to read temperature" {
 		t.Fatal(err)
@@ -201,7 +221,7 @@ func TestThermalSensor_Sense_fail_3(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", sensorFilename: "temp"}
 	e := physic.Env{}
 	err := d.Sense(&e)
 	if err == nil {
@@ -231,7 +251,7 @@ func TestThermalSensor_Precision_Kelvin(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", sensorFilename: "temp"}
 	e := physic.Env{}
 	d.Precision(&e)
 	if e.Temperature != physic.Kelvin {
@@ -253,7 +273,7 @@ func TestThermalSensor_Precision_MilliKelvin(t *testing.T) {
 			return nil, errors.New("unknown file")
 		}
 	}
-	d := ThermalSensor{name: "cpu", root: "//\000/"}
+	d := ThermalSensor{name: "cpu", root: "//\000/", sensorFilename: "temp"}
 	e := physic.Env{}
 	d.Precision(&e)
 	if e.Temperature != physic.MilliKelvin {


### PR DESCRIPTION
The w1_therm kernel model exposes onewire thermometers under /sys/class/hwmon/

```
$ ls /sys/bus/w1/devices/
28-011319dd865d
28-011319e04763
w1_bus_master1
$ cat /sys/class/hwmon/hwmon*/name 
w1_slave_temp
w1_slave_temp
$ cat /sys/class/hwmon/hwmon*/device/name
28-011319dd865d
28-011319e04763
$ cat /sys/class/hwmon/hwmon*/temp1_input
24250
23750
$ sudo ./thermal
thermal_zone0: cpu_thermal: 36.400°C
hwmon0: 28-011319dd865d: 24.250°C
hwmon1: 28-011319e04763: 23.750°C
```