### PR TITLE
physic: Adds flag.Value for physic.Temperature

### DIFF
--- a/conn/physic/example_test.go
+++ b/conn/physic/example_test.go
@@ -495,7 +495,7 @@ func ExampleTemperature_Set() {
 	}
 	fmt.Println(t)
 
-	if err := t.Set("0F"); err != nil {
+	if err := t.Set("0°F"); err != nil {
 		log.Fatal(err)
 	}
 	fmt.Println(t)

--- a/conn/physic/example_test.go
+++ b/conn/physic/example_test.go
@@ -474,7 +474,50 @@ func ExampleTemperature() {
 	// Output:
 	// -273.150°C
 	// 23.010°C
-	// 26.666°C
+	// 26.667°C
+}
+
+func ExampleTemperature_Set() {
+	var t physic.Temperature
+
+	if err := t.Set("0°C"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(t)
+
+	if err := t.Set("1C"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(t)
+
+	if err := t.Set("5MK"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(t)
+
+	if err := t.Set("0F"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(t)
+
+	if err := t.Set("32F"); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(t)
+
+	// Output:
+	// 0°C
+	// 1°C
+	// 5M°C
+	// -17.778°C
+	// 0°C
+}
+
+func ExampleTemperature_flag() {
+	var t physic.Temperature
+
+	flag.Var(&t, "temp", "thermostat setpoint")
+	flag.Parse()
 }
 
 func ExamplePower() {

--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -1160,7 +1160,124 @@ type Temperature int64
 
 // String returns the temperature formatted as a string in °Celsius.
 func (t Temperature) String() string {
+	if t < minCelsius || t > maxCelsius {
+		return nanoAsString(int64(t)) + "K"
+	}
 	return nanoAsString(int64(t-ZeroCelsius)) + "°C"
+}
+
+// Set sets the Temperature to the value represented by s. Units are to be
+// provided in "C", "°C", "F" or "K" with an optional SI prefix: "p", "n", "u",
+// "µ", "m", "k", "M", "G" or "T".
+func (t *Temperature) Set(s string) error {
+	d, n, err := atod(s)
+	if err != nil {
+		if e, ok := err.(*parseError); ok {
+			switch e.err {
+			case errNotANumber:
+				if found, _ := containsUnitString(s[n:], "°C", "C", "F", "K"); found != "" {
+					return errors.New("does not contain number")
+				}
+				return errors.New("does not contain number or unit \"°C\"")
+			case errOverflowsInt64:
+				return errors.New("maximum value is " + maxTemperature.String())
+			case errOverflowsInt64Negative:
+				return errors.New("minimum value is " + minTemperature.String())
+			}
+		}
+		return err
+	}
+
+	var si prefix
+	if n != len(s) {
+		r, rsize := utf8.DecodeRuneInString(s[n:])
+		if r <= 1 || rsize == 0 {
+			return &parseError{
+				err: errors.New("unexpected end of string"),
+			}
+		}
+		var siSize int
+		si, siSize = parseSIPrefix(r)
+		n += siSize
+	}
+	switch s[n:] {
+	case "F":
+		// F to nK  nK = 555555555.56*F + 255372222222
+		fPerK := decimal{
+			base: 55555555556,
+			exp:  -2,
+			neg:  false,
+		}
+		f, _ := decimalMul(d, fPerK)
+		v, err := dtoi(f, int(si))
+		if err != nil {
+			if e, ok := err.(*parseError); ok {
+				switch e.err {
+				case errOverflowsInt64:
+					return errors.New("maximum value is " + strconv.FormatInt(int64(maxFahrenheit), 10) + "F")
+				case errOverflowsInt64Negative:
+					return errors.New("minimum value is " + strconv.FormatInt(int64(minFahrenheit), 10) + "F")
+				}
+			}
+			return err
+		}
+		// We need an extra check here to make sure that will not overflow with
+		// the addition of ZeroFahrenheit.
+		switch {
+		case v > int64(maxTemperature-ZeroFahrenheit):
+			return errors.New("maximum value is " + strconv.FormatInt(int64(maxFahrenheit), 10) + "F")
+		case v < int64(minTemperature+ZeroFahrenheit):
+			return errors.New("minimum value is " + strconv.FormatInt(int64(minFahrenheit), 10) + "F")
+		}
+
+		v += int64(ZeroFahrenheit)
+		*t = (Temperature)(v)
+	case "K":
+		v, err := dtoi(d, int(si-nano))
+		if err != nil {
+			if e, ok := err.(*parseError); ok {
+				switch e.err {
+				case errOverflowsInt64:
+					return errors.New("maximum value is " + strconv.FormatInt(int64(maxTemperature/1000000000), 10) + "K")
+				case errOverflowsInt64Negative:
+					return errors.New("minimum value is " + strconv.FormatInt(int64(minTemperature/1000000000), 10) + "K")
+				}
+			}
+			return err
+		}
+		*t = (Temperature)(v)
+	case "C", "°C":
+		v, err := dtoi(d, int(si-nano))
+		if err != nil {
+			if e, ok := err.(*parseError); ok {
+				switch e.err {
+				case errOverflowsInt64:
+					return errors.New("maximum value is " + strconv.FormatInt(int64(maxCelsius/1000000000), 10) + "°C")
+				case errOverflowsInt64Negative:
+					return errors.New("minimum value is " + strconv.FormatInt(int64(minCelsius/1000000000), 10) + "°C")
+				}
+			}
+			return err
+		}
+		// We need an extra check here to make sure that will not overflow with
+		// the addition of ZeroCelsius.
+		switch {
+		case v > int64(maxCelsius):
+			return errors.New("maximum value is " + strconv.FormatInt(int64(maxCelsius/1000000000), 10) + "°C")
+		case v < int64(minCelsius):
+			return errors.New("minimum value is " + strconv.FormatInt(int64(minCelsius/1000000000), 10) + "°C")
+		}
+		v += int64(ZeroCelsius)
+		*t = (Temperature)(v)
+	case "":
+		return noUnits("°C")
+	default:
+		if found, extra := containsUnitString(s[n:], "°C", "C", "F", "K"); found != "" {
+			return unknownUnitPrefix(found, extra, "p,n,u,µ,m,k,M,G or T")
+		}
+		return incorrectUnit(s[n:], "physic.Temperature")
+	}
+	return nil
 }
 
 const (
@@ -1178,9 +1295,20 @@ const (
 	Celsius      Temperature = Kelvin
 
 	// Conversion between Kelvin and Fahrenheit.
-	ZeroFahrenheit  Temperature = 255372 * MilliKelvin
+	ZeroFahrenheit  Temperature = 255372222222 * NanoKelvin
 	MilliFahrenheit Temperature = 555555 * NanoKelvin
 	Fahrenheit      Temperature = 555555555 * NanoKelvin
+
+	maxTemperature Temperature = (1 << 63) - 1
+	minTemperature Temperature = -((1 << 63) - 1)
+
+	// Maximum Celsius is 9223371763704775807°nC.
+	maxCelsius Temperature = maxTemperature - ZeroCelsius
+	minCelsius Temperature = -maxCelsius
+
+	// Maximum Fahrenheit is 16602069204F
+	maxFahrenheit Temperature = 16602069204
+	minFahrenheit Temperature = -maxFahrenheit
 )
 
 // Power is a measurement of power stored as a nano watts.

--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -1160,22 +1160,22 @@ type Temperature int64
 
 // String returns the temperature formatted as a string in °Celsius.
 func (t Temperature) String() string {
-	if t < minCelsius || t > maxCelsius {
+	if t < -ZeroCelsius || t > maxCelsius {
 		return nanoAsString(int64(t)) + "K"
 	}
 	return nanoAsString(int64(t-ZeroCelsius)) + "°C"
 }
 
 // Set sets the Temperature to the value represented by s. Units are to be
-// provided in "C", "°C", "F" or "K" with an optional SI prefix: "p", "n", "u",
-// "µ", "m", "k", "M", "G" or "T".
+// provided in "C", "°C", "F", "°F" or "K" with an optional SI prefix: "p", "n",
+// "u", "µ", "m", "k", "M", "G" or "T".
 func (t *Temperature) Set(s string) error {
 	d, n, err := atod(s)
 	if err != nil {
 		if e, ok := err.(*parseError); ok {
 			switch e.err {
 			case errNotANumber:
-				if found, _ := containsUnitString(s[n:], "°C", "C", "F", "K"); found != "" {
+				if found, _ := containsUnitString(s[n:], "°C", "C", "°F", "F", "K"); found != "" {
 					return errors.New("does not contain number")
 				}
 				return errors.New("does not contain number or unit \"°C\"")
@@ -1201,11 +1201,11 @@ func (t *Temperature) Set(s string) error {
 		n += siSize
 	}
 	switch s[n:] {
-	case "F":
+	case "F", "°F":
 		// F to nK  nK = 555555555.56*F + 255372222222
 		fPerK := decimal{
-			base: 55555555556,
-			exp:  -2,
+			base: 555555555556,
+			exp:  -3,
 			neg:  false,
 		}
 		f, _ := decimalMul(d, fPerK)
@@ -1216,7 +1216,7 @@ func (t *Temperature) Set(s string) error {
 				case errOverflowsInt64:
 					return errors.New("maximum value is " + strconv.FormatInt(int64(maxFahrenheit), 10) + "F")
 				case errOverflowsInt64Negative:
-					return errors.New("minimum value is " + strconv.FormatInt(int64(minFahrenheit), 10) + "F")
+					return errors.New("minimum value is -459.67F")
 				}
 			}
 			return err
@@ -1226,10 +1226,9 @@ func (t *Temperature) Set(s string) error {
 		switch {
 		case v > int64(maxTemperature-ZeroFahrenheit):
 			return errors.New("maximum value is " + strconv.FormatInt(int64(maxFahrenheit), 10) + "F")
-		case v < int64(minTemperature+ZeroFahrenheit):
-			return errors.New("minimum value is " + strconv.FormatInt(int64(minFahrenheit), 10) + "F")
+		case v < int64(-ZeroFahrenheit):
+			return errors.New("minimum value is -459.67F")
 		}
-
 		v += int64(ZeroFahrenheit)
 		*t = (Temperature)(v)
 	case "K":
@@ -1240,10 +1239,13 @@ func (t *Temperature) Set(s string) error {
 				case errOverflowsInt64:
 					return errors.New("maximum value is " + strconv.FormatInt(int64(maxTemperature/1000000000), 10) + "K")
 				case errOverflowsInt64Negative:
-					return errors.New("minimum value is " + strconv.FormatInt(int64(minTemperature/1000000000), 10) + "K")
+					return errors.New("minimum value is 0K")
 				}
 			}
 			return err
+		}
+		if v < 0 {
+			return errors.New("minimum value is 0K")
 		}
 		*t = (Temperature)(v)
 	case "C", "°C":
@@ -1254,7 +1256,7 @@ func (t *Temperature) Set(s string) error {
 				case errOverflowsInt64:
 					return errors.New("maximum value is " + strconv.FormatInt(int64(maxCelsius/1000000000), 10) + "°C")
 				case errOverflowsInt64Negative:
-					return errors.New("minimum value is " + strconv.FormatInt(int64(minCelsius/1000000000), 10) + "°C")
+					return errors.New("minimum value is -273.15°C")
 				}
 			}
 			return err
@@ -1264,15 +1266,15 @@ func (t *Temperature) Set(s string) error {
 		switch {
 		case v > int64(maxCelsius):
 			return errors.New("maximum value is " + strconv.FormatInt(int64(maxCelsius/1000000000), 10) + "°C")
-		case v < int64(minCelsius):
-			return errors.New("minimum value is " + strconv.FormatInt(int64(minCelsius/1000000000), 10) + "°C")
+		case v < int64(-ZeroCelsius):
+			return errors.New("minimum value is " + "-273.15°C")
 		}
 		v += int64(ZeroCelsius)
 		*t = (Temperature)(v)
 	case "":
 		return noUnits("°C")
 	default:
-		if found, extra := containsUnitString(s[n:], "°C", "C", "F", "K"); found != "" {
+		if found, extra := containsUnitString(s[n:], "°C", "C", "°F", "F", "K"); found != "" {
 			return unknownUnitPrefix(found, extra, "p,n,u,µ,m,k,M,G or T")
 		}
 		return incorrectUnit(s[n:], "physic.Temperature")
@@ -1300,15 +1302,13 @@ const (
 	Fahrenheit      Temperature = 555555555 * NanoKelvin
 
 	maxTemperature Temperature = (1 << 63) - 1
-	minTemperature Temperature = -((1 << 63) - 1)
+	minTemperature Temperature = 0
 
 	// Maximum Celsius is 9223371763704775807°nC.
 	maxCelsius Temperature = maxTemperature - ZeroCelsius
-	minCelsius Temperature = -maxCelsius
 
 	// Maximum Fahrenheit is 16602069204F
 	maxFahrenheit Temperature = 16602069204
-	minFahrenheit Temperature = -maxFahrenheit
 )
 
 // Power is a measurement of power stored as a nano watts.

--- a/conn/physic/units.go
+++ b/conn/physic/units.go
@@ -1202,7 +1202,7 @@ func (t *Temperature) Set(s string) error {
 	}
 	switch s[n:] {
 	case "F", "°F":
-		// F to nK  nK = 555555555.56*F + 255372222222
+		// F to nK  nK = 555555555.556*F + 255372222222
 		fPerK := decimal{
 			base: 555555555556,
 			exp:  -3,

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -2624,7 +2624,6 @@ func TestTemperature_Set(t *testing.T) {
 		{"1K", Kelvin},
 		{"100C", ZeroCelsius + 100*Celsius},
 		{"-40F", ZeroCelsius - 40*Celsius},
-
 		{fmt.Sprintf("%dnC", int64(maxCelsius)), ZeroCelsius + maxCelsius},
 		{"-273.15C", 0},
 		{fmt.Sprintf("%dnK", int64(maxTemperature)), maxTemperature},

--- a/conn/physic/units_test.go
+++ b/conn/physic/units_test.go
@@ -2624,15 +2624,16 @@ func TestTemperature_Set(t *testing.T) {
 		{"1K", Kelvin},
 		{"100C", ZeroCelsius + 100*Celsius},
 		{"-40F", ZeroCelsius - 40*Celsius},
+
 		{fmt.Sprintf("%dnC", int64(maxCelsius)), ZeroCelsius + maxCelsius},
-		{fmt.Sprintf("%dnC", int64(minCelsius)), ZeroCelsius + minCelsius},
+		{"-273.15C", 0},
 		{fmt.Sprintf("%dnK", int64(maxTemperature)), maxTemperature},
-		{fmt.Sprintf("%dnK", int64(minTemperature)), minTemperature},
+		{fmt.Sprintf("%dnK", int64(minTemperature)), 0},
 		{fmt.Sprintf("%dF", int64(maxFahrenheit)), 9223372033887869742},
-		{fmt.Sprintf("%dF", int64(minFahrenheit)), -9223371523143425298},
+		{"-459.67F", 0},
 		{"1GK", GigaKelvin},
 		{"1kC", ZeroCelsius + 1000*Celsius},
-		{"16kF", 9144261111182},
+		{"16kF", 9144261111118},
 	}
 
 	fails := []struct {
@@ -2640,12 +2641,16 @@ func TestTemperature_Set(t *testing.T) {
 		err string
 	}{
 		{
+			"-1nK",
+			"minimum value is 0K",
+		},
+		{
 			fmt.Sprintf("%dnC", int64(maxCelsius+1)),
 			"maximum value is 9223371763°C",
 		},
 		{
-			fmt.Sprintf("%dnC", int64(minCelsius-1)),
-			"minimum value is -9223371763°C",
+			fmt.Sprintf("%dnC", int64(-ZeroCelsius-1)),
+			"minimum value is -273.15°C",
 		},
 		{
 			"9223372036854775808nK",
@@ -2653,23 +2658,23 @@ func TestTemperature_Set(t *testing.T) {
 		},
 		{
 			"-9223372036854775808nK",
-			"minimum value is -9.223GK",
+			"minimum value is -273.150°C",
 		},
 		{
 			fmt.Sprintf("%dF", int64(maxFahrenheit+1)),
 			"maximum value is 16602069204F",
 		},
 		{
-			fmt.Sprintf("%dF", int64(minFahrenheit-1)),
-			"minimum value is -16602069204F",
+			"-459.671F",
+			"minimum value is -459.67F",
 		},
 		{
 			fmt.Sprintf("%dF", int64(maxCelsius)),
 			"maximum value is 16602069204F",
 		},
 		{
-			fmt.Sprintf("%dF", int64(minCelsius)),
-			"minimum value is -16602069204F",
+			"-273.151C",
+			"minimum value is -273.15°C",
 		},
 		{
 			"9.224GK",
@@ -2677,7 +2682,7 @@ func TestTemperature_Set(t *testing.T) {
 		},
 		{
 			"-9.224GK",
-			"minimum value is -9223372036K",
+			"minimum value is 0K",
 		},
 		{
 			"9.224GC",
@@ -2685,10 +2690,14 @@ func TestTemperature_Set(t *testing.T) {
 		},
 		{
 			"-9.224GC",
-			"minimum value is -9223371763°C",
+			"minimum value is -273.15°C",
 		},
 		{
-			"1000000000TF",
+			"-9.224TF",
+			"minimum value is -459.67F",
+		},
+		{
+			"100000000000TF",
 			errExponentOverflow.Error(),
 		},
 		{


### PR DESCRIPTION
This adds support for the flag.Value interface for Temperature unit type.
Add Set and flag doc examples.
Add Set() for Temperature.
Add Tests for Temperature Set().
Add Set() and flag.Value examples for Temperature.
Fix Fahrenheit rounding error in Example.
Fix Temperature stringer overflow for temperatures > allowed by Celsius.

This should close #303.