### PR TITLE
mcp9808: add experimental support for digital temperature sensor

### DIFF
--- a/experimental/cmd/mcp9808/main.go
+++ b/experimental/cmd/mcp9808/main.go
@@ -55,7 +55,7 @@ func mainImpl() error {
 	for {
 		select {
 		case <-everySecond:
-			t, err := sensor.Sense()
+			t, err := sensor.SenseTemp()
 			if err != nil {
 				return fmt.Errorf("sensor reading error: %v", err)
 			}

--- a/experimental/cmd/mcp9808/main.go
+++ b/experimental/cmd/mcp9808/main.go
@@ -1,0 +1,74 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// mcp9808 communicates with an mcp9808 sensor reading ambient temperature.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/experimental/devices/mcp9808"
+	"periph.io/x/periph/host"
+)
+
+func mainImpl() error {
+	if _, err := host.Init(); err != nil {
+		return err
+	}
+	address := flag.Int("address", 0x18, "I²C address")
+	i2cbus := flag.String("bus", "", "I²C bus (/dev/i2c-1)")
+
+	flag.Parse()
+
+	fmt.Println("Starting MCP9808 Temperature Sensor")
+	if _, err := host.Init(); err != nil {
+		return err
+	}
+
+	// Open default I²C bus.
+	bus, err := i2creg.Open(*i2cbus)
+	if err != nil {
+		return fmt.Errorf("failed to open I²C: %v", err)
+	}
+	defer bus.Close()
+
+	// Create a new temperature sensor a sense with default options.
+	sensor, err := mcp9808.New(bus, &mcp9808.Opts{Address: *address})
+	if err != nil {
+		return fmt.Errorf("failed to open new sensor: %v", err)
+	}
+
+	// Read values from sensor every second.
+	everySecond := time.NewTicker(time.Second).C
+	var halt = make(chan os.Signal)
+	signal.Notify(halt, syscall.SIGTERM)
+	signal.Notify(halt, syscall.SIGINT)
+
+	fmt.Println("ctrl+c to exit")
+	for {
+		select {
+		case <-everySecond:
+			t, err := sensor.Sense()
+			if err != nil {
+				return fmt.Errorf("sensor reading error: %v", err)
+			}
+			fmt.Println(t)
+		case <-halt:
+			return nil
+		}
+	}
+}
+
+func main() {
+	if err := mainImpl(); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp9808: %s.\n", err)
+		return
+	}
+}

--- a/experimental/cmd/mcp9808/main.go
+++ b/experimental/cmd/mcp9808/main.go
@@ -40,13 +40,13 @@ func mainImpl() error {
 	defer bus.Close()
 
 	// Create a new temperature sensor a sense with default options.
-	sensor, err := mcp9808.New(bus, &mcp9808.Opts{Address: *address})
+	sensor, err := mcp9808.New(bus, &mcp9808.Opts{Addr: *address})
 	if err != nil {
 		return fmt.Errorf("failed to open new sensor: %v", err)
 	}
 
 	// Read values from sensor every second.
-	everySecond := time.NewTicker(time.Second).C
+	everySecond := time.Tick(time.Second)
 	var halt = make(chan os.Signal)
 	signal.Notify(halt, syscall.SIGTERM)
 	signal.Notify(halt, syscall.SIGINT)

--- a/experimental/devices/mcp9808/doc.go
+++ b/experimental/devices/mcp9808/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package mcp9808 controls a Microchip MCP9808 digital I²C temperature sensor.
+//
+// Features
+//
+// -40°C and +125°C Operating Range.
+//
+// User-Selectable Measurement Resolution: +0.5°C, +0.25°C, +0.125°C, +0.0625°C.
+//
+// User-Programmable Temperature Alerts.
+//
+// Datasheet
+//
+// http://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf
+package mcp9808

--- a/experimental/devices/mcp9808/example_test.go
+++ b/experimental/devices/mcp9808/example_test.go
@@ -8,14 +8,13 @@ import (
 	"fmt"
 	"log"
 
-	"periph.io/x/periph/conn/physic"
-
 	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/conn/physic"
 	"periph.io/x/periph/experimental/devices/mcp9808"
 	"periph.io/x/periph/host"
 )
 
-func ExampleDev_Sense() {
+func ExampleDev_SenseTemp() {
 	// Make sure periph is initialized.
 	if _, err := host.Init(); err != nil {
 		log.Fatal(err)
@@ -35,7 +34,7 @@ func ExampleDev_Sense() {
 	}
 
 	// Read values from sensor.
-	measurement, err := sensor.Sense()
+	measurement, err := sensor.SenseTemp()
 
 	if err != nil {
 		log.Fatalln(err)
@@ -74,10 +73,8 @@ func ExampleDev_SenseWithAlerts() {
 		log.Fatalln(err)
 	}
 
-	if len(alerts) > 0 {
-		for _, alert := range alerts {
-			fmt.Println(alert)
-		}
+	for _, alert := range alerts {
+		fmt.Println(alert)
 	}
 
 	fmt.Println(temperature)

--- a/experimental/devices/mcp9808/example_test.go
+++ b/experimental/devices/mcp9808/example_test.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package mcp9808_test
+
+import (
+	"fmt"
+	"log"
+
+	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/experimental/devices/mcp9808"
+	"periph.io/x/periph/host"
+)
+
+func Example() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Open default I²C bus.
+	bus, err := i2creg.Open("")
+	if err != nil {
+		log.Fatalf("failed to open I²C: %v", err)
+	}
+	defer bus.Close()
+
+	// Create a new power sensor.
+	sensor, err := mcp9808.New(bus, &mcp9808.DefaultOpts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	// Read values from sensor.
+	measurement, err := sensor.Sense()
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	fmt.Println(measurement)
+}

--- a/experimental/devices/mcp9808/example_test.go
+++ b/experimental/devices/mcp9808/example_test.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"log"
 
+	"periph.io/x/periph/conn/physic"
+
 	"periph.io/x/periph/conn/i2c/i2creg"
 	"periph.io/x/periph/experimental/devices/mcp9808"
 	"periph.io/x/periph/host"
 )
 
-func Example() {
+func ExampleDev_Sense() {
 	// Make sure periph is initialized.
 	if _, err := host.Init(); err != nil {
 		log.Fatal(err)
@@ -26,7 +28,7 @@ func Example() {
 	}
 	defer bus.Close()
 
-	// Create a new power sensor.
+	// Create a new temperature sensor.
 	sensor, err := mcp9808.New(bus, &mcp9808.DefaultOpts)
 	if err != nil {
 		log.Fatalln(err)
@@ -40,4 +42,43 @@ func Example() {
 	}
 
 	fmt.Println(measurement)
+}
+
+func ExampleDev_SenseWithAlerts() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Open default I²C bus.
+	bus, err := i2creg.Open("")
+	if err != nil {
+		log.Fatalf("failed to open I²C: %v", err)
+	}
+	defer bus.Close()
+
+	// Create a new temperature sensor.
+	sensor, err := mcp9808.New(bus, &mcp9808.DefaultOpts)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	lower := physic.ZeroCelsius
+	upper := physic.ZeroCelsius + 25*physic.Celsius
+	critical := physic.ZeroCelsius + 32*physic.Celsius
+
+	// Read values from sensor.
+	temperature, alerts, err := sensor.SenseWithAlerts(lower, upper, critical)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if len(alerts) > 0 {
+		for _, alert := range alerts {
+			fmt.Println(alert)
+		}
+	}
+
+	fmt.Println(temperature)
 }

--- a/experimental/devices/mcp9808/mcp9808.go
+++ b/experimental/devices/mcp9808/mcp9808.go
@@ -84,6 +84,11 @@ func (d *Dev) Sense(e *physic.Env) error {
 	return err
 }
 
+// SenseContinuous returns measurements as °C, on a continuous basis.
+// The application must call Halt() to stop the sensing when done to stop the
+// sensor and close the channel.
+// It's the responsibility of the caller to retrieve the values from the channel
+// as fast as possible, otherwise the interval may not be respected.
 func (d *Dev) SenseContinuous(interval time.Duration) (<-chan physic.Env, error) {
 	switch d.res {
 	case Maximum:

--- a/experimental/devices/mcp9808/mcp9808.go
+++ b/experimental/devices/mcp9808/mcp9808.go
@@ -1,0 +1,345 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package mcp9808
+
+import (
+	"encoding/binary"
+	"errors"
+	"sync"
+
+	"periph.io/x/periph/conn"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/mmr"
+	"periph.io/x/periph/conn/physic"
+)
+
+// Opts holds the configuration options.
+//
+// Slave Address
+//
+// Depending which pins the A0, A1 and A2 pins are connected to will change the
+// slave address. Default configuration is address 0x18 (Ax pins to GND). For a
+// full address table see datasheet.
+type Opts struct {
+	Address    int
+	Resolution resolution
+}
+
+// DefaultOpts is the recommended default options.
+var DefaultOpts = Opts{
+	Address:    0x18,
+	Resolution: Maximum,
+}
+
+// New opens a handle to an mcp9808 sensor.
+func New(bus i2c.Bus, opts *Opts) (*Dev, error) {
+
+	i2cAddress := DefaultOpts.Address
+	if opts.Address != 0 {
+		if opts.Address < 0x18 || opts.Address > 0x1f {
+			return nil, errAddressOutOfRange
+		}
+		i2cAddress = opts.Address
+	}
+
+	dev := &Dev{
+		m: mmr.Dev8{
+			Conn:  &i2c.Dev{Bus: bus, Addr: uint16(i2cAddress)},
+			Order: binary.BigEndian,
+		},
+	}
+
+	if err := dev.setResolution(opts.Resolution); err != nil {
+		return nil, err
+	}
+	if err := dev.enable(); err != nil {
+		return nil, err
+	}
+
+	return dev, nil
+}
+
+// Dev is a handle to the mcp9808 sensor.
+type Dev struct {
+	m mmr.Dev8
+
+	mu       sync.Mutex
+	critical physic.Temperature
+	upper    physic.Temperature
+	lower    physic.Temperature
+	shutdown bool
+}
+
+// Sense reads the current ambient temperature.
+func (d *Dev) Sense() (physic.Temperature, error) {
+	if err := d.enable(); err != nil {
+		return 0, err
+	}
+	tbits, err := d.m.ReadUint16(temperature)
+	if err != nil {
+		return 0, errReadTemperature
+	}
+	// Convert to physic.Temperature 0.0625°C per bit
+	t := physic.Temperature(tbits&0x0FFF) * 62500 * physic.MicroKelvin
+	if tbits&0x1000 > 0 {
+		// Check for bit sign.
+		t = -t
+	}
+	t += physic.ZeroCelsius
+	return t, nil
+}
+
+// SenseWithAlerts reads the ambient temperature and returns an slice of any
+// alerts that have been tripped. Lower must be less than upper which must be
+// less than critical.
+func (d *Dev) SenseWithAlerts(lower, upper, critical physic.Temperature) (physic.Temperature, []Alert, error) {
+	if critical > upper && upper > lower {
+		if err := d.setCriticalAlert(critical); err != nil {
+			return 0, nil, err
+		}
+		if err := d.setUpperAlert(upper); err != nil {
+			return 0, nil, err
+		}
+		if err := d.setLowerAlert(lower); err != nil {
+			return 0, nil, err
+		}
+	} else {
+		return 0, nil, errAlertInvalid
+	}
+
+	if err := d.enable(); err != nil {
+		return 0, nil, err
+	}
+
+	tbits, err := d.m.ReadUint16(temperature)
+	if err != nil {
+		return 0, nil, errReadTemperature
+	}
+	// Convert to physic.Temperature 0.0625°C per bit
+	t := physic.Temperature(tbits&0x0FFF) * 62500 * physic.MicroKelvin
+	if tbits&0x1000 > 0 {
+		// Check for bit sign.
+		t = -t
+	}
+	t += physic.ZeroCelsius
+	// Check for Alerts.
+	if tbits&0xe000 > 0 {
+		var as []Alert
+		if tbits&0x8000 > 0 {
+			// Critical Alert bit set.
+			crit, err := d.m.ReadUint16(critAlert)
+			if err != nil {
+				return t, nil, errReadCriticalAlert
+			}
+			t := alertBitsToTemperature(crit)
+			as = append(as, Alert{"critical", t})
+		}
+
+		if tbits&0x4000 > 0 {
+			// Upper Alert bit set.
+			upper, err := d.m.ReadUint16(upperAlert)
+			if err != nil {
+				return t, nil, errReadUpperAlert
+			}
+			t := alertBitsToTemperature(upper)
+			as = append(as, Alert{"upper", t})
+		}
+
+		if tbits&0x2000 > 0 {
+			// Lower Alert bit set.
+			lower, err := d.m.ReadUint16(lowerAlert)
+			if err != nil {
+				return t, nil, errReadLowerAlert
+			}
+			t := alertBitsToTemperature(lower)
+			as = append(as, Alert{"lower", t})
+		}
+
+		return t, as, nil
+	}
+
+	return t, nil, nil
+}
+
+// Halt put the mcp9808 into shutdown mode. It will not read temperatures while
+// in shutdown mode.
+func (d *Dev) Halt() error {
+	if err := d.m.WriteUint16(configuration, 0x0100); err != nil {
+		return errWritingConfiguration
+	}
+
+	d.mu.Lock()
+	d.shutdown = true
+	d.mu.Unlock()
+
+	return nil
+}
+
+func (d *Dev) String() string {
+	return "MCP9808"
+}
+
+func (d *Dev) enable() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.shutdown {
+		if err := d.m.WriteUint16(configuration, 0x0000); err != nil {
+			return errWritingConfiguration
+		}
+		d.shutdown = false
+	}
+	return nil
+}
+
+func (d *Dev) setResolution(r resolution) error {
+	switch r {
+	case Low:
+		if err := d.m.WriteUint8(resolutionConfig, 0x00); err != nil {
+			return errWritingResolution
+		}
+	case Medium:
+		if err := d.m.WriteUint8(resolutionConfig, 0x01); err != nil {
+			return errWritingResolution
+		}
+	case High:
+		if err := d.m.WriteUint8(resolutionConfig, 0x02); err != nil {
+			return errWritingResolution
+		}
+	case Maximum:
+		if err := d.m.WriteUint8(resolutionConfig, 0x03); err != nil {
+			return errWritingResolution
+		}
+	default:
+		return errInvalidResolution
+	}
+
+	return nil
+}
+
+func (d *Dev) setCriticalAlert(t physic.Temperature) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if t == d.critical {
+		return nil
+	}
+	crit, err := alertTemperatureToBits(t)
+	if err != nil {
+		return err
+	}
+	if err := d.m.WriteUint16(critAlert, crit); err != nil {
+		return errWritingCritAlert
+	}
+	d.critical = t
+	return nil
+}
+
+func (d *Dev) setUpperAlert(t physic.Temperature) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if t == d.upper {
+		return nil
+	}
+	upper, err := alertTemperatureToBits(t)
+	if err != nil {
+		return err
+	}
+	if err := d.m.WriteUint16(upperAlert, upper); err != nil {
+		return errWritingUpperAlert
+	}
+	d.upper = t
+	return nil
+}
+
+func (d *Dev) setLowerAlert(t physic.Temperature) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if t == d.lower {
+		return nil
+	}
+	lower, err := alertTemperatureToBits(t)
+	if err != nil {
+		return err
+	}
+	if err := d.m.WriteUint16(lowerAlert, lower); err != nil {
+		return errWritingLowerAlert
+	}
+	d.lower = t
+	return nil
+}
+
+type Alert struct {
+	AlertMode  string
+	AlertLevel physic.Temperature
+}
+
+const (
+	// Register addresses.
+	configuration    byte = 0x01
+	upperAlert       byte = 0x02
+	lowerAlert       byte = 0x03
+	critAlert        byte = 0x04
+	temperature      byte = 0x05
+	manifactureID    byte = 0x06
+	deviceID         byte = 0x07
+	resolutionConfig byte = 0x08
+)
+
+var (
+	errReadTemperature      = errors.New("failed to read ambient temperature")
+	errReadCriticalAlert    = errors.New("failed to read critical temperature")
+	errReadUpperAlert       = errors.New("failed to read upper temperature")
+	errReadLowerAlert       = errors.New("failed to read lower temperature")
+	errAddressOutOfRange    = errors.New("i2c address out of range")
+	errInvalidResolution    = errors.New("invalid resolution")
+	errWritingResolution    = errors.New("failed to write resolution configuration")
+	errWritingConfiguration = errors.New("failed to write configuration")
+	errWritingCritAlert     = errors.New("failed to write critical alert configuration")
+	errWritingUpperAlert    = errors.New("failed to write upper alert configuration")
+	errWritingLowerAlert    = errors.New("failed to write lower alert configuration")
+	errAlertOutOfRange      = errors.New("alert seeting exceeds operating conditions")
+	errAlertInvalid         = errors.New("invalid alert temperature configuration")
+)
+
+func alertBitsToTemperature(b uint16) physic.Temperature {
+	b = (b >> 2) & 0x07FF
+	t := physic.Temperature(b&0x03FF) * 250 * physic.MilliKelvin
+	if b&0x400 > 0 {
+		t = -t
+	}
+	t += physic.ZeroCelsius
+	return t
+}
+
+func alertTemperatureToBits(t physic.Temperature) (uint16, error) {
+	const (
+		maxAlert = 125*physic.Kelvin + physic.ZeroCelsius
+		minAlert = -40*physic.Kelvin + physic.ZeroCelsius
+	)
+	if t >= maxAlert || t <= minAlert {
+		return 0, errAlertOutOfRange
+	}
+	t -= physic.ZeroCelsius
+	t /= 250 * physic.MilliKelvin
+
+	var bits uint16
+	if t < 0 {
+		t = -t
+		bits |= 0x400
+	}
+	bits |= uint16(t)
+	bits = bits << 2
+	return bits, nil
+}
+
+type resolution uint8
+
+const (
+	Maximum resolution = 0
+	Low     resolution = 1
+	Medium  resolution = 2
+	High    resolution = 3
+)
+
+var _ conn.Resource = &Dev{}

--- a/experimental/devices/mcp9808/mcp9808_test.go
+++ b/experimental/devices/mcp9808/mcp9808_test.go
@@ -203,7 +203,6 @@ func TestSenseContinuous(t *testing.T) {
 		}
 		mcp9808.Halt()
 	}
-
 }
 
 func TestPrecision(t *testing.T) {
@@ -705,9 +704,7 @@ func TestDev_setResolution(t *testing.T) {
 		if err := mcp9808.setResolution(tt.res); err != tt.err {
 			t.Errorf("setResolution(%s) expected %v but got %v", tt.name, tt.err, err)
 		}
-
 	}
-
 }
 
 func TestDev_setCriticalAlert(t *testing.T) {
@@ -930,5 +927,4 @@ func Test_temperatureToAlertBits(t *testing.T) {
 			t.Errorf("alertBitsToTemperature(%s) expected error %v", tt.name, tt.want)
 		}
 	}
-
 }

--- a/experimental/devices/mcp9808/mcp9808_test.go
+++ b/experimental/devices/mcp9808/mcp9808_test.go
@@ -1,0 +1,746 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package mcp9808
+
+import (
+	"encoding/binary"
+	"reflect"
+	"testing"
+
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2ctest"
+	"periph.io/x/periph/conn/mmr"
+	"periph.io/x/periph/conn/physic"
+)
+
+func TestNew(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Opts
+		tx   []i2ctest.IO
+		want error
+	}{
+		{
+			name: "defaults",
+			opts: DefaultOpts,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{resolutionConfig, 0x03}, R: []byte{}},
+				{Addr: 0x18, W: []byte{configuration, 0x00, 0x00}, R: []byte{}},
+			},
+			want: nil,
+		},
+		{
+			name: "bad address",
+			opts: Opts{Address: 0x40},
+			want: errAddressOutOfRange,
+		},
+		{
+			name: "io error",
+			opts: Opts{Address: 0x18},
+			want: errWritingResolution,
+		},
+	}
+
+	for _, tt := range tests {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+
+		_, err := New(&bus, &tt.opts)
+		if err != tt.want {
+			t.Errorf("New(%s) expected %v but got %v ", tt.name, tt.want, err)
+		}
+	}
+}
+
+func TestSense(t *testing.T) {
+	tests := []struct {
+		name string
+		want physic.Temperature
+		tx   []i2ctest.IO
+		err  error
+	}{
+		{
+			name: "0C",
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0x00, 0x00}},
+			},
+			want: physic.ZeroCelsius,
+			err:  nil,
+		},
+		{
+			name: "10C",
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0x00, 0xa0}},
+			},
+			want: physic.ZeroCelsius + 10*physic.Kelvin,
+			err:  nil,
+		},
+		{
+			name: "-10C",
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0x10, 0xa0}},
+			},
+			want: physic.ZeroCelsius - 10*physic.Kelvin,
+			err:  nil,
+		},
+		{
+			name: "io error",
+			tx:   []i2ctest.IO{},
+			err:  errReadTemperature,
+		},
+	}
+
+	for _, tt := range tests {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+		}
+		got, err := mcp9808.Sense()
+		if tt.want != got {
+			t.Errorf("%s Sense() expected %v but got %v ", tt.name, tt.want, got)
+		}
+		if err != tt.err {
+			t.Errorf("%s Sense() expected %v but got %v ", tt.name, tt.err, err)
+		}
+	}
+}
+
+func TestSenseWithAlerts(t *testing.T) {
+	tests := []struct {
+		name     string
+		critical physic.Temperature
+		upper    physic.Temperature
+		lower    physic.Temperature
+		temp     physic.Temperature
+		alerts   []Alert
+		tx       []i2ctest.IO
+		err      error
+	}{
+		{
+			name:     "read no alert",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			temp:     physic.ZeroCelsius + 1*physic.Kelvin,
+			alerts:   nil,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0x00, 0x10}},
+			},
+			err: nil,
+		},
+		{
+			name:     "get lower Alert",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			temp:     physic.ZeroCelsius - 1*physic.Kelvin,
+			alerts: []Alert{
+				{"lower", physic.ZeroCelsius},
+			},
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0x30, 0x10}},
+				{Addr: 0x18, W: []byte{lowerAlert}, R: []byte{0x00, 0x00}},
+			},
+			err: nil,
+		},
+		{
+			name:     "get upper Alert",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			temp:     physic.ZeroCelsius + 7*physic.Kelvin,
+			alerts: []Alert{
+				{"upper", physic.ZeroCelsius + 5*physic.Kelvin},
+			},
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0x40, 0x70}},
+				{Addr: 0x18, W: []byte{upperAlert}, R: []byte{0x00, 0x50}},
+			},
+			err: nil,
+		},
+		{
+			name:     "get critical Alert",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			temp:     physic.ZeroCelsius + 15*physic.Kelvin,
+			alerts: []Alert{
+				{"critical", physic.ZeroCelsius + 10*physic.Kelvin},
+				{"upper", physic.ZeroCelsius + 5*physic.Kelvin},
+			},
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0xc0, 0xf0}},
+				{Addr: 0x18, W: []byte{critAlert}, R: []byte{0x00, 0xa0}},
+				{Addr: 0x18, W: []byte{upperAlert}, R: []byte{0x00, 0x50}},
+			},
+			err: nil,
+		},
+		{
+			name:     "set critical error",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			err:      errWritingCritAlert,
+		},
+		{
+			name:     "set upper error",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+			},
+			err: errWritingUpperAlert,
+		},
+		{
+			name:     "set lower error",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+			},
+			err: errWritingLowerAlert,
+		},
+		{
+			name:     "invalid alert config",
+			critical: physic.ZeroCelsius + 1*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			tx:       []i2ctest.IO{},
+			err:      errAlertInvalid,
+		},
+		{
+			name:     "temperature io error",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+			},
+			err: errReadTemperature,
+		},
+		{
+			name:     "read critical io error",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			temp:     physic.ZeroCelsius + 15*physic.Kelvin,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0xc0, 0xf0}},
+			},
+			err: errReadCriticalAlert,
+		},
+		{
+			name:     "read upper io error",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			temp:     physic.ZeroCelsius + 15*physic.Kelvin,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0xc0, 0xf0}},
+				{Addr: 0x18, W: []byte{critAlert}, R: []byte{0x00, 0xa0}},
+			},
+			err: errReadUpperAlert,
+		},
+		{
+			name:     "read lower io error",
+			critical: physic.ZeroCelsius + 10*physic.Kelvin,
+			upper:    physic.ZeroCelsius + 5*physic.Kelvin,
+			lower:    physic.ZeroCelsius,
+			temp:     physic.ZeroCelsius - 1*physic.Kelvin,
+			alerts:   nil,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0xa0}, R: nil},
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x50}, R: nil},
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+				{Addr: 0x18, W: []byte{temperature}, R: []byte{0x30, 0x10}},
+			},
+			err: errReadLowerAlert,
+		},
+	}
+
+	for _, tt := range tests {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+		}
+		temp, alerts, err := mcp9808.SenseWithAlerts(tt.lower, tt.upper, tt.critical)
+		if err != tt.err {
+			t.Errorf("SenseWithAlerts(%s) wanted err: %v but got: %v", tt.name, tt.err, err)
+		}
+		if temp != tt.temp {
+			t.Errorf("SenseWithAlerts(%s) wanted temp: %s but got: %s", tt.name, tt.temp, temp)
+		}
+		if !reflect.DeepEqual(alerts, tt.alerts) {
+			t.Errorf("SenseWithAlerts(%s) expected alerts %+v but got %+v ", tt.name, tt.alerts, alerts)
+		}
+	}
+}
+
+func TestDevHalt(t *testing.T) {
+	tests := []struct {
+		name     string
+		tx       []i2ctest.IO
+		shutdown bool
+		want     bool
+		err      error
+	}{
+		{
+			name: "shutdown",
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{configuration, 0x01, 0x00}, R: nil},
+			},
+			shutdown: false,
+			want:     true,
+			err:      nil,
+		},
+		{
+			name: "io error",
+			tx:   []i2ctest.IO{
+				// {Addr: 0x18, W: []byte{configuration, 0x01, 0x00}, R: nil},
+			},
+			shutdown: false,
+			want:     false,
+			err:      errWritingConfiguration,
+		},
+	}
+	for _, tt := range tests {
+
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+			shutdown: tt.shutdown,
+		}
+
+		if err := mcp9808.Halt(); err != tt.err {
+			t.Errorf("Halt(%s) wanted error: %v but got: %v", tt.name, tt.err, err)
+		}
+		if mcp9808.shutdown != tt.want {
+			t.Errorf("Halt(%s) expected dev to be: %t but is: %t", tt.name, tt.want, mcp9808.shutdown)
+		}
+	}
+}
+
+func TestDevString(t *testing.T) {
+	mcp9808 := &Dev{}
+	want := "MCP9808"
+	if want != mcp9808.String() {
+		t.Errorf("mpc9808.String() expected %s but got %s", want, mcp9808.String())
+	}
+}
+
+func TestDev_enable(t *testing.T) {
+	tests := []struct {
+		name     string
+		tx       []i2ctest.IO
+		shutdown bool
+		want     bool
+		err      error
+	}{
+		{
+			name: "shutdown",
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{configuration, 0x00, 0x00}, R: nil},
+			},
+			shutdown: true,
+			want:     false,
+			err:      nil,
+		},
+		{
+			name: "io error",
+			tx:   []i2ctest.IO{
+				// {Addr: 0x18, W: []byte{configuration, 0x01, 0x00}, R: nil},
+			},
+			shutdown: true,
+			want:     true,
+			err:      errWritingConfiguration,
+		},
+	}
+	for _, tt := range tests {
+
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+			shutdown: tt.shutdown,
+		}
+
+		if err := mcp9808.enable(); err != tt.err {
+			t.Errorf("enable(%s) wanted error: %v but got: %v", tt.name, tt.err, err)
+		}
+		if mcp9808.shutdown != tt.want {
+			t.Errorf("enable(%s) expected dev to be: %t but is: %t", tt.name, tt.want, mcp9808.shutdown)
+		}
+	}
+}
+
+func TestDev_setResolution(t *testing.T) {
+	succeeds := []struct {
+		name string
+		res  resolution
+		tx   []i2ctest.IO
+		err  error
+	}{
+		{
+			name: "Low",
+			res:  Low,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{resolutionConfig, 0x00}, R: nil},
+			},
+			err: nil,
+		}, {
+			name: "Medium",
+			res:  Medium,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{resolutionConfig, 0x01}, R: nil},
+			},
+			err: nil,
+		}, {
+			name: "High",
+			res:  High,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{resolutionConfig, 0x02}, R: nil},
+			},
+			err: nil,
+		}, {
+			name: "Maximum",
+			res:  Maximum,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{resolutionConfig, 0x03}, R: nil},
+			},
+			err: nil,
+		},
+	}
+
+	fails := []struct {
+		name string
+		res  resolution
+		tx   []i2ctest.IO
+		err  error
+	}{
+		{
+			name: "Low",
+			res:  Low,
+			err:  errWritingResolution,
+		}, {
+			name: "Medium",
+			res:  Medium,
+			err:  errWritingResolution,
+		}, {
+			name: "High",
+			res:  High,
+			err:  errWritingResolution,
+		}, {
+			name: "Maximum",
+			res:  Maximum,
+			err:  errWritingResolution,
+		}, {
+			name: "Unknown",
+			res:  resolution(5),
+			err:  errInvalidResolution,
+		},
+	}
+
+	for _, tt := range succeeds {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+		}
+		if err := mcp9808.setResolution(tt.res); err != tt.err {
+			t.Errorf("setResolution(%s) expected %v but got %v", tt.name, tt.err, err)
+		}
+
+	}
+
+	for _, tt := range fails {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+		}
+		if err := mcp9808.setResolution(tt.res); err != tt.err {
+			t.Errorf("setResolution(%s) expected %v but got %v", tt.name, tt.err, err)
+		}
+
+	}
+
+}
+
+func TestDev_setCriticalAlert(t *testing.T) {
+	tests := []struct {
+		name  string
+		alert physic.Temperature
+		crit  physic.Temperature
+		tx    []i2ctest.IO
+		err   error
+	}{
+		{
+			name:  "0C",
+			alert: physic.ZeroCelsius,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{critAlert, 0x00, 0x00}, R: nil},
+			},
+			err: nil,
+		},
+		{
+			name:  "125C",
+			alert: physic.ZeroCelsius + 125*physic.Kelvin,
+			tx:    []i2ctest.IO{},
+			err:   errAlertOutOfRange,
+		},
+		{
+			name:  "io error",
+			alert: physic.ZeroCelsius,
+			tx:    []i2ctest.IO{},
+			err:   errWritingCritAlert,
+		},
+		{
+			name:  "nop",
+			alert: physic.ZeroCelsius,
+			crit:  physic.ZeroCelsius,
+			tx:    []i2ctest.IO{},
+			err:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+			critical: tt.crit,
+		}
+		if err := mcp9808.setCriticalAlert(tt.alert); err != tt.err {
+			t.Errorf("setCriticalAlert(%s) expected %v but got %v", tt.name, tt.err, err)
+		}
+	}
+}
+
+func TestDev_setUpperAlert(t *testing.T) {
+	tests := []struct {
+		name  string
+		alert physic.Temperature
+		tx    []i2ctest.IO
+		upper physic.Temperature
+		err   error
+	}{
+		{
+			name:  "0C",
+			alert: physic.ZeroCelsius,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{upperAlert, 0x00, 0x00}, R: nil},
+			},
+			err: nil,
+		},
+		{
+			name:  "125C",
+			alert: physic.ZeroCelsius + 125*physic.Kelvin,
+			tx:    []i2ctest.IO{},
+			err:   errAlertOutOfRange,
+		},
+		{
+			name:  "io error",
+			alert: physic.ZeroCelsius,
+			tx:    []i2ctest.IO{},
+			err:   errWritingUpperAlert,
+		},
+		{
+			name:  "nop",
+			alert: physic.ZeroCelsius,
+			upper: physic.ZeroCelsius,
+			tx:    []i2ctest.IO{},
+			err:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+			upper: tt.upper,
+		}
+		if err := mcp9808.setUpperAlert(tt.alert); err != tt.err {
+			t.Errorf("setUpperAlert(%s) expected %v but got %v", tt.name, tt.err, err)
+		}
+	}
+}
+
+func TestDev_setLowerAlert(t *testing.T) {
+	tests := []struct {
+		name  string
+		alert physic.Temperature
+		tx    []i2ctest.IO
+		lower physic.Temperature
+		err   error
+	}{
+		{
+			name:  "0C",
+			alert: physic.ZeroCelsius,
+			tx: []i2ctest.IO{
+				{Addr: 0x18, W: []byte{lowerAlert, 0x00, 0x00}, R: nil},
+			},
+			err: nil,
+		},
+		{
+			name:  "125C",
+			alert: physic.ZeroCelsius + 125*physic.Kelvin,
+			tx:    []i2ctest.IO{},
+			err:   errAlertOutOfRange,
+		},
+		{
+			name:  "io error",
+			alert: physic.ZeroCelsius,
+			tx:    []i2ctest.IO{},
+			err:   errWritingLowerAlert,
+		},
+		{
+			name:  "nop",
+			alert: physic.ZeroCelsius,
+			lower: physic.ZeroCelsius,
+			tx:    []i2ctest.IO{},
+			err:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		bus := i2ctest.Playback{
+			Ops:       tt.tx,
+			DontPanic: true,
+		}
+
+		mcp9808 := &Dev{
+			m: mmr.Dev8{
+				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
+				Order: binary.BigEndian},
+			lower: tt.lower,
+		}
+		if err := mcp9808.setLowerAlert(tt.alert); err != tt.err {
+			t.Errorf("setLowerAlert(%s) expected %v but got %v", tt.name, tt.err, err)
+		}
+	}
+}
+
+func Test_alertBitsToTemperature(t *testing.T) {
+	tests := []struct {
+		name string
+		bits uint16
+		want physic.Temperature
+	}{
+		{"0°C", 0x0000, physic.ZeroCelsius},
+		{"0.25°C", 0x0004, physic.ZeroCelsius + 250*physic.MilliKelvin},
+		{"-0.25°C", 0x1004, physic.ZeroCelsius - 250*physic.MilliKelvin},
+	}
+
+	for _, tt := range tests {
+		if got := alertBitsToTemperature(tt.bits); got != tt.want {
+			t.Errorf("alertBitsToTemperature(%s) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func Test_temperatureToAlertBits(t *testing.T) {
+	succeeds := []struct {
+		name  string
+		alert physic.Temperature
+		want  uint16
+	}{
+		{"0°C", physic.ZeroCelsius, 0x0000},
+		{"0.25°C", physic.ZeroCelsius + 250*physic.MilliKelvin, 0x0004},
+		{"-0.25°C", physic.ZeroCelsius - 250*physic.MilliKelvin, 0x1004},
+		{"124.75°C", physic.ZeroCelsius + 124750*physic.MilliKelvin, 0x07cc},
+		{"-39.75°C", physic.ZeroCelsius - 39750*physic.MilliKelvin, 0x127c},
+	}
+
+	fails := []struct {
+		name  string
+		alert physic.Temperature
+		want  error
+	}{
+		{"125°C", physic.ZeroCelsius + 125*physic.Kelvin, errAlertOutOfRange},
+		{"-40°C", physic.ZeroCelsius - 40*physic.Kelvin, errAlertOutOfRange},
+	}
+
+	for _, tt := range succeeds {
+		got, err := alertTemperatureToBits(tt.alert)
+		if got != tt.want && err == nil {
+			t.Errorf("alertBitsToTemperature(%s) = %x, want %x", tt.name, got, tt.want)
+		}
+		if err != nil {
+			t.Errorf("alertBitsToTemperature(%s) got unexpected error: %v", tt.name, err)
+		}
+	}
+
+	for _, tt := range fails {
+		if _, err := alertTemperatureToBits(tt.alert); err == nil {
+			t.Errorf("alertBitsToTemperature(%s) expected error %v", tt.name, tt.want)
+		}
+	}
+
+}

--- a/experimental/devices/mcp9808/mcp9808_test.go
+++ b/experimental/devices/mcp9808/mcp9808_test.go
@@ -33,12 +33,12 @@ func TestNew(t *testing.T) {
 		},
 		{
 			name: "bad address",
-			opts: Opts{Address: 0x40},
+			opts: Opts{Addr: 0x40},
 			want: errAddressOutOfRange,
 		},
 		{
 			name: "io error",
-			opts: Opts{Address: 0x18},
+			opts: Opts{Addr: 0x18},
 			want: errWritingResolution,
 		},
 	}
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestSense(t *testing.T) {
+func TestSenseTemp(t *testing.T) {
 	tests := []struct {
 		name string
 		want physic.Temperature
@@ -104,12 +104,12 @@ func TestSense(t *testing.T) {
 				Conn:  &i2c.Dev{Bus: &bus, Addr: 0x18},
 				Order: binary.BigEndian},
 		}
-		got, err := mcp9808.Sense()
+		got, err := mcp9808.SenseTemp()
 		if tt.want != got {
-			t.Errorf("%s Sense() expected %v but got %v ", tt.name, tt.want, got)
+			t.Errorf("%s SenseTemp() expected %v but got %v ", tt.name, tt.want, got)
 		}
 		if err != tt.err {
-			t.Errorf("%s Sense() expected %v but got %v ", tt.name, tt.err, err)
+			t.Errorf("%s SenseTemp() expected %v but got %v ", tt.name, tt.err, err)
 		}
 	}
 }
@@ -539,8 +539,8 @@ func TestDev_setCriticalAlert(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:  "125C",
-			alert: physic.ZeroCelsius + 125*physic.Kelvin,
+			name:  "126C",
+			alert: physic.ZeroCelsius + 126*physic.Kelvin,
 			tx:    []i2ctest.IO{},
 			err:   errAlertOutOfRange,
 		},
@@ -594,8 +594,8 @@ func TestDev_setUpperAlert(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:  "125C",
-			alert: physic.ZeroCelsius + 125*physic.Kelvin,
+			name:  "126C",
+			alert: physic.ZeroCelsius + 126*physic.Kelvin,
 			tx:    []i2ctest.IO{},
 			err:   errAlertOutOfRange,
 		},
@@ -649,8 +649,8 @@ func TestDev_setLowerAlert(t *testing.T) {
 			err: nil,
 		},
 		{
-			name:  "125C",
-			alert: physic.ZeroCelsius + 125*physic.Kelvin,
+			name:  "126C",
+			alert: physic.ZeroCelsius + 126*physic.Kelvin,
 			tx:    []i2ctest.IO{},
 			err:   errAlertOutOfRange,
 		},
@@ -723,8 +723,8 @@ func Test_temperatureToAlertBits(t *testing.T) {
 		alert physic.Temperature
 		want  error
 	}{
-		{"125°C", physic.ZeroCelsius + 125*physic.Kelvin, errAlertOutOfRange},
-		{"-40°C", physic.ZeroCelsius - 40*physic.Kelvin, errAlertOutOfRange},
+		{"126°C", physic.ZeroCelsius + 126*physic.Kelvin, errAlertOutOfRange},
+		{"-41°C", physic.ZeroCelsius - 41*physic.Kelvin, errAlertOutOfRange},
 	}
 
 	for _, tt := range succeeds {

--- a/experimental/devices/mcp9808/mcp9808smoketest/mcp9808smoketest.go
+++ b/experimental/devices/mcp9808/mcp9808smoketest/mcp9808smoketest.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package mcp9808smoketest
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+
+	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/experimental/devices/mcp9808"
+	"periph.io/x/periph/host"
+)
+
+// SmokeTest is imported by periph-smoketest.
+type SmokeTest struct {
+}
+
+// Name implements the SmokeTest interface.
+func (s *SmokeTest) Name() string {
+	return "mcp9808"
+}
+
+// Description implements the SmokeTest interface.
+func (s *SmokeTest) Description() string {
+	return "Tests MCP9808 over I²C"
+}
+
+// Run implements the SmokeTest interface.
+func (s *SmokeTest) Run(f *flag.FlagSet, args []string) (err error) {
+	i2cID := f.String("i2c", "", "I²C bus to use")
+	i2cAddr := f.Int("ia", 0x18, "I²C bus address use: 0x18 to 0x1f")
+	if err := f.Parse(args); err != nil {
+		return err
+	}
+	if f.NArg() != 0 {
+		f.Usage()
+		return errors.New("unrecognized arguments")
+	}
+
+	fmt.Println("Starting MCP9808 Temperature Sensor\nctrl+c to exit")
+	if _, err := host.Init(); err != nil {
+		return err
+	}
+
+	// Open default i2c bus.
+	bus, err := i2creg.Open(*i2cID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err2 := bus.Close(); err == nil {
+			err = err2
+		}
+	}()
+
+	// Create a new temperature sensor a with maximum resolution.
+	config := mcp9808.Opts{
+		Address:    *i2cAddr,
+		Resolution: mcp9808.Maximum,
+	}
+
+	sensor, err := mcp9808.New(bus, &config)
+	if err != nil {
+		return err
+	}
+	t, err := sensor.Sense()
+	if err != nil {
+		return err
+	}
+	fmt.Println(t)
+
+	return nil
+}

--- a/experimental/devices/mcp9808/mcp9808smoketest/mcp9808smoketest.go
+++ b/experimental/devices/mcp9808/mcp9808smoketest/mcp9808smoketest.go
@@ -58,8 +58,8 @@ func (s *SmokeTest) Run(f *flag.FlagSet, args []string) (err error) {
 
 	// Create a new temperature sensor a with maximum resolution.
 	config := mcp9808.Opts{
-		Address:    *i2cAddr,
-		Resolution: mcp9808.Maximum,
+		Addr: *i2cAddr,
+		Res:  mcp9808.Maximum,
 	}
 
 	sensor, err := mcp9808.New(bus, &config)

--- a/experimental/devices/mcp9808/mcp9808smoketest/mcp9808smoketest.go
+++ b/experimental/devices/mcp9808/mcp9808smoketest/mcp9808smoketest.go
@@ -66,7 +66,7 @@ func (s *SmokeTest) Run(f *flag.FlagSet, args []string) (err error) {
 	if err != nil {
 		return err
 	}
-	t, err := sensor.Sense()
+	t, err := sensor.SenseTemp()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add initial support for microchip i2c MCP9808 temperature sensor.