### PR TITLE
i2c: Adds i2c.Addr type and flag.Value interface.

### DIFF
--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -110,11 +110,11 @@ func (d *Dev) Duplex() conn.Duplex {
 	return conn.Half
 }
 
-// Addr is an I²C slave address. Addr implements the flag.Value interface.
+// Addr is an I²C slave address.
 type Addr uint16
 
 // Set sets the Addr to a value represented by the string s. Values maybe in
-// decimal or hexadecimal form.
+// decimal or hexadecimal form. Set implements the flag.Value interface.
 func (a *Addr) Set(s string) error {
 	u, err := strconv.ParseUint(s, 0, 16)
 	if err != nil {

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -116,8 +116,8 @@ type Addr uint16
 // Set sets the Addr to a value represented by the string s. Values maybe in
 // decimal or hexadecimal form. Set implements the flag.Value interface.
 func (a *Addr) Set(s string) error {
-	// Allow for only maximum of 11 bits for i2c addresses.
-	u, err := strconv.ParseUint(s, 0, 11)
+	// Allow for only maximum of 10 bits for i2c addresses.
+	u, err := strconv.ParseUint(s, 0, 10)
 	if err != nil {
 		return errI2CSetError
 	}

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -116,11 +116,8 @@ type Addr uint16
 // Set sets the Addr to a value respresented by the string s. Values maybe in
 // decimal or hexadecimal form.
 func (a *Addr) Set(s string) error {
-	u, err := strconv.ParseUint(s, 0, strconv.IntSize)
+	u, err := strconv.ParseUint(s, 0, 16)
 	if err != nil {
-		return errI2CSetError
-	}
-	if u > 0xffff {
 		return errI2CSetError
 	}
 	*a = Addr(u)

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -116,12 +116,9 @@ type Addr uint16
 // Set sets the Addr to a value represented by the string s. Values maybe in
 // decimal or hexadecimal form. Set implements the flag.Value interface.
 func (a *Addr) Set(s string) error {
-	u, err := strconv.ParseUint(s, 0, 16)
+	// Allow for only maximum of 11 bits for i2c addresses.
+	u, err := strconv.ParseUint(s, 0, 11)
 	if err != nil {
-		return errI2CSetError
-	}
-	// Allow for 10 bit i2c addresses.
-	if u > 0x07ff {
 		return errI2CSetError
 	}
 	*a = Addr(u)

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -110,14 +110,18 @@ func (d *Dev) Duplex() conn.Duplex {
 	return conn.Half
 }
 
-// Addr implements flag.Value.
+// Addr is an I²C slave address. Addr implements the flag.Value interface.
 type Addr uint16
 
-// Set sets the Addr to a value respresented by the string s. Values maybe in
+// Set sets the Addr to a value represented by the string s. Values maybe in
 // decimal or hexadecimal form.
 func (a *Addr) Set(s string) error {
 	u, err := strconv.ParseUint(s, 0, 16)
 	if err != nil {
+		return errI2CSetError
+	}
+	// Allow for 10 bit i2c addresses.
+	if u > 0x07ff {
 		return errI2CSetError
 	}
 	*a = Addr(u)

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -19,6 +19,7 @@
 package i2c
 
 import (
+	"errors"
 	"io"
 	"strconv"
 
@@ -109,6 +110,23 @@ func (d *Dev) Duplex() conn.Duplex {
 	return conn.Half
 }
 
-//
+// Addr implements flag.Value.
+type Addr uint16
+
+// Set sets the Addr to a value respresented by the string s. Values maybe in
+// decimal or hexadecimal form.
+func (a *Addr) Set(s string) error {
+	u, err := strconv.ParseUint(s, 0, strconv.IntSize)
+	if err != nil {
+		return errI2CSetError
+	}
+	if u > 0xffff {
+		return errI2CSetError
+	}
+	*a = Addr(u)
+	return nil
+}
+
+var errI2CSetError = errors.New("invalid i2c address")
 
 var _ conn.Conn = &Dev{}

--- a/conn/i2c/i2c_test.go
+++ b/conn/i2c/i2c_test.go
@@ -114,7 +114,7 @@ func TestAddr_Set(t *testing.T) {
 		{"0x18", 0x18, nil},
 		{"24", 24, nil},
 		{"0x7ff", 2047, nil},
-		{"65536", 0, errI2CSetError},
+		{"0x800", 0, errI2CSetError},
 		{"-1", 0, errI2CSetError},
 	}
 

--- a/conn/i2c/i2c_test.go
+++ b/conn/i2c/i2c_test.go
@@ -104,3 +104,30 @@ func (f *fakeBus) SetSpeed(freq physic.Frequency) error {
 	f.freq = freq
 	return f.err
 }
+
+func TestAddr_Set(t *testing.T) {
+
+	tests := []struct {
+		str  string
+		want Addr
+		err  error
+	}{
+		{"0x18", 0x18, nil},
+		{"24", 24, nil},
+		{"65535", 65535, nil},
+		{"65536", 0, errI2CSetError},
+		{"-1", 0, errI2CSetError},
+	}
+
+	for _, tt := range tests {
+		var a Addr
+		// fmt.Println(tt)
+		if err := a.Set(tt.str); err != tt.err {
+			t.Errorf("i2cAddr.Set(%s) error %v", tt.str, err)
+		}
+		if tt.err == nil && a != tt.want {
+			t.Errorf("i2cAddr.Set(%s) expected %d but got %d", tt.str, tt.want, a)
+		}
+	}
+
+}

--- a/conn/i2c/i2c_test.go
+++ b/conn/i2c/i2c_test.go
@@ -113,8 +113,8 @@ func TestAddr_Set(t *testing.T) {
 	}{
 		{"0x18", 0x18, nil},
 		{"24", 24, nil},
-		{"0x7ff", 2047, nil},
-		{"0x800", 0, errI2CSetError},
+		{"0x3ff", 0x3ff, nil},
+		{"0x400", 0, errI2CSetError},
 		{"-1", 0, errI2CSetError},
 	}
 

--- a/conn/i2c/i2c_test.go
+++ b/conn/i2c/i2c_test.go
@@ -106,7 +106,6 @@ func (f *fakeBus) SetSpeed(freq physic.Frequency) error {
 }
 
 func TestAddr_Set(t *testing.T) {
-
 	tests := []struct {
 		str  string
 		want Addr
@@ -114,14 +113,13 @@ func TestAddr_Set(t *testing.T) {
 	}{
 		{"0x18", 0x18, nil},
 		{"24", 24, nil},
-		{"65535", 65535, nil},
+		{"0x7ff", 2047, nil},
 		{"65536", 0, errI2CSetError},
 		{"-1", 0, errI2CSetError},
 	}
 
 	for _, tt := range tests {
 		var a Addr
-		// fmt.Println(tt)
 		if err := a.Set(tt.str); err != tt.err {
 			t.Errorf("i2cAddr.Set(%s) error %v", tt.str, err)
 		}
@@ -129,5 +127,4 @@ func TestAddr_Set(t *testing.T) {
 			t.Errorf("i2cAddr.Set(%s) expected %d but got %d", tt.str, tt.want, a)
 		}
 	}
-
 }


### PR DESCRIPTION
This is adds a new type i2c.Addr and Set methods that implement the flag.Value interface as a convenience for device maintainers.

Add i2c.Addr
Add i2c.Addr Set()
Add Tests.

helps with #360 