### PR TITLE
fs: add new epoll loop to fix issue 323

### DIFF
--- a/host/fs/fs.go
+++ b/host/fs/fs.go
@@ -16,10 +16,10 @@ import (
 
 // Ioctler is a file handle that supports ioctl calls.
 type Ioctler interface {
-	// Ioctl sends a linux ioctl on the file handle. op is effectively a uint32.
+	// Ioctl sends a linux ioctl on the file handle.
 	//
-	// The op is expected to be encoded in the format on x64. ARM happens to
-	// share the same format.
+	// op is effectively an uint32. op is expected to be encoded in the format on
+	// x64. ARM happens to share the same format.
 	Ioctl(op uint, data uintptr) error
 }
 

--- a/host/fs/fs_linux.go
+++ b/host/fs/fs_linux.go
@@ -5,9 +5,13 @@
 package fs
 
 import (
+	"errors"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
+	"time"
 )
 
 const isLinux = true
@@ -114,3 +118,272 @@ func (e *event) wait(timeoutms int) (int, error) {
 	// http://man7.org/linux/man-pages/man2/epoll_wait.2.html
 	return syscall.EpollWait(e.epollFd, e.event[:], timeoutms)
 }
+
+//
+
+// eventsListener listens for events for multiple files as a single system call.
+//
+// One OS thread is needed for all the events. This is more efficient on single
+// core system.
+type eventsListener struct {
+	wg sync.WaitGroup
+
+	mu      sync.Mutex
+	closing bool
+	// file descriptor of the epoll handle itself.
+	epollFd int
+	// pipes to wake up the loop()
+	r, w *os.File
+	// mapping of file descriptors to wait on with their corresponding channels.
+	fds    map[int32]chan<- time.Time
+	wakeUp <-chan time.Time
+}
+
+// init must be called on a fresh instance.
+func (e *eventsListener) init() error {
+	e.mu.Lock()
+	if e.epollFd != 0 {
+		// Was already initialized.
+		e.mu.Unlock()
+		return nil
+	}
+	e.closing = false
+	var err error
+	e.epollFd, err = syscall.EpollCreate(1)
+	if err != nil {
+		return err
+	}
+	e.r, e.w, err = os.Pipe()
+	e.fds = map[int32]chan<- time.Time{}
+	// Only need epollIN. epollPRI has no effect on pipes.
+	const flags = epollET | epollIN
+	if err := e.addFdInner(e.r.Fd(), flags); err != nil {
+		return err
+	}
+	wakeUp := make(chan time.Time)
+	e.fds[int32(e.r.Fd())] = wakeUp
+	e.wakeUp = wakeUp
+	// The mutex is still held after this function exits, it's loop() that will
+	// release the mutex.
+	//
+	// This forces loop() to be started before addFd() can be called by users.
+	e.wg.Add(1)
+	go e.loop()
+	return nil
+}
+
+// stopLoop releases the epoll resource and terminates the polling loop.
+//
+// This is used in unit tests only.
+func (e *eventsListener) stopLoop() error {
+	e.mu.Lock()
+	if e.epollFd == 0 {
+		// Was already closed.
+		e.mu.Unlock()
+		return nil
+	}
+	if len(e.fds) != 1 {
+		// Disallow closing if there is any listener, as wakeUpLoop() could
+		// deadlock otherwise.
+		e.mu.Unlock()
+		return errors.New("cannot stop loop() while there's an active listener")
+	}
+	e.closing = true
+	e.mu.Unlock()
+	// Wake up the poller so it notices it should quit.
+	e.wakeUpLoop(nil)
+	// It is important to wait for the loop() function to exit, as EpollWait()
+	// will not return on a closed file handle.
+	e.wg.Wait()
+	e.mu.Lock()
+	_ = e.w.Close()
+	e.w = nil
+	_ = e.r.Close()
+	e.r = nil
+	err := syscall.Close(e.epollFd)
+	e.epollFd = 0
+	e.mu.Unlock()
+	return err
+}
+
+// loop is the main event loop.
+func (e *eventsListener) loop() {
+	defer e.wg.Done()
+	var events []syscall.EpollEvent
+	type lookup struct {
+		c     chan<- time.Time
+		event epollEvent
+	}
+	var lookups []lookup
+	for first := true; ; {
+		if !first {
+			e.mu.Lock()
+		}
+		if len(events) < len(e.fds) {
+			events = make([]syscall.EpollEvent, len(e.fds))
+		}
+		closing := e.closing
+		e.mu.Unlock()
+		first = false
+
+		if closing {
+			// We're done.
+			return
+		}
+		if len(events) == 0 {
+			panic("internal error: there's should be at least one pipe")
+		}
+
+		// http://man7.org/linux/man-pages/man2/epoll_wait.2.html
+		n, err := syscall.EpollWait(e.epollFd, events, -1)
+		if n <= 0 {
+			// -1 if an error occurred (EBADF, EFAULT, EINVAL) or the call was
+			// interrupted by a signal (EINTR).
+			// 0 is the timeout occurred. In this case there's no timeout specified.
+			// Still handle this explicitly in case a timeout could be triggered by
+			// external events, like system sleep.
+			continue
+		}
+		if err != nil {
+			// TODO(maruel): It'd be nice to be able to surface this.
+			// This may cause a busy loop. Hopefully the user will notice and will
+			// fix their code.
+			// This can happen when removeFd() is called, in this case silently
+			// ignore the error.
+			continue
+		}
+
+		now := time.Now()
+		// Create a look up table with the lock, so that then the channel can be
+		// pushed to without the lock.
+		if cap(lookups) < n {
+			lookups = make([]lookup, 0, n)
+		} else {
+			lookups = lookups[:0]
+		}
+
+		e.mu.Lock()
+		for _, ev := range events[:n] {
+			ep := epollEvent(ev.Events)
+			// Skip over file descriptors that are not present.
+			c, ok := e.fds[ev.Fd]
+			if !ok {
+				// That's a race condition where the file descriptor was removed by
+				// removeFd() but it still triggered. Ignore this event.
+				continue
+			}
+			// Look at the event to determine if it's worth sending a pulse. It's
+			// maybe not worth it.
+			if ep&epollERR != 0 {
+				// TODO(maruel): We should stop listening to this file descriptor.
+				// Same for epollHUP.
+			}
+			// pipe and sockets trigger epollIN and epollOUT, but GPIO sysfs
+			// triggers epollPRI.
+			if ep&(epollPRI|epollIN|epollOUT) != 0 {
+				lookups = append(lookups, lookup{c: c, event: ep})
+			}
+		}
+		e.mu.Unlock()
+
+		// Once the lock is released, send the timestamps.
+		for _, t := range lookups {
+			t.c <- now
+		}
+	}
+}
+
+// addFd starts listening to events generated by file descriptor |fd|.
+//
+// fd is the OS file descriptor. In practice, it must fit a int32 value. It
+// works on pipes, sockets and sysfs objects like GPIO but not on standard
+// files.
+//
+// c is the channel to send events to. Unbuffered channel will block the event
+// loop, which may mean lost events, especially if multiple files are listened
+// to simultaneously.
+//
+// flags is the events to listen to. No need to specify epollERR and epollHUP,
+// they are sent anyway.
+//
+// addFd lazy initializes eventsListener if it was not initialized yet.
+//
+// It can fail due to various reasons, a few are:
+//   ENOSPC: /proc/sys/fs/epoll/max_user_watches limit was exceeded
+//   ENOMEM: No memory available
+//   EPERM: fd is a regular file or directory
+func (e *eventsListener) addFd(fd uintptr, c chan<- time.Time, flags epollEvent) error {
+	if c == nil {
+		return errors.New("fd: addFd requires a valid channel")
+	}
+	if err := e.init(); err != nil {
+		return err
+	}
+	if err := e.addFdInner(fd, flags); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	e.fds[int32(fd)] = c
+	e.mu.Unlock()
+	// Wake up the poller so it notices there's one new file.
+	e.wakeUpLoop(nil)
+	return nil
+}
+
+func (e *eventsListener) addFdInner(fd uintptr, flags epollEvent) error {
+	ev := syscall.EpollEvent{Events: uint32(flags), Fd: int32(fd)}
+	return syscall.EpollCtl(e.epollFd, epollCTLAdd, int(fd), &ev)
+}
+
+// removeFd stop listening to events on this file descriptor.
+func (e *eventsListener) removeFd(fd uintptr) error {
+	if err := syscall.EpollCtl(e.epollFd, epollCTLDel, int(fd), nil); err != nil {
+		return err
+	}
+	e.mu.Lock()
+	delete(e.fds, int32(fd))
+	e.mu.Unlock()
+	// Wake up the poller so it notices there's one less file.
+	e.wakeUpLoop(nil)
+	return nil
+}
+
+// wakeUpLoop wakes up the poller and waits for it.
+//
+// Must not be called with the lock held.
+func (e *eventsListener) wakeUpLoop(c <-chan time.Time) time.Time {
+	e.mu.Lock()
+	running := e.epollFd != 0
+	e.mu.Unlock()
+	if !running {
+		// The loop is not running, nothing to wake up.
+		return time.Now()
+	}
+	// TODO(maruel): Figure out a way to wake up that doesn't require emptying.
+	var b [1]byte
+	_, _ = e.w.Write(b[:])
+	var t time.Time
+	if c != nil {
+		// To prevent deadlock, also empty c.
+		for {
+			select {
+			case <-c:
+			case t = <-e.wakeUp:
+				goto out
+			}
+		}
+	out:
+	} else {
+		t = <-e.wakeUp
+	}
+	// Don't forget to empty the pipe. Sadly, this will wake up the loop a second
+	// time.
+	_, _ = e.r.Read(b[:])
+	return t
+}
+
+// events is the global events listener.
+//
+// It uses a single global goroutine lazily initialized to call
+// syscall.EpollWait() to listen to many file descriptors at once.
+var events eventsListener

--- a/host/fs/fs_linux_test.go
+++ b/host/fs/fs_linux_test.go
@@ -5,7 +5,11 @@
 package fs
 
 import (
+	"io/ioutil"
+	"net"
+	"os"
 	"testing"
+	"time"
 )
 
 func TestEpollEvent_String(t *testing.T) {
@@ -17,5 +21,209 @@ func TestEpollEvent_String(t *testing.T) {
 	}
 	if s := epollEvent(0).String(); s != "0" {
 		t.Fatal(s)
+	}
+}
+
+func TestAddFd_Zero(t *testing.T) {
+	// We assume this is a bad file descriptor.
+	ev, cancelEv := getListener(t)
+	defer cancelEv()
+
+	const flags = epollET | epollPRI
+	if err := ev.addFd(0xFFFFFFFF, make(chan time.Time), flags); err == nil || err.Error() != "bad file descriptor" {
+		t.Fatal("expected failure", err)
+	}
+}
+
+func TestAddFd_File(t *testing.T) {
+	// listen cannot listen to a file.
+	ev, cancelEv := getListener(t)
+	defer cancelEv()
+
+	f, err := ioutil.TempFile("", "periph_fs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.Remove(f.Name()); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	const flags = epollET | epollPRI
+	if err := ev.addFd(f.Fd(), make(chan time.Time), flags); err == nil || err.Error() != "operation not permitted" {
+		t.Fatal("expected failure", err)
+	}
+}
+
+func TestListen_Pipe(t *testing.T) {
+	start := time.Now()
+	ev, cancelEv := getListener(t)
+	defer cancelEv()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := make(chan time.Time)
+	// Pipes do not support epollPRI, so use epollIN instead.
+	const flags = epollET | epollIN
+	if err := ev.addFd(r.Fd(), c, flags); err != nil {
+		t.Fatal(err)
+	}
+
+	// Produce a single event.
+	if _, err := w.Write([]byte("foo")); err != nil {
+		t.Fatal(err)
+	}
+	expectChan(t, c, start)
+	notExpectChan(t, c, "should have produced a single event")
+
+	// Produce one or two events.
+	if _, err := w.Write([]byte("bar")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("baz")); err != nil {
+		t.Fatal(err)
+	}
+	expectChan(t, c, start)
+	// It's a race condition between EpollWait() and reading back from the
+	// channel.
+	select {
+	case <-c:
+	default:
+	}
+
+	if err := ev.removeFd(r.Fd()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestListen_Socket(t *testing.T) {
+	start := time.Now()
+	ev, _ := getListener(t)
+
+	ln, err := net.ListenTCP("tcp4", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := ln.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	conn, err := net.DialTCP("tcp4", nil, ln.Addr().(*net.TCPAddr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	recv, err := ln.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := recv.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	f, err := recv.(*net.TCPConn).File()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This channel needs to be buffered since there's going to be an even
+	// immediately triggered.
+	c := make(chan time.Time, 1)
+	// TODO(maruel): Sockets do support epollPRI on out-of-band data. This would
+	// make this test a bit more similar to testing a GPIO sysfs file descriptor.
+	const flags = epollET | epollIN
+	if err := ev.addFd(f.Fd(), c, flags); err != nil {
+		t.Fatal(err)
+	}
+	notExpectChan(t, c, "starting should not produce an event")
+
+	// Produce one or two events.
+	// It's a race condition between EpollWait() and reading back from the
+	// channel.
+	if _, err := conn.Write([]byte("bar\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := conn.Write([]byte("baz\n")); err != nil {
+		t.Fatal(err)
+	}
+	expectChan(t, c, start)
+	// It's a race condition between EpollWait() and reading back from the
+	// channel.
+	select {
+	case <-c:
+	default:
+	}
+
+	// Empty the buffer.
+	var buf [16]byte
+	expected := "bar\nbaz\n"
+	if n, err := recv.Read(buf[:]); n != len(expected) || err != nil {
+		t.Fatal(n, err)
+	}
+	if s := string(buf[:len(expected)]); s != expected {
+		t.Fatal(s)
+	}
+
+	// Produce one event.
+	if _, err := conn.Write([]byte("foo\n")); err != nil {
+		t.Fatal(err)
+	}
+	expectChan(t, c, start)
+	notExpectChan(t, c, "should have produced a single event")
+
+	if err := ev.removeFd(f.Fd()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestWakeUpLoop(t *testing.T) {
+	// Make sure it doesn't hang when the loop is not running.
+	ev := &eventsListener{}
+	ev.wakeUpLoop(nil)
+}
+
+//
+
+// getListener returns a preinitialized eventsListenenr
+func getListener(t *testing.T) (*eventsListener, func()) {
+	ev := &eventsListener{}
+	if err := ev.init(); err != nil {
+		t.Fatal(err)
+	}
+	return ev, func() {
+		if err := ev.stopLoop(); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func expectChan(t *testing.T, c <-chan time.Time, start time.Time) {
+	select {
+	case v := <-c:
+		if v.Before(start) {
+			t.Fatal("received an timestamp that was too early", v, start)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out after 5 seconds, waiting for an event")
+	}
+}
+
+func notExpectChan(t *testing.T, c <-chan time.Time, errmsg string) {
+	select {
+	case <-c:
+		t.Fatal(errmsg)
+	default:
 	}
 }

--- a/host/fs/fs_other.go
+++ b/host/fs/fs_other.go
@@ -23,3 +23,11 @@ func (e *event) makeEvent(f uintptr) error {
 func (e *event) wait(timeoutms int) (int, error) {
 	return 0, errors.New("fs: unreachable code")
 }
+
+type eventsListener struct {
+}
+
+// events is the global events listener.
+//
+// It is not used outside linux.
+var events eventsListener


### PR DESCRIPTION
The new epoll loop has the following properties:
- It uses a single blocking OS thread, independent of the number of
  edges watched.
- Notes the timestamp at which each event fires.

Includes unit tests that are testing on OS pipes and sockets, as we
can't assume there's GPIO sysfs handles available (e.g. travis). This
increases code coverage to 70% on linux.

Small doc update to Ioctler.

No externally visible change yet.