### PR TITLE
host/fs: arm64 EpollCreate

### DIFF
--- a/host/fs/fs_linux.go
+++ b/host/fs/fs_linux.go
@@ -99,8 +99,16 @@ type event struct {
 // syscall.EpollCreate: http://man7.org/linux/man-pages/man2/epoll_create.2.html
 // syscall.EpollCtl: http://man7.org/linux/man-pages/man2/epoll_ctl.2.html
 func (e *event) makeEvent(fd uintptr) error {
-	epollFd, err := syscall.EpollCreate1(0)
-	if err != nil {
+	epollFd, err := syscall.EpollCreate(1)
+	switch {
+	case err == nil:
+		break
+	case err.Error() == "function not implemented":
+		// Some arch (arm64) do not implement EpollCreate()
+		if epollFd, err = syscall.EpollCreate1(0); err != nil {
+			return err
+		}
+	default:
 		return err
 	}
 	e.epollFd = epollFd
@@ -149,8 +157,16 @@ func (e *eventsListener) init() error {
 	}
 	e.closing = false
 	var err error
-	e.epollFd, err = syscall.EpollCreate1(0)
-	if err != nil {
+	e.epollFd, err = syscall.EpollCreate(1)
+	switch {
+	case err == nil:
+		break
+	case err.Error() == "function not implemented":
+		// Some arch (arm64) do not implement EpollCreate()
+		if e.epollFd, err = syscall.EpollCreate1(0); err != nil {
+			return err
+		}
+	default:
 		return err
 	}
 	e.r, e.w, err = os.Pipe()

--- a/host/fs/fs_linux.go
+++ b/host/fs/fs_linux.go
@@ -104,7 +104,7 @@ func (e *event) makeEvent(fd uintptr) error {
 	case err == nil:
 		break
 	case err.Error() == "function not implemented":
-		// Some arch (arm64) do not implement EpollCreate()
+		// Some arch (arm64) do not implement EpollCreate().
 		if epollFd, err = syscall.EpollCreate1(0); err != nil {
 			return err
 		}
@@ -162,7 +162,7 @@ func (e *eventsListener) init() error {
 	case err == nil:
 		break
 	case err.Error() == "function not implemented":
-		// Some arch (arm64) do not implement EpollCreate()
+		// Some arch (arm64) do not implement EpollCreate().
 		if e.epollFd, err = syscall.EpollCreate1(0); err != nil {
 			return err
 		}

--- a/host/fs/fs_linux.go
+++ b/host/fs/fs_linux.go
@@ -99,7 +99,7 @@ type event struct {
 // syscall.EpollCreate: http://man7.org/linux/man-pages/man2/epoll_create.2.html
 // syscall.EpollCtl: http://man7.org/linux/man-pages/man2/epoll_ctl.2.html
 func (e *event) makeEvent(fd uintptr) error {
-	epollFd, err := syscall.EpollCreate(1)
+	epollFd, err := syscall.EpollCreate1(0)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (e *eventsListener) init() error {
 	}
 	e.closing = false
 	var err error
-	e.epollFd, err = syscall.EpollCreate(1)
+	e.epollFd, err = syscall.EpollCreate1(0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds syscall.EpollCreate1(0) to use if syscall.EpollCreate(1) fails with "function not implemented."

Should have identical behavior on systems that support syscall.EpollCreate(). Acceptable extra overhead on arm64 to use syscall.EpollCreate1(). If both are not supported the failure behavior is the same as before.

helps with #368