### PR TITLE
i2c: Add Stringer for i2c.Addr

### DIFF
--- a/conn/i2c/example_test.go
+++ b/conn/i2c/example_test.go
@@ -5,6 +5,7 @@
 package i2c_test
 
 import (
+	"flag"
 	"fmt"
 	"log"
 
@@ -56,4 +57,10 @@ func ExamplePins() {
 		fmt.Printf("SDA: %s", p.SDA())
 		fmt.Printf("SCL: %s", p.SCL())
 	}
+}
+
+func ExampleAddr_flag() {
+	var addr i2c.Addr
+	flag.Var(&addr, "addr", "i2c device address")
+	flag.Parse()
 }

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -125,6 +125,11 @@ func (a *Addr) Set(s string) error {
 	return nil
 }
 
+// String returns the i2c.Addr as a string formated in hex.
+func (a Addr) String() string {
+	return "0x" + strconv.FormatInt(int64(a), 16)
+}
+
 var errI2CSetError = errors.New("invalid i2c address")
 
 var _ conn.Conn = &Dev{}

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -125,7 +125,7 @@ func (a *Addr) Set(s string) error {
 	return nil
 }
 
-// String returns i2c.Addr as a string formated in hexadecimal.
+// String returns an i2c.Addr as a string formated in hexadecimal.
 func (a Addr) String() string {
 	return "0x" + strconv.FormatInt(int64(a), 16)
 }

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -125,7 +125,7 @@ func (a *Addr) Set(s string) error {
 	return nil
 }
 
-// String returns the i2c.Addr as a string formated in hex.
+// String returns s i2c.Addr as a string formated in hexadecimal.
 func (a Addr) String() string {
 	return "0x" + strconv.FormatInt(int64(a), 16)
 }

--- a/conn/i2c/i2c.go
+++ b/conn/i2c/i2c.go
@@ -125,7 +125,7 @@ func (a *Addr) Set(s string) error {
 	return nil
 }
 
-// String returns s i2c.Addr as a string formated in hexadecimal.
+// String returns i2c.Addr as a string formated in hexadecimal.
 func (a Addr) String() string {
 	return "0x" + strconv.FormatInt(int64(a), 16)
 }

--- a/conn/i2c/i2c_test.go
+++ b/conn/i2c/i2c_test.go
@@ -140,8 +140,7 @@ func TestAddr_String(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := tt.Addr.String()
-		if got != tt.want {
+		if got := tt.Addr.String(); got != tt.want {
 			t.Errorf("i2cAddr.String() expected %s but got %s", tt.want, got)
 		}
 	}

--- a/conn/i2c/i2c_test.go
+++ b/conn/i2c/i2c_test.go
@@ -128,3 +128,21 @@ func TestAddr_Set(t *testing.T) {
 		}
 	}
 }
+
+func TestAddr_String(t *testing.T) {
+	tests := []struct {
+		Addr Addr
+		want string
+	}{
+		{0x01, "0x1"},
+		{0x24, "0x24"},
+		{0x3ff, "0x3ff"},
+	}
+
+	for _, tt := range tests {
+		got := tt.Addr.String()
+		if got != tt.want {
+			t.Errorf("i2cAddr.String() expected %s but got %s", tt.want, got)
+		}
+	}
+}


### PR DESCRIPTION
Add Addr.String()
Add Flag example

i2c.Addr was missing String() to complete flag.Value interface.