### PR TITLE
physic: Improve Frequency rounding, add Period()

### DIFF
--- a/conn/gpio/gpiostream/gpiostream.go
+++ b/conn/gpio/gpiostream/gpiostream.go
@@ -60,7 +60,7 @@ func (b *BitStream) Duration() time.Duration {
 	if b.Freq == 0 {
 		return 0
 	}
-	return b.Freq.Duration() * time.Duration(len(b.Bits)*8)
+	return b.Freq.Period() * time.Duration(len(b.Bits)*8)
 }
 
 // GoString implements fmt.GoStringer.
@@ -102,7 +102,7 @@ func (e *EdgeStream) Duration() time.Duration {
 	for _, edge := range e.Edges {
 		t += int(edge)
 	}
-	return e.Freq.Duration() * time.Duration(t)
+	return e.Freq.Period() * time.Duration(t)
 }
 
 // Program is a loop of streams.

--- a/conn/physic/example_test.go
+++ b/conn/physic/example_test.go
@@ -289,9 +289,9 @@ func ExampleFrequency_flag() {
 	flag.Parse()
 }
 
-func ExampleFrequency_Duration() {
-	fmt.Println(physic.MilliHertz.Duration())
-	fmt.Println(physic.MegaHertz.Duration())
+func ExampleFrequency_Period() {
+	fmt.Println(physic.MilliHertz.Period())
+	fmt.Println(physic.MegaHertz.Period())
 	// Output:
 	// 16m40s
 	// 1µs
@@ -302,7 +302,7 @@ func ExamplePeriodToFrequency() {
 	fmt.Println(physic.PeriodToFrequency(time.Minute))
 	// Output:
 	// 1MHz
-	// 16.666mHz
+	// 16.667mHz
 }
 
 func ExampleMass() {

--- a/experimental/conn/gpio/gpioutil/polledge.go
+++ b/experimental/conn/gpio/gpioutil/polledge.go
@@ -32,7 +32,7 @@ type pollEdge struct {
 // freq must be above 0. A reasonable value is 20Hz reading. High rate
 // essentially means a busy loop.
 func PollEdge(p gpio.PinIO, freq physic.Frequency) gpio.PinIO {
-	return &pollEdge{PinIO: p, period: freq.Duration(), die: make(chan struct{}, 1)}
+	return &pollEdge{PinIO: p, period: freq.Period(), die: make(chan struct{}, 1)}
 }
 
 // In implements gpio.PinIO.

--- a/experimental/devices/ads1x15/ads1x15.go
+++ b/experimental/devices/ads1x15/ads1x15.go
@@ -424,7 +424,7 @@ func (p *analogPin) ReadContinuous() <-chan analog.Sample {
 	}
 	reading := make(chan analog.Sample, 16)
 	p.stop = make(chan struct{})
-	t := time.NewTicker(p.requestedFrequency.Duration())
+	t := time.NewTicker(p.requestedFrequency.Period())
 
 	go func(s <-chan struct{}) {
 		defer t.Stop()

--- a/experimental/devices/bitbang/i2c.go
+++ b/experimental/devices/bitbang/i2c.go
@@ -52,7 +52,7 @@ func New(clk gpio.PinIO, data gpio.PinIO, f physic.Frequency) (*I2C, error) {
 	i := &I2C{
 		scl:       clk,
 		sda:       data,
-		halfCycle: f.Duration() / 2,
+		halfCycle: f.Period() / 2,
 	}
 	return i, nil
 }
@@ -126,7 +126,7 @@ func (i *I2C) Tx(addr uint16, w, r []byte) error {
 func (i *I2C) SetSpeed(f physic.Frequency) error {
 	i.mu.Lock()
 	defer i.mu.Unlock()
-	i.halfCycle = f.Duration() / 2
+	i.halfCycle = f.Period() / 2
 	return nil
 }
 

--- a/experimental/devices/bitbang/spi.go
+++ b/experimental/devices/bitbang/spi.go
@@ -73,7 +73,7 @@ func (s *SPI) Connect(f physic.Frequency, mode spi.Mode, bits int) (spi.Conn, er
 	defer s.spiConn.mu.Unlock()
 	s.spiConn.freqDev = f
 	if s.spiConn.freqDev != 0 && (s.spiConn.freqPort == 0 || s.spiConn.freqDev < s.spiConn.freqPort) {
-		s.spiConn.halfCycle = f.Duration() / 2
+		s.spiConn.halfCycle = f.Period() / 2
 	}
 	s.spiConn.mode = mode
 	s.spiConn.bits = bits
@@ -101,7 +101,7 @@ func (s *SPI) LimitSpeed(f physic.Frequency) error {
 	defer s.spiConn.mu.Unlock()
 	s.spiConn.freqPort = f
 	if s.spiConn.freqDev == 0 || s.spiConn.freqPort < s.spiConn.freqDev {
-		s.spiConn.halfCycle = f.Duration() / 2
+		s.spiConn.halfCycle = f.Period() / 2
 	}
 	return nil
 }


### PR DESCRIPTION
- Improve rounding and add unit tests to confirm.
- Period() is the same function than Duration() but better describes what
  is returned.
- Fix support for negative value.
- Upgrade all call sites inside periph.
- Fix Frequency documentation that incorrectly stated it's an int32,
  it's in fact an int64.
- Duration() will be removed in v4.0.0 as part of issue #379.