### PR TITLE
cmd: use physic.Frequency as flag.Value

### DIFF
--- a/cmd/apa102/main.go
+++ b/cmd/apa102/main.go
@@ -119,7 +119,8 @@ func mainImpl() error {
 	intensity := flag.Int("l", int(apa102.DefaultOpts.Intensity), "light intensity [1-255]; 255 is full intensity")
 	temperature := flag.Int("t", int(apa102.DefaultOpts.Temperature), "light temperature in Kelvin [3500-7500]; 6500 is neutral")
 	globalPWM := flag.Bool("g", false, "disable the global PWM and perceptual mapping")
-	hz := flag.Int("hz", 0, "SPI port speed")
+	var hz physic.Frequency
+	flag.Var(&hz, "hz", "SPI port speed")
 	color := flag.String("color", "208020", "hex encoded color to show")
 	imgName := flag.String("img", "", "image to load")
 	lineMs := flag.Int("linems", 2, "number of ms to show each line of the image")
@@ -149,8 +150,8 @@ func mainImpl() error {
 		return err
 	}
 	defer s.Close()
-	if *hz != 0 {
-		if err := s.LimitSpeed(physic.Frequency(*hz) * physic.Hertz); err != nil {
+	if hz != 0 {
+		if err := s.LimitSpeed(hz); err != nil {
 			return err
 		}
 	}

--- a/cmd/bmxx80/main.go
+++ b/cmd/bmxx80/main.go
@@ -72,7 +72,8 @@ func mainImpl() error {
 	i2cID := flag.String("i2c", "", "I²C bus to use (default, uses the first I²C found)")
 	i2cAddr := flag.Uint("ia", 0x76, "I²C bus address to use; either 0x76 (BMx280, the default) or 0x77 (BMP180)")
 	spiID := flag.String("spi", "", "SPI port to use")
-	hz := flag.Int("hz", 0, "I²C bus/SPI port speed")
+	var hz physic.Frequency
+	flag.Var(&hz, "hz", "I²C bus/SPI port speed")
 	sample1x := flag.Bool("s1", false, "sample at 1x")
 	sample2x := flag.Bool("s2", false, "sample at 2x")
 	sample4x := flag.Bool("s4", false, "sample at 4x")
@@ -145,8 +146,8 @@ func mainImpl() error {
 			printPin("MISO", p.MISO())
 			printPin("CS", p.CS())
 		}
-		if *hz != 0 {
-			if err := s.LimitSpeed(physic.Frequency(*hz) * physic.Hertz); err != nil {
+		if hz != 0 {
+			if err := s.LimitSpeed(hz); err != nil {
 				return err
 			}
 		}
@@ -163,8 +164,8 @@ func mainImpl() error {
 			printPin("SCL", p.SCL())
 			printPin("SDA", p.SDA())
 		}
-		if *hz != 0 {
-			if err := i.SetSpeed(physic.Frequency(*hz) * physic.Hertz); err != nil {
+		if hz != 0 {
+			if err := i.SetSpeed(hz); err != nil {
 				return err
 			}
 		}

--- a/cmd/cap1xxx/main.go
+++ b/cmd/cap1xxx/main.go
@@ -28,7 +28,8 @@ import (
 func mainImpl() error {
 	i2cID := flag.String("i2c", "", "I²C bus to use")
 	i2cAddr := flag.Uint("ia", 0x29, "I²C bus address to use, Pimoroni's Drum Hat is 0x2c")
-	hz := flag.Int("hz", 0, "I²C bus/SPI port speed")
+	var hz physic.Frequency
+	flag.Var(&hz, "hz", "I²C bus/SPI port speed")
 	verbose := flag.Bool("v", false, "verbose mode")
 	alertPinName := flag.String("alert", "GPIO25", "Name of the alert/interrupt pin")
 	resetPinName := flag.String("reset", "GPIO21", "Name of the reset pin")
@@ -61,8 +62,8 @@ func mainImpl() error {
 		printPin("SDA", p.SDA())
 	}
 
-	if *hz != 0 {
-		if err := i2cBus.SetSpeed(physic.Frequency(*hz) * physic.Hertz); err != nil {
+	if hz != 0 {
+		if err := i2cBus.SetSpeed(hz); err != nil {
 			return fmt.Errorf("couldn't set the i2c bus speed - %s", err)
 		}
 	}

--- a/cmd/i2c-io/main.go
+++ b/cmd/i2c-io/main.go
@@ -26,7 +26,8 @@ func mainImpl() error {
 	// TODO(maruel): This is not generic enough.
 	write := flag.Bool("w", false, "write instead of reading")
 	reg := flag.Int("r", -1, "register to address")
-	hz := flag.Int("hz", 0, "I²C bus speed (may require root)")
+	var hz physic.Frequency
+	flag.Var(&hz, "hz", "I²C bus speed (may require root)")
 	l := flag.Int("l", 1, "length of data to read; ignored if -w is specified")
 	flag.Parse()
 	if !*verbose {
@@ -78,8 +79,8 @@ func mainImpl() error {
 	}
 	defer bus.Close()
 
-	if *hz != 0 {
-		if err := bus.SetSpeed(physic.Frequency(*hz) * physic.Hertz); err != nil {
+	if hz != 0 {
+		if err := bus.SetSpeed(hz); err != nil {
 			return err
 		}
 	}

--- a/cmd/lepton/main.go
+++ b/cmd/lepton/main.go
@@ -383,8 +383,10 @@ func grabFrame(dev *lepton.Dev, path string, meta bool) error {
 func mainImpl() error {
 	i2cID := flag.String("i2c", "", "I²C bus to use")
 	spiID := flag.String("spi", "", "SPI port to use")
-	i2cHz := flag.Int("i2chz", 0, "I²C bus speed")
-	spiHz := flag.Int("spihz", 0, "SPI port speed")
+	var i2cHz physic.Frequency
+	flag.Var(&i2cHz, "i2chz", "I²C bus speed")
+	var spiHz physic.Frequency
+	flag.Var(&spiHz, "spihz", "SPI port speed")
 
 	meta := flag.Bool("meta", false, "print metadata")
 	output := flag.String("o", "", "PNG file to save")
@@ -415,8 +417,8 @@ func mainImpl() error {
 		return err
 	}
 	defer spiPort.Close()
-	if *spiHz != 0 {
-		if err := spiPort.LimitSpeed(physic.Frequency(*spiHz) * physic.Hertz); err != nil {
+	if spiHz != 0 {
+		if err := spiPort.LimitSpeed(spiHz); err != nil {
 			return err
 		}
 	}
@@ -426,8 +428,8 @@ func mainImpl() error {
 		return err
 	}
 	defer i2cBus.Close()
-	if *i2cHz != 0 {
-		if err := i2cBus.SetSpeed(physic.Frequency(*i2cHz) * physic.Hertz); err != nil {
+	if i2cHz != 0 {
+		if err := i2cBus.SetSpeed(i2cHz); err != nil {
 			return err
 		}
 	}

--- a/cmd/spi-io/main.go
+++ b/cmd/spi-io/main.go
@@ -88,7 +88,8 @@ func runTx(s spi.Conn, args []string) error {
 
 func mainImpl() error {
 	spiID := flag.String("b", "", "SPI port to use")
-	hz := flag.Int("hz", 1000000, "SPI port speed")
+	hz := physic.MegaHertz
+	flag.Var(&hz, "hz", "SPI port speed")
 
 	nocs := flag.Bool("nocs", false, "do not assert the CS line")
 	half := flag.Bool("half", false, "half duplex mode, sharing MOSI and MISO")
@@ -127,7 +128,7 @@ func mainImpl() error {
 		return err
 	}
 	defer s.Close()
-	c, err := s.Connect(physic.Frequency(*hz)*physic.Hertz, m, *bits)
+	c, err := s.Connect(hz, m, *bits)
 	if err != nil {
 		return err
 	}

--- a/cmd/ssd1306/main.go
+++ b/cmd/ssd1306/main.go
@@ -131,7 +131,8 @@ func mainImpl() error {
 	i2cID := flag.String("i2c", "", "I²C bus to use")
 	spiID := flag.String("spi", "", "SPI port to use")
 	dcName := flag.String("dc", "", "DC pin to use in 4-wire SPI mode")
-	hz := flag.Int("hz", 0, "I²C bus/SPI port speed")
+	var hz physic.Frequency
+	flag.Var(&hz, "hz", "I²C bus/SPI port speed")
 
 	h := flag.Int("h", 64, "display height")
 	w := flag.Int("w", 128, "display width")
@@ -165,8 +166,8 @@ func mainImpl() error {
 			return err
 		}
 		defer c.Close()
-		if *hz != 0 {
-			if err := c.LimitSpeed(physic.Frequency(*hz) * physic.Hertz); err != nil {
+		if hz != 0 {
+			if err := c.LimitSpeed(hz); err != nil {
 				return err
 			}
 		}
@@ -188,8 +189,8 @@ func mainImpl() error {
 			return err
 		}
 		defer c.Close()
-		if *hz != 0 {
-			if err := c.SetSpeed(physic.Frequency(*hz) * physic.Hertz); err != nil {
+		if hz != 0 {
+			if err := c.SetSpeed(hz); err != nil {
 				return err
 			}
 		}

--- a/experimental/cmd/nrzled/main.go
+++ b/experimental/cmd/nrzled/main.go
@@ -125,7 +125,8 @@ func mainImpl() error {
 	spiID := flag.String("spi", "", "Use SPI MOSI implemntation")
 	clear := flag.Bool("clear", false, "Blank the lights on exit")
 	numPixels := flag.Int("n", nrzled.DefaultOpts.NumPixels, "number of pixels on the strip")
-	hz := flag.Int("s", int(nrzled.DefaultOpts.Freq/physic.Hertz), "speed in Hz")
+	hz := nrzled.DefaultOpts.Freq
+	flag.Var(&hz, "s", "speed in Hz")
 	channels := flag.Int("channels", nrzled.DefaultOpts.Channels, "number of color channels, use 4 for RGBW")
 	color := flag.String("color", "208020", "hex encoded color to show")
 	imgName := flag.String("img", "", "image to load")
@@ -179,7 +180,7 @@ func mainImpl() error {
 			}
 			opts := nrzled.DefaultOpts
 			opts.NumPixels = *numPixels
-			opts.Freq = physic.Frequency(*hz) * physic.Hertz
+			opts.Freq = hz
 			opts.Channels = *channels
 			if disp, err = nrzled.NewStream(s, &opts); err != nil {
 				return err


### PR DESCRIPTION
This permits the user to specify nicer value like '-hz 1MHz'.

This change is fully backward compatible, as 'naked' frequency is now
supported.