### PR TITLE
sysfs: switch GPIO to use context.Context based epoll wait

### DIFF
--- a/cmd/periph-smoketest/gpiosmoketest/gpiosmoketest.go
+++ b/cmd/periph-smoketest/gpiosmoketest/gpiosmoketest.go
@@ -239,7 +239,7 @@ func (s *SmokeTest) testEdgesBoth(p1, p2 gpio.PinIO) error {
 	}
 	time.Sleep(s.shortDelay)
 	if !<-s.expectNoEdge(p1) {
-		fmt.Printf("    warning: there should be no edge right after setting a pin\n")
+		return errors.New("spurious edge 1")
 	}
 	s.slowSleep()
 
@@ -340,12 +340,8 @@ func (s *SmokeTest) testWaitForEdge(p1, p2 gpio.PinIO) (err error) {
 	if d := time.Since(now); d < short {
 		return fmt.Errorf("wait returned too early after %s; < %s", d, short)
 	} else if d >= timeout {
-		//return fmt.Errorf("wait timed out after %s; >= %s", d, timeout)
-		fmt.Println("Known failure due to https://github.com/google/periph/issues/323")
-		return nil
+		return fmt.Errorf("wait timed out after %s", d)
 	}
-	return errors.New("unexpected success; https://github.com/google/periph/issues/323")
-	/* Need to comment out otherwise go vet will be unhappy.
 	s.slowSleep()
 
 	fmt.Printf("  Testing WaitForEdge+In\n")
@@ -385,7 +381,6 @@ func (s *SmokeTest) testWaitForEdge(p1, p2 gpio.PinIO) (err error) {
 		return fmt.Errorf("second wait timed out after %s; > %s", d, timeout)
 	}
 	return nil
-	*/
 }
 
 // testEdgesSide tests with gpio.RisingEdge or gpio.FallingEdge.

--- a/host/fs/fs.go
+++ b/host/fs/fs.go
@@ -82,6 +82,8 @@ type Event struct {
 // epoll_wait() call is running, so no edge is missed. Two edges will be
 // coallesced into one if the user mode process can't keep up. There's no
 // accumulation of edges.
+//
+// Deprecated: to be removed in v4.0.0.
 func (e *Event) MakeEvent(fd uintptr) error {
 	return e.event.makeEvent(fd)
 }

--- a/host/fs/fs_linux.go
+++ b/host/fs/fs_linux.go
@@ -82,6 +82,9 @@ func ioctl(f uintptr, op uint, arg uintptr) error {
 	return nil
 }
 
+// event listens for events for a single file thru events.
+//
+// Deprecated: to be removed in v4.0.0.
 type event struct {
 	event   [1]syscall.EpollEvent
 	epollFd int

--- a/host/sysfs/fs_linux.go
+++ b/host/sysfs/fs_linux.go
@@ -5,6 +5,7 @@
 package sysfs
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strconv"
@@ -312,6 +313,18 @@ func (e *eventsListener) wakeUpLoop(c <-chan time.Time) time.Time {
 	// time.
 	_, _ = e.r.Read(b[:])
 	return t
+}
+
+// listen wraps addFd() and removeFd(), and listens for edges on the file
+// descriptor fd.
+//
+// Returns an error if listening to the file descriptor failed.
+func (e *eventsListener) listen(ctx context.Context, fd uintptr, c chan<- time.Time) error {
+	if err := e.addFd(fd, c, epollET|epollPRI); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	return e.removeFd(fd)
 }
 
 // events is the global events listener.

--- a/host/sysfs/fs_other.go
+++ b/host/sysfs/fs_other.go
@@ -6,7 +6,17 @@
 
 package sysfs
 
+import (
+	"context"
+	"errors"
+	"time"
+)
+
 type eventsListener struct {
+}
+
+func (e *eventsListener) listen(ctx context.Context, fd uintptr, c chan<- time.Time) error {
+	return errors.New("not implemented")
 }
 
 // events is the global events listener.


### PR DESCRIPTION
- Fixes Pin.Halt(), In() and Out() to unblock any pending WaitForEdge().
- Enable all of gpiosmoketest.
- Handle spurious edges deterministically.

This fixes issue 323.


I want to do more extensive testing on it before committing. Having a burn in test would be nice, albeit it only need to not be worse than the current implementation, it doesn't necessarily need to be perfect.

Also, I find the code too complicated, so I need to figure out a way to simplify it.