### PR TITLE
as7262 add internal context.context

### DIFF
--- a/experimental/devices/as7262/as7262.go
+++ b/experimental/devices/as7262/as7262.go
@@ -243,8 +243,6 @@ func (d *Dev) Halt() error {
 		if !open {
 			return nil
 		}
-	case <-time.After(time.Second):
-		return errHaltTimeout
 	}
 	return nil
 }
@@ -555,7 +553,6 @@ var (
 	errPinTimeout     = errors.New("timeout waiting for interrupt signal on pin")
 	errHalted         = errors.New("received halt command")
 	errGainValue      = errors.New("invalid gain value")
-	errHaltTimeout    = errors.New("halt timeout, sensor may not have been started")
 )
 
 const (

--- a/experimental/devices/as7262/as7262.go
+++ b/experimental/devices/as7262/as7262.go
@@ -34,12 +34,14 @@ var DefaultOpts = Opts{
 // New opens a handle to an AS7262 sensor.
 func New(bus i2c.Bus, opts *Opts) (*Dev, error) {
 	// The nil or zero values for gain and interrupt are valid
+	c := make(chan struct{})
+	close(c)
 	return &Dev{
 		c:         &i2c.Dev{Bus: bus, Addr: 0x49},
 		gain:      opts.Gain,
 		interrupt: opts.InterruptPin,
 		cancel:    func() {},
-		done:      make(chan struct{}),
+		done:      c,
 	}, nil
 }
 

--- a/experimental/devices/as7262/as7262.go
+++ b/experimental/devices/as7262/as7262.go
@@ -238,14 +238,9 @@ func (d *Dev) Halt() error {
 	d.cancelMu.Lock()
 	defer d.cancelMu.Unlock()
 	d.cancel()
-	select {
 	// A receive can always proceed on a closed channel we can use that
 	// to signal that the running process has been canceled correctly.
-	case _, open := <-d.done:
-		if open {
-			return errors.New("not closed")
-		}
-	}
+	_, _ = <-d.done
 	return nil
 }
 
@@ -298,9 +293,7 @@ func (d *Dev) Gain(gain Gain) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	ctx, cancel := context.WithTimeout(context.Background(), sensorTimeout)
-	defer cancel()
-	if err := d.writeVirtualRegister(ctx, controlReg, uint8(gain)); err != nil {
+	if err := d.writeVirtualRegister(context.Background(), controlReg, uint8(gain)); err != nil {
 		return err
 	}
 	d.gain = gain

--- a/experimental/devices/as7262/as7262_test.go
+++ b/experimental/devices/as7262/as7262_test.go
@@ -354,7 +354,7 @@ func TestDev_pollStatus(t *testing.T) {
 			d := &Dev{
 				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
 				cancel: cancel,
-				done:   ctx.Done,
+				done:   make(chan struct{}),
 			}
 
 			if tt.halt != 0 {
@@ -454,7 +454,7 @@ func TestDev_writeVirtualRegister(t *testing.T) {
 			d := &Dev{
 				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
 				cancel: cancel,
-				done:   ctx.Done,
+				done:   make(chan struct{}),
 			}
 
 			if tt.halt != 0 {
@@ -592,7 +592,7 @@ func TestDev_readVirtualRegister(t *testing.T) {
 			d := &Dev{
 				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
 				cancel: cancel,
-				done:   ctx.Done,
+				done:   make(chan struct{}),
 			}
 
 			if tt.halt != 0 {
@@ -745,7 +745,7 @@ func TestDev_pollDataReady(t *testing.T) {
 			d := &Dev{
 				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
 				cancel: cancel,
-				done:   ctx.Done,
+				done:   make(chan struct{}),
 			}
 
 			if tt.halt != 0 {

--- a/experimental/devices/as7262/as7262_test.go
+++ b/experimental/devices/as7262/as7262_test.go
@@ -358,7 +358,11 @@ func TestDev_pollStatus(t *testing.T) {
 			}
 
 			if tt.halt != 0 {
-				go d.Halt()
+				go func() {
+					if err := d.Halt(); err != nil {
+						t.Errorf("Halt() expected nil but got %v", err)
+					}
+				}()
 			}
 
 			got := d.pollStatus(ctx, tt.dir)
@@ -458,7 +462,11 @@ func TestDev_writeVirtualRegister(t *testing.T) {
 			}
 
 			if tt.halt != 0 {
-				go d.Halt()
+				go func() {
+					if err := d.Halt(); err != nil {
+						t.Errorf("Halt() expected nil but got %v", err)
+					}
+				}()
 			}
 
 			got := d.writeVirtualRegister(ctx, 0x04, 0xFF)
@@ -596,7 +604,11 @@ func TestDev_readVirtualRegister(t *testing.T) {
 			}
 
 			if tt.halt != 0 {
-				go d.Halt()
+				go func() {
+					if err := d.Halt(); err != nil {
+						t.Errorf("Halt() expected nil but got %v", err)
+					}
+				}()
 			}
 
 			got := d.readVirtualRegister(ctx, 0x04, tt.data)
@@ -749,7 +761,11 @@ func TestDev_pollDataReady(t *testing.T) {
 			}
 
 			if tt.halt != 0 {
-				go d.Halt()
+				go func() {
+					if err := d.Halt(); err != nil {
+						t.Errorf("Halt() expected nil but got %v", err)
+					}
+				}()
 			}
 
 			got := d.pollDataReady(ctx)

--- a/experimental/devices/as7262/as7262_test.go
+++ b/experimental/devices/as7262/as7262_test.go
@@ -800,8 +800,8 @@ func TestNew(t *testing.T) {
 
 		// Halt with empty context.
 		err = d.Halt()
-		if err != nil {
-			t.Errorf("New Sensor halt wanted nil but got %v", err)
+		if err != errHaltTimeout {
+			t.Errorf("New Sensor halt wanted %v but got %v", errHaltTimeout, err)
 		}
 	}
 }

--- a/experimental/devices/as7262/as7262_test.go
+++ b/experimental/devices/as7262/as7262_test.go
@@ -17,7 +17,7 @@ import (
 	"periph.io/x/periph/conn/physic"
 )
 
-var defaultSensorTimeOut = time.Millisecond * 200
+var defaultSensorTimeOut = sensorTimeout
 
 func TestDev_Sense(t *testing.T) {
 

--- a/experimental/devices/as7262/as7262_test.go
+++ b/experimental/devices/as7262/as7262_test.go
@@ -5,6 +5,7 @@
 package as7262
 
 import (
+	"context"
 	"reflect"
 	"testing"
 	"time"
@@ -16,13 +17,11 @@ import (
 	"periph.io/x/periph/conn/physic"
 )
 
+var defaultSensorTimeOut = time.Millisecond * 200
+
 func TestDev_Sense(t *testing.T) {
 
 	type timefunc func(*Dev) func(time.Duration) <-chan time.Time
-
-	defer func() {
-		waitForSensor = time.After
-	}()
 
 	haltit := func(dev *Dev) func(time.Duration) <-chan time.Time {
 		return func(d time.Duration) <-chan time.Time {
@@ -35,7 +34,7 @@ func TestDev_Sense(t *testing.T) {
 		return func(d time.Duration) <-chan time.Time {
 			t := make(chan time.Time, 1)
 			t <- time.Now()
-			dev.timeout = time.Millisecond * 1
+			sensorTimeout = time.Millisecond * 1
 			return t
 		}
 	}
@@ -86,17 +85,6 @@ func TestDev_Sense(t *testing.T) {
 			waiter:   dontwait,
 			sendEdge: false,
 			wantErr:  errPinTimeout,
-			want:     Spectrum{},
-			tx:       sensorTestCaseInteruptValidRead,
-		},
-		{
-			name: "haltBeforeforEdge",
-			opts: Opts{
-				InterruptPin: intPin,
-			},
-			waiter:   dontwait,
-			sendEdge: false,
-			wantErr:  errHalted,
 			want:     Spectrum{},
 			tx:       sensorTestCaseInteruptValidRead,
 		},
@@ -169,39 +157,43 @@ func TestDev_Sense(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		bus := &i2ctest.Playback{
-			Ops:       tt.tx,
-			DontPanic: true,
-		}
-		d, _ := New(bus, &tt.opts)
+		t.Run(tt.name, func(t *testing.T) {
 
-		waitForSensor = tt.waiter(d)
+			defer func() {
+				// cleanup
+				waitForSensor = time.After
+				sensorTimeout = defaultSensorTimeOut
+			}()
 
-		if d.interrupt != nil && tt.sendEdge {
-			intPin.EdgesChan <- gpio.High
-		}
-		if tt.name == "haltBeforeforEdge" {
-			// Time must be less than senseTime.
-			time.AfterFunc(time.Millisecond, func() {
-				d.Halt()
-			})
-		}
-
-		got, err := d.Sense(physic.MilliAmpere*100, time.Millisecond*3)
-
-		if _, ok := tt.wantErr.(*IOError); ok {
-			if _, ok := err.(*IOError); !ok {
-				t.Errorf("expected IOError but %T", err)
+			bus := &i2ctest.Playback{
+				Ops:       tt.tx,
+				DontPanic: true,
 			}
-			if err.(*IOError).Op != tt.wantErr.(*IOError).Op {
-				t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, err.(*IOError).Op)
+
+			d, _ := New(bus, &tt.opts)
+
+			waitForSensor = tt.waiter(d)
+
+			if d.interrupt != nil && tt.sendEdge {
+				intPin.EdgesChan <- gpio.High
 			}
-		} else if err != tt.wantErr {
-			t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
-		}
-		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("Dev.Sense() = %v, want %v", got, tt.want)
-		}
+
+			got, err := d.Sense(physic.MilliAmpere*100, time.Millisecond*3)
+
+			if _, ok := tt.wantErr.(*IOError); ok {
+				if _, ok := err.(*IOError); !ok {
+					t.Errorf("expected IOError but %T", err)
+				}
+				if err.(*IOError).Op != tt.wantErr.(*IOError).Op {
+					t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, err.(*IOError).Op)
+				}
+			} else if err != tt.wantErr {
+				t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Dev.Sense() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -272,7 +264,7 @@ func TestDev_pollStatus(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{}},
 			},
 			dir:     reading,
-			timeout: time.Millisecond * 1,
+			timeout: time.Second,
 			wantErr: &IOError{"reading status register", nil},
 		},
 		{
@@ -290,8 +282,8 @@ func TestDev_pollStatus(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
 			},
 			dir:     reading,
-			timeout: time.Millisecond * 1000,
-			halt:    time.Nanosecond,
+			timeout: time.Second,
+			halt:    1,
 			wantErr: errHalted,
 		},
 		{
@@ -300,7 +292,7 @@ func TestDev_pollStatus(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x01}},
 			},
 			dir:     reading,
-			timeout: time.Millisecond * 1000,
+			timeout: time.Second,
 			wantErr: nil,
 		},
 		{
@@ -309,7 +301,7 @@ func TestDev_pollStatus(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
 			},
 			dir:     writing,
-			timeout: time.Millisecond * 1000,
+			timeout: time.Second,
 			wantErr: nil,
 		},
 		{
@@ -318,7 +310,7 @@ func TestDev_pollStatus(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
 			},
 			dir:     clearBuffer,
-			timeout: time.Millisecond * 1000,
+			timeout: time.Second,
 			wantErr: nil,
 		},
 		{
@@ -329,7 +321,7 @@ func TestDev_pollStatus(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
 			},
 			dir:     clearBuffer,
-			timeout: time.Millisecond * 1000,
+			timeout: time.Second,
 			wantErr: nil,
 		},
 		{
@@ -339,68 +331,48 @@ func TestDev_pollStatus(t *testing.T) {
 				{Addr: 0x49, W: []byte{readReg}, R: []byte{}},
 			},
 			dir:     clearBuffer,
-			timeout: time.Millisecond * 1000,
+			timeout: time.Second,
 			wantErr: &IOError{"clearing buffer", nil},
-		},
-		{
-			name: "retry1",
-			tx: []i2ctest.IO{
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x01}},
-			},
-			dir:     reading,
-			timeout: time.Millisecond * 100,
-			wantErr: nil,
-		},
-		{
-			name: "retrywithHalt",
-			tx: []i2ctest.IO{
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x01}},
-			},
-			dir:     reading,
-			timeout: time.Millisecond * 100,
-			halt:    time.Millisecond * 3,
-			wantErr: errHalted,
 		},
 	}
 	for _, tt := range tests {
-		bus := &i2ctest.Playback{
-			Ops:       tt.tx,
-			DontPanic: true,
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			bus := &i2ctest.Playback{
+				Ops:       tt.tx,
+				DontPanic: true,
+			}
 
-		d := &Dev{
-			c:       &i2c.Dev{Bus: bus, Addr: 0x49},
-			done:    make(chan struct{}, 1),
-			timeout: tt.timeout,
-		}
-		defer d.Halt()
-		if tt.halt > time.Nanosecond {
-			go func() {
-				time.Sleep(tt.halt)
-				d.Halt()
+			ctx, cancel := context.WithCancel(context.Background())
+
+			sensorTimeout = tt.timeout
+			defer func() {
+				// cleanup
+				sensorTimeout = defaultSensorTimeOut
+				cancel()
 			}()
-		} else if tt.halt != 0 {
-			d.Halt()
-			d.Halt()
-		}
 
-		got := d.pollStatus(tt.dir)
-		// t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
+			d := &Dev{
+				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
+				cancel: cancel,
+			}
 
-		if _, ok := tt.wantErr.(*IOError); ok {
-			if _, ok := got.(*IOError); !ok {
-				t.Errorf("expected IOError but %T", got)
+			if tt.halt != 0 {
+				d.Halt()
 			}
-			if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
-				t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+
+			got := d.pollStatus(ctx, tt.dir)
+
+			if _, ok := tt.wantErr.(*IOError); ok {
+				if _, ok := got.(*IOError); !ok {
+					t.Errorf("expected IOError but %T", got)
+				}
+				if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
+					t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+				}
+			} else if got != tt.wantErr {
+				t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
 			}
-		} else if got != tt.wantErr {
-			t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
-		}
+		})
 	}
 }
 
@@ -463,37 +435,42 @@ func TestDev_writeVirtualRegister(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		bus := &i2ctest.Playback{
-			Ops:       tt.tx,
-			DontPanic: true,
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			bus := &i2ctest.Playback{
+				Ops:       tt.tx,
+				DontPanic: true,
+			}
 
-		d := &Dev{
-			c:       &i2c.Dev{Bus: bus, Addr: 0x49},
-			done:    make(chan struct{}, 1),
-			timeout: tt.timeout,
-		}
-		defer d.Halt()
-		if tt.halt > time.Nanosecond {
-			go func() {
-				time.Sleep(tt.halt)
-				d.Halt()
+			ctx, cancel := context.WithCancel(context.Background())
+
+			sensorTimeout = tt.timeout
+			defer func() {
+				// cleanup
+				sensorTimeout = defaultSensorTimeOut
+				cancel()
 			}()
-		} else if tt.halt != 0 {
-			d.Halt()
-		}
 
-		got := d.writeVirtualRegister(0x04, 0xFF)
-		if _, ok := tt.wantErr.(*IOError); ok {
-			if _, ok := got.(*IOError); !ok {
-				t.Errorf("expected IOError but %T", got)
+			d := &Dev{
+				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
+				cancel: cancel,
 			}
-			if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
-				t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+
+			if tt.halt != 0 {
+				d.Halt()
 			}
-		} else if got != tt.wantErr {
-			t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
-		}
+
+			got := d.writeVirtualRegister(ctx, 0x04, 0xFF)
+			if _, ok := tt.wantErr.(*IOError); ok {
+				if _, ok := got.(*IOError); !ok {
+					t.Errorf("expected IOError but %T", got)
+				}
+				if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
+					t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+				}
+			} else if got != tt.wantErr {
+				t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
+			}
+		})
 	}
 }
 
@@ -512,10 +489,15 @@ func TestDev_readVirtualRegister(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:    "errHalted",
-			tx:      []i2ctest.IO{},
+			name: "errHalted",
+			tx: []i2ctest.IO{
+				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
+				{Addr: 0x49, W: []byte{writeReg, 0x04}, R: []byte{}},
+				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
+				{Addr: 0x49, W: []byte{readReg}, R: []byte{0x00}},
+			},
 			data:    []byte{0x00},
-			halt:    time.Nanosecond,
+			halt:    1,
 			timeout: time.Millisecond * 100,
 			wantErr: errHalted,
 		},
@@ -523,7 +505,6 @@ func TestDev_readVirtualRegister(t *testing.T) {
 			name: "errClearingBuffer",
 			tx: []i2ctest.IO{
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x01}},
-				// {Addr: 0x49, W: []byte{statusReg}, R: []byte{0x02}},
 			},
 			data:    []byte{0x00},
 			timeout: time.Millisecond * 100,
@@ -591,36 +572,42 @@ func TestDev_readVirtualRegister(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		bus := &i2ctest.Playback{
-			Ops:       tt.tx,
-			DontPanic: true,
-		}
-		d := &Dev{
-			c:       &i2c.Dev{Bus: bus, Addr: 0x49},
-			done:    make(chan struct{}, 1),
-			timeout: tt.timeout,
-		}
-		// defer d.Halt()
-		if tt.halt > time.Nanosecond {
-			go func() {
-				time.Sleep(tt.halt)
-				d.Halt()
-			}()
-		} else if tt.halt != 0 {
-			d.Halt()
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			bus := &i2ctest.Playback{
+				Ops:       tt.tx,
+				DontPanic: true,
+			}
 
-		got := d.readVirtualRegister(0x04, tt.data)
-		if _, ok := tt.wantErr.(*IOError); ok {
-			if _, ok := got.(*IOError); !ok {
-				t.Errorf("expected IOError but %T", got)
+			ctx, cancel := context.WithCancel(context.Background())
+
+			sensorTimeout = tt.timeout
+			defer func() {
+				// cleanup
+				sensorTimeout = defaultSensorTimeOut
+				cancel()
+			}()
+
+			d := &Dev{
+				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
+				cancel: cancel,
 			}
-			if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
-				t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+
+			if tt.halt != 0 {
+				d.Halt()
 			}
-		} else if got != tt.wantErr {
-			t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
-		}
+
+			got := d.readVirtualRegister(ctx, 0x04, tt.data)
+			if _, ok := tt.wantErr.(*IOError); ok {
+				if _, ok := got.(*IOError); !ok {
+					t.Errorf("expected IOError but %T", got)
+				}
+				if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
+					t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+				}
+			} else if got != tt.wantErr {
+				t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
+			}
+		})
 	}
 }
 
@@ -633,10 +620,15 @@ func TestDev_pollDataReady(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name:    "errHalted",
-			tx:      []i2ctest.IO{},
-			halt:    time.Nanosecond,
-			timeout: time.Millisecond * 100,
+			name: "errHalted",
+			tx: []i2ctest.IO{
+				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
+				{Addr: 0x49, W: []byte{writeReg, controlReg}, R: []byte{}},
+				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x01}},
+				{Addr: 0x49, W: []byte{readReg}, R: []byte{0x03}},
+			},
+			halt:    1,
+			timeout: time.Millisecond * 1000,
 			wantErr: errHalted,
 		},
 		{
@@ -644,7 +636,7 @@ func TestDev_pollDataReady(t *testing.T) {
 			tx: []i2ctest.IO{
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{}},
 			},
-			timeout: time.Millisecond * 100,
+			timeout: time.Millisecond * 1000,
 			wantErr: &IOError{"reading status register", nil},
 		},
 		{
@@ -653,7 +645,7 @@ func TestDev_pollDataReady(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
 				{Addr: 0x49, W: []byte{writeReg}, R: []byte{}},
 			},
-			timeout: time.Millisecond * 100,
+			timeout: time.Millisecond * 1000,
 			wantErr: &IOError{"setting virtual register", nil},
 		},
 		{
@@ -663,7 +655,7 @@ func TestDev_pollDataReady(t *testing.T) {
 				{Addr: 0x49, W: []byte{writeReg, controlReg}, R: []byte{}},
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x00}},
 			},
-			timeout: time.Millisecond * 100,
+			timeout: time.Millisecond * 1000,
 			wantErr: &IOError{"reading status register", nil},
 		},
 		{
@@ -674,7 +666,7 @@ func TestDev_pollDataReady(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x01}},
 				{Addr: 0x49, W: []byte{}, R: []byte{}},
 			},
-			timeout: time.Millisecond * 100,
+			timeout: time.Millisecond * 1000,
 			wantErr: &IOError{"reading virtual register", nil},
 		},
 		{
@@ -696,7 +688,7 @@ func TestDev_pollDataReady(t *testing.T) {
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x01}},
 				{Addr: 0x49, W: []byte{readReg}, R: []byte{0x03}},
 			},
-			timeout: time.Millisecond * 100,
+			timeout: time.Millisecond * 1000,
 			wantErr: nil,
 		},
 		{
@@ -732,37 +724,42 @@ func TestDev_pollDataReady(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		bus := &i2ctest.Playback{
-			Ops:       tt.tx,
-			DontPanic: true,
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			bus := &i2ctest.Playback{
+				Ops:       tt.tx,
+				DontPanic: true,
+			}
 
-		d := &Dev{
-			c:       &i2c.Dev{Bus: bus, Addr: 0x49},
-			done:    make(chan struct{}, 1),
-			timeout: tt.timeout,
-		}
-		defer d.Halt()
-		if tt.halt > time.Nanosecond {
-			go func() {
-				time.Sleep(tt.halt)
-				d.Halt()
+			ctx, cancel := context.WithCancel(context.Background())
+
+			sensorTimeout = tt.timeout
+			defer func() {
+				// cleanup
+				sensorTimeout = defaultSensorTimeOut
+				cancel()
 			}()
-		} else if tt.halt != 0 {
-			d.Halt()
-		}
 
-		got := d.pollDataReady()
-		if _, ok := tt.wantErr.(*IOError); ok {
-			if _, ok := got.(*IOError); !ok {
-				t.Errorf("expected IOError but %T", got)
+			d := &Dev{
+				c:      &i2c.Dev{Bus: bus, Addr: 0x49},
+				cancel: cancel,
 			}
-			if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
-				t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+
+			if tt.halt != 0 {
+				d.Halt()
 			}
-		} else if got != tt.wantErr {
-			t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
-		}
+
+			got := d.pollDataReady(ctx)
+			if _, ok := tt.wantErr.(*IOError); ok {
+				if _, ok := got.(*IOError); !ok {
+					t.Errorf("expected IOError but %T", got)
+				}
+				if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
+					t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+				}
+			} else if got != tt.wantErr {
+				t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
+			}
+		})
 	}
 }
 
@@ -812,23 +809,9 @@ func TestDev_Gain(t *testing.T) {
 			name: "errStatusIO",
 			tx: []i2ctest.IO{
 				{Addr: 0x49, W: []byte{statusReg}, R: []byte{}},
-				// {Addr: 0x49, W: []byte{writeReg}, R: []byte{}},
 			},
 			timeout: time.Millisecond * 100,
 			wantErr: &IOError{"reading status register", nil},
-		},
-		{
-			name: "errHalt",
-			tx: []i2ctest.IO{
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x03}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x03}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x03}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x03}},
-				{Addr: 0x49, W: []byte{statusReg}, R: []byte{0x03}},
-			},
-			halt:    true,
-			timeout: time.Millisecond * 100,
-			wantErr: errHalted,
 		},
 		{
 			name:    "errGainValue",
@@ -854,21 +837,19 @@ func TestDev_Gain(t *testing.T) {
 			DontPanic: true,
 		}
 		d, _ := New(bus, &DefaultOpts)
-		go func() {
-			time.Sleep(time.Millisecond * 1)
-			d.Halt()
-		}()
+
+		sensorTimeout = tt.timeout
 		got := d.Gain(tt.gain)
 
 		if _, ok := tt.wantErr.(*IOError); ok {
 			if _, ok := got.(*IOError); !ok {
-				t.Errorf("expected IOError but %T", got)
+				t.Errorf("%s: expected IOError but %T", tt.name, got)
 			}
 			if got.(*IOError).Op != tt.wantErr.(*IOError).Op {
-				t.Errorf("expected %s, but got %s", tt.wantErr.(*IOError).Op, got.(*IOError).Op)
+				t.Errorf("%s: expected %s, but got %s", tt.name, tt.wantErr.(*IOError).Op, got.(*IOError).Op)
 			}
 		} else if got != tt.wantErr {
-			t.Errorf("expected error: %v but got: %v", tt.wantErr, got)
+			t.Errorf("%s: expected error: %v but got: %v", tt.name, tt.wantErr, got)
 		}
 	}
 }
@@ -941,19 +922,19 @@ func TestIOError_Error(t *testing.T) {
 	}
 }
 
-func TestIntergration_AfterHalt(t *testing.T) {
-	bus := &i2ctest.Playback{
-		Ops:       sensorTestCaseValidRead,
-		DontPanic: true,
-	}
-	d, _ := New(bus, &DefaultOpts)
+// func TestIntergration_AfterHalt(t *testing.T) {
+// 	bus := &i2ctest.Playback{
+// 		Ops:       sensorTestCaseValidRead,
+// 		DontPanic: true,
+// 	}
+// 	d, _ := New(bus, &DefaultOpts)
 
-	d.Halt()
-	if _, err := d.Sense(physic.MilliAmpere*100, time.Millisecond*3); err == errHalted {
-		t.Errorf("got %v expected nil", errHalted)
-	}
-	d.Halt()
-	if err := d.Gain(G1x); err == errHalted {
-		t.Errorf("got %v expected nil", errHalted)
-	}
-}
+// 	d.Halt()
+// 	if _, err := d.Sense(physic.MilliAmpere*100, time.Millisecond*3); err == errHalted {
+// 		t.Errorf("got %v expected nil", errHalted)
+// 	}
+// 	d.Halt()
+// 	if err := d.Gain(G1x); err == errHalted {
+// 		t.Errorf("got %v expected nil", errHalted)
+// 	}
+// }

--- a/experimental/devices/as7262/as7262_test.go
+++ b/experimental/devices/as7262/as7262_test.go
@@ -17,7 +17,7 @@ import (
 	"periph.io/x/periph/conn/physic"
 )
 
-var defaultSensorTimeOut = sensorTimeout
+var defaultSensorTimeOut = time.Millisecond * 200
 
 func TestDev_Sense(t *testing.T) {
 
@@ -800,8 +800,8 @@ func TestNew(t *testing.T) {
 
 		// Halt with empty context.
 		err = d.Halt()
-		if err != errHaltTimeout {
-			t.Errorf("New Sensor halt wanted %v but got %v", errHaltTimeout, err)
+		if err != nil {
+			t.Errorf("New Sensor halt wanted nil but got %v", err)
 		}
 	}
 }


### PR DESCRIPTION
replaces some fragile time based tests with a with cancel context. No external api changes.