### PR TITLE
sysfs: fix a data race condition in events

### DIFF
--- a/host/sysfs/fs_linux_test.go
+++ b/host/sysfs/fs_linux_test.go
@@ -54,7 +54,7 @@ func TestAddFd_File(t *testing.T) {
 	}
 }
 
-func TestListen_Pipe(t *testing.T) {
+func TestManual_Listen_Pipe(t *testing.T) {
 	start := time.Now()
 	ev := getListener(t)
 
@@ -96,7 +96,7 @@ func TestListen_Pipe(t *testing.T) {
 	}
 }
 
-func TestListen_Socket(t *testing.T) {
+func TestManual_Listen_Socket(t *testing.T) {
 	start := time.Now()
 	ev := getListener(t)
 


### PR DESCRIPTION
It's not used yet. In practice the previous code would have worked
mostly fine, but it's triggering data race check with running tests with
-race, so it's necessary to have this fixed.
