### PR TITLE
mcp9808: Fix conversions between temperature and bits

### DIFF
--- a/experimental/devices/mcp9808/mcp9808.go
+++ b/experimental/devices/mcp9808/mcp9808.go
@@ -264,10 +264,10 @@ func (d *Dev) readTemperature() (physic.Temperature, uint8, error) {
 		return 0, 0, errReadTemperature
 	}
 	// Convert to physic.Temperature 0.0625°C per bit
-	t := physic.Temperature(tbits&0x0FFF) * 62500 * physic.MicroKelvin
+	t := physic.Temperature(tbits&0x0fff) * 62500 * physic.MicroKelvin
 	if tbits&0x1000 > 0 {
-		// Check for bit sign.
-		t = -t
+		// Check for sign bit.
+		t -= 256 * physic.Celsius
 	}
 	t += physic.ZeroCelsius
 	return t, uint8(tbits>>8) & 0xe0, nil
@@ -383,10 +383,10 @@ var (
 )
 
 func alertBitsToTemperature(b uint16) physic.Temperature {
-	b = (b >> 2) & 0x07FF
-	t := physic.Temperature(b&0x03FF) * 250 * physic.MilliKelvin
+	b = (b >> 2) & 0x07ff
+	t := physic.Temperature(b&0x03ff) * 250 * physic.MilliKelvin
 	if b&0x400 > 0 {
-		t = -t
+		t -= 256 * physic.Celsius
 	}
 	t += physic.ZeroCelsius
 	return t
@@ -403,13 +403,14 @@ func alertTemperatureToBits(t physic.Temperature) (uint16, error) {
 	// 0.25°C per bit.
 	t /= 250 * physic.MilliKelvin
 
-	var bits uint16
-	if t < 0 {
-		t = -t
-		bits |= 0x400
-	}
-	bits |= uint16(t)
-	bits = bits << 2
+	// We don't need to explicitly handle negative temperatures because both Go and the MCP9808
+	// store negative values using two's complement. We can rely on Go's implementation since
+	// we know that the bits of a negative value are already in two's complement, implying that
+	// the sign bit will already be set to 1 due to the range check. We need to be sure to mask
+	// off the 3 most significant bits after shifting though: they will all be set to 1 if the
+	// value is negative. Also mask off the 2 least significant bits. While not strictly necessary,
+	// the MCP9808 doesn't use them.
+	bits := (uint16(t) << 2) & 0x1ffc
 	return bits, nil
 }
 

--- a/experimental/devices/mcp9808/mcp9808.go
+++ b/experimental/devices/mcp9808/mcp9808.go
@@ -264,7 +264,7 @@ func (d *Dev) readTemperature() (physic.Temperature, uint8, error) {
 		return 0, 0, errReadTemperature
 	}
 	// Convert to physic.Temperature 0.0625°C per bit
-	t := physic.Temperature(tbits&0x0fff) * 62500 * physic.MicroKelvin
+	t := physic.Temperature(tbits&0x0FFF) * 62500 * physic.MicroKelvin
 	if tbits&0x1000 > 0 {
 		// Check for sign bit.
 		t -= 256 * physic.Celsius
@@ -383,8 +383,8 @@ var (
 )
 
 func alertBitsToTemperature(b uint16) physic.Temperature {
-	b = (b >> 2) & 0x07ff
-	t := physic.Temperature(b&0x03ff) * 250 * physic.MilliKelvin
+	b = (b >> 2) & 0x07FF
+	t := physic.Temperature(b&0x03FF) * 250 * physic.MilliKelvin
 	if b&0x400 > 0 {
 		t -= 256 * physic.Celsius
 	}


### PR DESCRIPTION
The datasheet (http://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf)
says that negative temperatures are stored in two's complement. See
page 22 for alert registers and pages 24-25 for the ambient temperature
register.

However, the code currently assumes negative values are stored in a
sign-and-magnitude representation. Fix this to handle two's complement
values correctly.

For register bits to temperature conversion this implementation follows
the datasheet, but the code in the datasheet isn't quite right -- it
should be `temp - 256` instead of `256 - temp` -- but the fact that the
256 figure is in Microchip's code backs up the idea stated in the text
that negative values are in two's complement. Others seem to agree that
this is correct: https://electronics.stackexchange.com/a/244826

For temperature to bits conversion this implementation relies on the
fact that Go also uses two's complement. I've added a long comment in
the code about this.