### PR TITLE
Fix typo

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,4 +1,4 @@
-# periph/cmd - read-to-use executables
+# periph/cmd - ready-to-use executables
 
 This directory contains directly usable tools installable via:
 


### PR DESCRIPTION
The site makes mention of ['ready-to-use'](https://periph.io/#tools).
