### PR TITLE
environment: migrate interface from physic.SenseEnv

### DIFF
--- a/conn/environment/doc.go
+++ b/conn/environment/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2019 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+// Package environment declares interfaces for environmental sensors.
+package environment

--- a/conn/environment/environment.go
+++ b/conn/environment/environment.go
@@ -1,0 +1,64 @@
+// Copyright 2018 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package environment
+
+import (
+	"context"
+	"time"
+
+	"periph.io/x/periph/conn"
+	"periph.io/x/periph/conn/physic"
+)
+
+// Weather represents measurements from an environmental sensor.
+type Weather struct {
+	Temperature physic.Temperature
+	Pressure    physic.Pressure
+	Humidity    physic.RelativeHumidity
+}
+
+// WeatherSample is a sample that occurred at the specified moment.
+//
+// It is used by SenseWeatherContinuous.
+type WeatherSample struct {
+	Weather
+	// T is the moment at which the sensing was initiated.
+	T time.Time
+	// Err is set if sensing failed. In this case it can be assumed that
+	// SenseWeatherContinuous() is aborting.
+	Err error
+}
+
+// SenseWeather represents an environmental weather sensor.
+type SenseWeather interface {
+	conn.Resource
+
+	// SenseWeather returns the value read from the sensor.
+	//
+	// Metrics in Weather unsupported by the sensor are not modified.
+	SenseWeather(w *Weather) error
+	// SenseWeatherContinuous sense continuously at the specified interval until
+	// the context is canceled.
+	//
+	// If the context passed in is already canceled, no measurement is done and
+	// nothing is sent to the channel.
+	//
+	// One measurement is done immediately upon call. The channel must be valid.
+	// It is up to the client to decide if the channel is buffered or not.
+	//
+	// In case of operation failure, sends an error with Err set and exits.
+	SenseWeatherContinuous(ctx context.Context, interval time.Duration, c chan<- WeatherSample)
+	// PrecisionWeather returns this sensor's precision.
+	//
+	// The w values are set to the number of bits that are significant for each
+	// items that this sensor can measure.
+	//
+	// Precision is not accuracy. The sensor may have absolute and relative
+	// errors in its measurement, that are likely well above the reported
+	// precision. Accuracy may be improved on some sensor by using oversampling,
+	// or doing oversampling in software. Refer to the sensor datasheet if
+	// available.
+	PrecisionWeather(w *Weather)
+}

--- a/conn/environment/example_test.go
+++ b/conn/environment/example_test.go
@@ -1,0 +1,157 @@
+// Copyright 2019 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
+package environment_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"periph.io/x/periph/conn/environment"
+	"periph.io/x/periph/conn/physic"
+	"periph.io/x/periph/host"
+)
+
+type fakeSensor struct {
+}
+
+func (f *fakeSensor) String() string {
+	return "fake"
+}
+
+func (f *fakeSensor) Halt() error {
+	return nil
+}
+
+func (f *fakeSensor) SenseWeather(w *environment.Weather) error {
+	w.Temperature = physic.ZeroCelsius + 23*physic.Celsius
+	w.Pressure = 101200 * physic.Pascal
+	w.Humidity = 540 * physic.MilliRH
+	return nil
+}
+
+func (f *fakeSensor) SenseWeatherContinuous(ctx context.Context, interval time.Duration, c chan<- environment.WeatherSample) {
+	c <- environment.WeatherSample{
+		T: time.Now(),
+		Weather: environment.Weather{
+			Temperature: physic.ZeroCelsius + 23*physic.Celsius,
+			Pressure:    101200 * physic.Pascal,
+			Humidity:    540 * physic.MilliRH,
+		},
+	}
+	c <- environment.WeatherSample{
+		T: time.Now(),
+		Weather: environment.Weather{
+			Temperature: physic.ZeroCelsius + 24*physic.Celsius,
+			Pressure:    101400 * physic.Pascal,
+			Humidity:    530 * physic.MilliRH,
+		},
+	}
+}
+
+func (f *fakeSensor) PrecisionWeather(w *environment.Weather) {
+	w.Temperature = 1 * physic.Celsius
+	w.Pressure = 100 * physic.Pascal
+	w.Humidity = 10 * physic.MilliRH
+}
+
+func ExampleWeather() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Get an handle to a weather sensing device.
+	var s environment.SenseWeather = &fakeSensor{}
+
+	// Print out the sensor precision.
+	var w environment.Weather
+	s.PrecisionWeather(&w)
+	fmt.Printf("Sensor precision:\n")
+	fmt.Printf("  Temperature: %gK\n", float64(w.Temperature)/float64(physic.Kelvin))
+	fmt.Printf("  Pressure:    %v\n", w.Pressure)
+	fmt.Printf("  Humidty:     %v\n", w.Humidity)
+	fmt.Printf("\n")
+
+	// Take one measure.
+	if err := s.SenseWeather(&w); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Sensor measurement:\n")
+	fmt.Printf("  Temperature: %v\n", w.Temperature)
+	fmt.Printf("  Pressure:    %v\n", w.Pressure)
+	fmt.Printf("  Humidty:     %v\n", w.Humidity)
+	// Output:
+	// Sensor precision:
+	//   Temperature: 1K
+	//   Pressure:    100Pa
+	//   Humidty:     1%rH
+	//
+	// Sensor measurement:
+	//   Temperature: 23°C
+	//   Pressure:    101.200kPa
+	//   Humidty:     54%rH
+}
+
+func ExampleWeatherSample() {
+	// Make sure periph is initialized.
+	if _, err := host.Init(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Get an handle to a weather sensing device.
+	var s environment.SenseWeather = &fakeSensor{}
+
+	// Measure at most for 2s.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	cw := make(chan environment.WeatherSample)
+	go func() {
+		s.SenseWeatherContinuous(ctx, time.Second, cw)
+		close(cw)
+	}()
+
+	// Terminate upon receiving an interrupt signal, like a Ctrl-C at the
+	// terminal prompt.
+	cs := make(chan os.Signal, 1)
+	signal.Notify(cs, os.Interrupt)
+	go func() {
+		<-cs
+		cancel()
+	}()
+
+	for {
+		select {
+		case w, ok := <-cw:
+			if !ok {
+				return
+			}
+			if w.Err != nil {
+				log.Fatal(w.Err)
+			}
+			fmt.Printf("Sensor measurement:\n")
+			fmt.Printf("  Temperature: %v\n", w.Temperature)
+			fmt.Printf("  Pressure:    %v\n", w.Pressure)
+			fmt.Printf("  Humidty:     %v\n", w.Humidity)
+		case <-ctx.Done():
+			// Wait for the goroutine to return.
+			_, _ = <-cw
+			return
+		}
+	}
+	// Output:
+	// Sensor measurement:
+	//   Temperature: 23°C
+	//   Pressure:    101.200kPa
+	//   Humidty:     54%rH
+	// Sensor measurement:
+	//   Temperature: 24°C
+	//   Pressure:    101.400kPa
+	//   Humidty:     53%rH
+}


### PR DESCRIPTION
- environment.SenseWeather replaces physic.SenseEnv in v4.
- Use Weather instead of Env. This is more precise.
- Use SenseWeather() instead of Sense(). The rationale for the rename is
  that we will add new SenseXX() functions, and a single device could
  sense multiple things (environment, orientation, etc) on the same Go
  object. Having all interfaces uses the generic verb 'Sense()' would
  cause conflict.
- Add examples but do not implement it yet.
- Make SenseWeatherContinous blocking (synchronous) and require a
  context. This is part of the larger context based operation in v4.

Package physic wasn't the right place to host this interface. Other
interfaces (like orientation) can be added to package environment.

No behavior change, only new interfaces.