### PR TITLE
bcm283x: present: check device tree on non-raspbian systems

### DIFF
--- a/host/bcm283x/gpio.go
+++ b/host/bcm283x/gpio.go
@@ -80,8 +80,11 @@ var (
 // Present returns true if running on a Broadcom bcm283x based CPU.
 func Present() bool {
 	if isArm {
-		hardware, ok := distro.CPUInfo()["Hardware"]
-		return ok && strings.HasPrefix(hardware, "BCM")
+		for _, line := range distro.DTCompatible() {
+			if strings.HasPrefix(line, "brcm,bcm") {
+				return true
+			}
+		}
 	}
 	return false
 }


### PR DESCRIPTION
This is required to use periph.io on https://gokrazy.org.

I don’t know whether the device-tree method also works on Raspbian. If so, would you like to use just the device-tree method everywhere, or do you want to go the more conservative fall-back approach I’m suggesting here?

Thanks,