### PR TITLE
rpi: obtain revision from device tree (for non-raspbian systems)

### DIFF
--- a/host/rpi/rpi.go
+++ b/host/rpi/rpi.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 
 	"periph.io/x/periph"
 	"periph.io/x/periph/conn/gpio"
@@ -794,13 +793,12 @@ func (d *driver) Init() (bool, error) {
 	// whenever it comes out.
 	// Revision codes from: http://elinux.org/RPi_HardwareHistory
 	f := features{}
-	rev := distro.CPUInfo()["Revision"]
-	if v, err := strconv.ParseUint(rev, 16, 32); err == nil {
-		if err := f.init(uint32(v)); err != nil {
-			return true, err
-		}
-	} else {
-		return true, fmt.Errorf("rpi: failed to read cpu_info: %v", err)
+	rev := distro.DTRevision()
+	if rev == 0 {
+		return true, fmt.Errorf("rpi: failed to obtain revision")
+	}
+	if err := f.init(rev); err != nil {
+		return true, err
 	}
 
 	return true, f.registerHeaders()


### PR DESCRIPTION
This is required to use periph.io on https://gokrazy.org.

This change was tested on:

Raspbian (2020-02-13-raspbian-buster-lite.img)
Raspberry Pi 4 Model B Rev 1.1
Raspberry Pi 3 Model B Rev 1.2

gokrazy (Linux 5.6.2)
Raspberry Pi 4 Model B Rev 1.1
Raspberry Pi 3 Model B Rev 1.2
