### PR TITLE
pca9685: Added Full-on/off support, fixed scaling to 12 bits

### DIFF
--- a/experimental/devices/pca9685/pca9685.go
+++ b/experimental/devices/pca9685/pca9685.go
@@ -145,3 +145,27 @@ func (d *Dev) SetAllPwm(on, off gpio.Duty) error {
 func (d *Dev) SetPwm(channel int, on, off gpio.Duty) error {
 	return d.setPWM(led0OnL+byte(4*channel), on, off)
 }
+
+// SetFullOff sets PWM duty to 0%.
+//
+// This function uses the dedicated bit to reduce bus traffic.
+func (d *Dev) SetFullOff(channel int) error {
+	_, err := d.dev.Write([]byte{
+		led0OnL + byte(4*channel) + 3, // LEDX_OFF_H
+		0x10,                          // bit 4 is full-off
+	})
+	return err
+}
+
+// SetFullOn sets PWM duty to 100%.
+//
+// This function uses the dedicated FULL_ON bit.
+func (d *Dev) SetFullOn(channel int) error {
+	_, err := d.dev.Write([]byte{
+		led0OnL + byte(4*channel) + 1, // LEDX_ON_H
+		0x10,                          // bit 4 is full-on
+		0,
+		0, // LEDX_OFF_H is cleared because full-off has a priority over full-on
+	})
+	return err
+}

--- a/experimental/devices/pca9685/pca9685_test.go
+++ b/experimental/devices/pca9685/pca9685_test.go
@@ -13,34 +13,38 @@ import (
 	"periph.io/x/periph/conn/physic"
 )
 
+func initializationSequence() []i2ctest.IO {
+	return []i2ctest.IO{
+		// All leds cleared by init
+		{Addr: I2CAddr, W: []byte{allLedOnL, 0, 0, 0, 0}, R: nil},
+		// mode2 is set
+		{Addr: I2CAddr, W: []byte{mode2, outDrv}, R: nil},
+		// mode1 is set
+		{Addr: I2CAddr, W: []byte{mode1, allCall}, R: nil},
+		// mode1 is read and sleep bit is cleared
+		{Addr: I2CAddr, W: []byte{mode1}, R: []byte{allCall | sleep}},
+		{Addr: I2CAddr, W: []byte{mode1, allCall | ai}, R: nil},
+
+		// SetPwmFreq 50 Hz
+		// Read mode
+		{Addr: I2CAddr, W: []byte{0x00}, R: []byte{allCall | ai}},
+		// Set sleep
+		{Addr: I2CAddr, W: []byte{0x00, allCall | ai | sleep}, R: nil},
+		// Set prescale
+		{Addr: I2CAddr, W: []byte{prescale, 122}, R: nil},
+		// Clear sleep
+		{Addr: I2CAddr, W: []byte{0x00, allCall | ai}, R: nil},
+		// Set Restart
+		{Addr: I2CAddr, W: []byte{0x00, allCall | ai | restart}, R: nil},
+	}
+}
+
 func TestPCA9685_pin(t *testing.T) {
 	scenario := &i2ctest.Playback{
-		Ops: []i2ctest.IO{
-			// All leds cleared by init
-			{Addr: I2CAddr, W: []byte{allLedOnL, 0, 0, 0, 0}, R: nil},
-			// mode2 is set
-			{Addr: I2CAddr, W: []byte{mode2, outDrv}, R: nil},
-			// mode1 is set
-			{Addr: I2CAddr, W: []byte{mode1, allCall}, R: nil},
-			// mode1 is read and sleep bit is cleared
-			{Addr: I2CAddr, W: []byte{mode1}, R: []byte{allCall | sleep}},
-			{Addr: I2CAddr, W: []byte{mode1, allCall | ai}, R: nil},
-
-			// SetPwmFreq 50 Hz
-			// Read mode
-			{Addr: I2CAddr, W: []byte{0x00}, R: []byte{allCall | ai}},
-			// Set sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | sleep}, R: nil},
-			// Set prescale
-			{Addr: I2CAddr, W: []byte{prescale, 122}, R: nil},
-			// Clear sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai}, R: nil},
-			// Set Restart
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | restart}, R: nil},
-
+		Ops: append(initializationSequence(),
 			// Set PWM value of pin 0 to 50%
-			{Addr: I2CAddr, W: []byte{led0OnL, 0, 0, 0, 0x08}, R: nil},
-		},
+			i2ctest.IO{Addr: I2CAddr, W: []byte{led0OnL, 0, 0, 0, 0x08}, R: nil},
+		),
 	}
 
 	dev, err := NewI2C(scenario, I2CAddr)
@@ -59,32 +63,10 @@ func TestPCA9685_pin(t *testing.T) {
 
 func TestPCA9685_pin_fullOff(t *testing.T) {
 	scenario := &i2ctest.Playback{
-		Ops: []i2ctest.IO{
-			// All leds cleared by init
-			{Addr: I2CAddr, W: []byte{allLedOnL, 0, 0, 0, 0}, R: nil},
-			// mode2 is set
-			{Addr: I2CAddr, W: []byte{mode2, outDrv}, R: nil},
-			// mode1 is set
-			{Addr: I2CAddr, W: []byte{mode1, allCall}, R: nil},
-			// mode1 is read and sleep bit is cleared
-			{Addr: I2CAddr, W: []byte{mode1}, R: []byte{allCall | sleep}},
-			{Addr: I2CAddr, W: []byte{mode1, allCall | ai}, R: nil},
-
-			// SetPwmFreq 50 Hz
-			// Read mode
-			{Addr: I2CAddr, W: []byte{0x00}, R: []byte{allCall | ai}},
-			// Set sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | sleep}, R: nil},
-			// Set prescale
-			{Addr: I2CAddr, W: []byte{prescale, 122}, R: nil},
-			// Clear sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai}, R: nil},
-			// Set Restart
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | restart}, R: nil},
-
+		Ops: append(initializationSequence(),
 			// Set PWM value of pin 0 to 0%
-			{Addr: I2CAddr, W: []byte{led0OnL + 3, 0x10}, R: nil},
-		},
+			i2ctest.IO{Addr: I2CAddr, W: []byte{led0OnL + 3, 0x10}, R: nil},
+		),
 	}
 
 	dev, err := NewI2C(scenario, I2CAddr)
@@ -103,32 +85,10 @@ func TestPCA9685_pin_fullOff(t *testing.T) {
 
 func TestPCA9685_pin_fullOn(t *testing.T) {
 	scenario := &i2ctest.Playback{
-		Ops: []i2ctest.IO{
-			// All leds cleared by init
-			{Addr: I2CAddr, W: []byte{allLedOnL, 0, 0, 0, 0}, R: nil},
-			// mode2 is set
-			{Addr: I2CAddr, W: []byte{mode2, outDrv}, R: nil},
-			// mode1 is set
-			{Addr: I2CAddr, W: []byte{mode1, allCall}, R: nil},
-			// mode1 is read and sleep bit is cleared
-			{Addr: I2CAddr, W: []byte{mode1}, R: []byte{allCall | sleep}},
-			{Addr: I2CAddr, W: []byte{mode1, allCall | ai}, R: nil},
-
-			// SetPwmFreq 50 Hz
-			// Read mode
-			{Addr: I2CAddr, W: []byte{0x00}, R: []byte{allCall | ai}},
-			// Set sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | sleep}, R: nil},
-			// Set prescale
-			{Addr: I2CAddr, W: []byte{prescale, 122}, R: nil},
-			// Clear sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai}, R: nil},
-			// Set Restart
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | restart}, R: nil},
-
+		Ops: append(initializationSequence(),
 			// Set PWM value of pin 0 to 100%
-			{Addr: I2CAddr, W: []byte{led0OnL + 1, 0x10, 0, 0}, R: nil},
-		},
+			i2ctest.IO{Addr: I2CAddr, W: []byte{led0OnL + 1, 0x10, 0, 0}, R: nil},
+		),
 	}
 
 	dev, err := NewI2C(scenario, I2CAddr)
@@ -147,32 +107,10 @@ func TestPCA9685_pin_fullOn(t *testing.T) {
 
 func TestPCA9685(t *testing.T) {
 	scenario := &i2ctest.Playback{
-		Ops: []i2ctest.IO{
-			// All leds cleared by init
-			{Addr: I2CAddr, W: []byte{allLedOnL, 0, 0, 0, 0}, R: nil},
-			// mode2 is set
-			{Addr: I2CAddr, W: []byte{mode2, outDrv}, R: nil},
-			// mode1 is set
-			{Addr: I2CAddr, W: []byte{mode1, allCall}, R: nil},
-			// mode1 is read and sleep bit is cleared
-			{Addr: I2CAddr, W: []byte{mode1}, R: []byte{allCall | sleep}},
-			{Addr: I2CAddr, W: []byte{mode1, allCall | ai}, R: nil},
-
-			// SetPwmFreq 50 Hz
-			// Read mode
-			{Addr: I2CAddr, W: []byte{0x00}, R: []byte{allCall | ai}},
-			// Set sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | sleep}, R: nil},
-			// Set prescale
-			{Addr: I2CAddr, W: []byte{prescale, 122}, R: nil},
-			// Clear sleep
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai}, R: nil},
-			// Set Restart
-			{Addr: I2CAddr, W: []byte{0x00, allCall | ai | restart}, R: nil},
-
+		Ops: append(initializationSequence(),
 			// Set PWM value of pin 0 to 50%
-			{Addr: I2CAddr, W: []byte{led0OnL, 0, 0, 0, 0x08}, R: nil},
-		},
+			i2ctest.IO{Addr: I2CAddr, W: []byte{led0OnL, 0, 0, 0, 0x08}, R: nil},
+		),
 	}
 
 	dev, err := NewI2C(scenario, I2CAddr)
@@ -182,5 +120,20 @@ func TestPCA9685(t *testing.T) {
 
 	if err = dev.SetPwm(0, 0, 0x800); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPCA9685_invalidCh(t *testing.T) {
+	scenario := &i2ctest.Playback{
+		Ops: append(initializationSequence()),
+	}
+
+	dev, err := NewI2C(scenario, I2CAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = dev.SetPwm(16, 0, 0x800); err == nil {
+		t.Fatal("Error expected")
 	}
 }

--- a/experimental/devices/pca9685/pins.go
+++ b/experimental/devices/pca9685/pins.go
@@ -7,7 +7,6 @@ package pca9685
 import (
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"periph.io/x/periph/conn/gpio"
@@ -17,7 +16,7 @@ import (
 )
 
 const (
-	dutyMax gpio.Duty = math.MaxUint16
+	dutyMax gpio.Duty = 1<<12 - 1
 )
 
 type pin struct {
@@ -27,8 +26,9 @@ type pin struct {
 
 // CreatePin creates a gpio handle for the given channel.
 func (d *Dev) CreatePin(channel int) (gpio.PinIO, error) {
-	if channel < 0 || channel >= 16 {
-		return nil, errors.New("PCA9685: Valid channel range is 0..15")
+	err := verifyChannel(channel)
+	if err != nil {
+		return nil, err
 	}
 	return &pin{
 		dev:     d,


### PR DESCRIPTION
This change incorporates two improvements for the pca9685 driver.

* My previous contribution included a bug, it scaled the duty cycle to 16 bits instead of the 12 bit resolution of this device.
* Now the full-off/full-on bits can be used as shortcuts to 0% and 100% duty with slightly less I2C traffic.