### PR TITLE
ssd1306: Made column differential work for SSD1306

### DIFF
--- a/devices/ssd1306/ssd1306_test.go
+++ b/devices/ssd1306/ssd1306_test.go
@@ -68,15 +68,42 @@ func TestI2C_String(t *testing.T) {
 
 func TestI2C_Draw_VerticalLSD_fast(t *testing.T) {
 	// Exercise the fast path.
-	buf := make([]byte, 1025)
+	buf := make([]byte, 129)
 	buf[0] = i2cData
 	buf[23] = 1
+
+	emptyBuf := make([]byte, 129)
+	emptyBuf[0] = i2cData
+
 	bus := i2ctest.Playback{
 		Ops: []i2ctest.IO{
 			// Startup initialization.
 			{Addr: 0x3c, W: initCmdI2C()},
-			// Actual draw buffer.
+
+			// Page 1
+			{Addr: 0x3c, W: []byte{0x00, 0xB0, 0x00, 0x10}},
 			{Addr: 0x3c, W: buf},
+			// Page 2
+			{Addr: 0x3c, W: []byte{0x00, 0xB1, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 3
+			{Addr: 0x3c, W: []byte{0x00, 0xB2, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 4
+			{Addr: 0x3c, W: []byte{0x00, 0xB3, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 5
+			{Addr: 0x3c, W: []byte{0x00, 0xB4, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 6
+			{Addr: 0x3c, W: []byte{0x00, 0xB5, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 7
+			{Addr: 0x3c, W: []byte{0x00, 0xB6, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 8
+			{Addr: 0x3c, W: []byte{0x00, 0xB7, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
 		},
 	}
 	dev, err := NewI2C(&bus, &DefaultOpts)
@@ -95,19 +122,43 @@ func TestI2C_Draw_VerticalLSD_fast(t *testing.T) {
 
 func TestI2C_Halt_Write(t *testing.T) {
 	// Exercise the fast path.
-	buf := make([]byte, 1025)
+	buf := make([]byte, 129)
 	buf[0] = i2cData
 	buf[23] = 1
+
+	emptyBuf := make([]byte, 129)
+	emptyBuf[0] = i2cData
 	bus := i2ctest.Playback{
 		Ops: []i2ctest.IO{
 			// Startup initialization.
 			{Addr: 0x3c, W: initCmdI2C()},
 			// Halt()
 			{Addr: 0x3c, W: []byte{0x0, 0xae}},
-			// transparent resume
-			{Addr: 0x3c, W: []byte{0x0, 0xaf}},
-			// Actual draw buffer.
+			// transparent resume & page 1 setup
+			{Addr: 0x3c, W: []byte{0x0, 0xaf, 0xB0, 0x00, 0x10}},
+			// Page 1
 			{Addr: 0x3c, W: buf},
+			// Page 2
+			{Addr: 0x3c, W: []byte{0x00, 0xB1, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 3
+			{Addr: 0x3c, W: []byte{0x00, 0xB2, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 4
+			{Addr: 0x3c, W: []byte{0x00, 0xB3, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 5
+			{Addr: 0x3c, W: []byte{0x00, 0xB4, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 6
+			{Addr: 0x3c, W: []byte{0x00, 0xB5, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 7
+			{Addr: 0x3c, W: []byte{0x00, 0xB6, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
+			// Page 8
+			{Addr: 0x3c, W: []byte{0x00, 0xB7, 0x00, 0x10}},
+			{Addr: 0x3c, W: emptyBuf},
 		},
 	}
 	dev, err := NewI2C(&bus, &DefaultOpts)
@@ -212,12 +263,36 @@ func TestI2C_Draw_fail(t *testing.T) {
 }
 
 func TestI2C_DrawGray(t *testing.T) {
+	buf := append([]byte{i2cData}, grayCheckboard()...)
+
 	bus := i2ctest.Playback{
 		Ops: []i2ctest.IO{
 			// Startup initialization.
 			{Addr: 0x3c, W: initCmdI2C()},
-			// Actual draw buffer.
-			{Addr: 0x3c, W: append([]byte{i2cData}, grayCheckboard()...)},
+			// Page 1
+			{Addr: 0x3c, W: []byte{0x00, 0xB0, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
+			// Page 2
+			{Addr: 0x3c, W: []byte{0x00, 0xB1, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
+			// Page 3
+			{Addr: 0x3c, W: []byte{0x00, 0xB2, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
+			// Page 4
+			{Addr: 0x3c, W: []byte{0x00, 0xB3, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
+			// Page 5
+			{Addr: 0x3c, W: []byte{0x00, 0xB4, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
+			// Page 6
+			{Addr: 0x3c, W: []byte{0x00, 0xB5, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
+			// Page 7
+			{Addr: 0x3c, W: []byte{0x00, 0xB6, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
+			// Page 8
+			{Addr: 0x3c, W: []byte{0x00, 0xB7, 0x00, 0x10}},
+			{Addr: 0x3c, W: buf},
 		},
 	}
 	dev, err := NewI2C(&bus, &DefaultOpts)
@@ -402,8 +477,8 @@ func TestSPI_4wire_String(t *testing.T) {
 }
 
 func TestSPI_4wire_Write_differential(t *testing.T) {
-	buf1 := make([]byte, 1024)
-	buf1[130] = 1
+	buf1 := make([]byte, 128)
+	buf1[29] = 1
 	buf2 := make([]byte, 128)
 	buf2[130-128] = 1
 	buf2[131-128] = 2
@@ -411,10 +486,35 @@ func TestSPI_4wire_Write_differential(t *testing.T) {
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				{W: getInitCmd(&Opts{W: 128, H: 64, Rotated: false})},
+
+				// Page 1
+				{W: []byte{0xB0, 0x00, 0x10}},
 				{W: buf1},
-				// Reset to write only to the first page.
-				{W: []byte{0x21, 0x0, 0x7f, 0x22, 0x1, 0x1}},
-				{W: buf2},
+				// Page 2
+				{W: []byte{0xB1, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 3
+				{W: []byte{0xB2, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 4
+				{W: []byte{0xB3, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 5
+				{W: []byte{0xB4, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 6
+				{W: []byte{0xB5, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 7
+				{W: []byte{0xB6, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 8
+				{W: []byte{0xB7, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+
+				// Only write to column 3 of page 1
+				{W: []byte{0xB1, 0x03, 0x10}},
+				{W: []byte{0x02}},
 			},
 		},
 	}
@@ -423,7 +523,7 @@ func TestSPI_4wire_Write_differential(t *testing.T) {
 		t.Fatal(err)
 	}
 	pix := make([]byte, 1024)
-	pix[130] = 1
+	pix[29] = 1
 	if n, err := dev.Write(pix); n != len(pix) || err != nil {
 		t.Fatal(n, err)
 	}
@@ -437,13 +537,36 @@ func TestSPI_4wire_Write_differential(t *testing.T) {
 }
 
 func TestSPI_4wire_Write_differential_fail(t *testing.T) {
-	buf1 := make([]byte, 1024)
-	buf1[130] = 1
+	buf1 := make([]byte, 128)
+	buf1[29] = 1
 	port := spitest.Playback{
 		Playback: conntest.Playback{
 			Ops: []conntest.IO{
 				{W: getInitCmd(&Opts{W: 128, H: 64, Rotated: false})},
+				// Page 1
+				{W: []byte{0xB0, 0x00, 0x10}},
 				{W: buf1},
+				// Page 2
+				{W: []byte{0xB1, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 3
+				{W: []byte{0xB2, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 4
+				{W: []byte{0xB3, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 5
+				{W: []byte{0xB4, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 6
+				{W: []byte{0xB5, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 7
+				{W: []byte{0xB6, 0x00, 0x10}},
+				{W: make([]byte, 128)},
+				// Page 8
+				{W: []byte{0xB7, 0x00, 0x10}},
+				{W: make([]byte, 128)},
 			},
 			DontPanic: true,
 		},
@@ -453,11 +576,11 @@ func TestSPI_4wire_Write_differential_fail(t *testing.T) {
 		t.Fatal(err)
 	}
 	pix := make([]byte, 1024)
-	pix[130] = 1
+	pix[29] = 1
 	if n, err := dev.Write(pix); n != len(pix) || err != nil {
 		t.Fatal(n, err)
 	}
-	pix[131] = 2
+	pix[29] = 2
 	if n, err := dev.Write(pix); n != 0 || !conntest.IsErr(err) {
 		t.Fatalf("expected conntest error: %v", err)
 	}
@@ -529,7 +652,7 @@ func getI2CPlayback() *i2ctest.Playback {
 }
 
 func grayCheckboard() []byte {
-	buf := make([]byte, 1024)
+	buf := make([]byte, 128)
 	for i := range buf {
 		if i&1 == 0 {
 			buf[i] = 0xaa


### PR DESCRIPTION
I changed ssd1306 driver to write page-by-page, and made column differential work without corrupting screen. This change is also preparation for sh1106 support, which I have working locally and plan to contribute in the future.