### PR TITLE
netlink/onewire: fix error handling when reading from the netlink socket

### DIFF
--- a/experimental/host/netlink/onewire.go
+++ b/experimental/host/netlink/onewire.go
@@ -281,32 +281,30 @@ func (ws *w1Socket) sendAndRecv(seq uint32, m *w1Msg) ([]byte, error) {
 		return nil, fmt.Errorf("failed to send W1 message: %v", err)
 	}
 
-	var (
-		data []byte
-		errs []error
-	)
+	var data []byte
+	var err1 error
 
 	// Read responses and acks for all commands. It is important to keep
 	// reading in case of an error to flush the netlink socket for future
 	// commands.
-	for i, cmd := range m.cmds {
+	for _, cmd := range m.cmds {
 		if cmd.wantResponse {
 			d, err := ws.recvCmd(seq, seq+1, m.typ, cmd.typ)
-			if err != nil {
-				errs = append(errs, fmt.Errorf("payload %d: %v", i, err))
+			if err1 == nil {
+				err1 = err
 			}
 			data = d
 		}
 
 		// Every command is ack'ed with a separate message, including commands
 		// for which a response has already been received.
-		if _, err := ws.recvCmd(seq, 0, m.typ, cmd.typ); err != nil {
-			errs = append(errs, fmt.Errorf("ack %d: %v", i, err))
+		if _, err := ws.recvCmd(seq, 0, m.typ, cmd.typ); err1 == nil {
+			err1 = err
 		}
 	}
 
-	if len(errs) > 0 {
-		return nil, fmt.Errorf("receive failures: %v", errs)
+	if err1 != nil {
+		return nil, fmt.Errorf("failed to receive response / acks: %v", err1)
 	}
 
 	return data, nil


### PR DESCRIPTION
When responding to a sequence of 1-wire commands, the kernel driver
individually acks every single one. It is important to keep reading all
of these messages in case of an error in order to flush the netlink
socket for future commands.