### PR TITLE
cap1xxx.go: shift touch sensors input statuses by d.inputStatuses array len

### DIFF
--- a/devices/cap1xxx/cap1xxx.go
+++ b/devices/cap1xxx/cap1xxx.go
@@ -159,7 +159,8 @@ func (d *Dev) InputStatus(t []TouchStatus) error {
 		// deltas[i] > int(thresholds[i])
 
 		// If the bit is set, it was touched.
-		if status&(1<<(7-i)) != 0 {
+		idx := len(d.inputStatuses) - 1
+		if status&(1<<(uint8(idx)-i)) != 0 {
 			if d.inputStatuses[i] == PressedStatus {
 				if d.opts.RetriggerOnHold {
 					d.inputStatuses[i] = HeldStatus


### PR DESCRIPTION
When dealing with a CAP1166 device (6 LEDs, 6 touch sensors), the touch sensors input statuses were not detected correctly.
The index referred by the byte shifting if was `7`, probably referring to the 8 touch sensors of the CAP1188.
Moving that index from  the original `7` to `len(d.inputStatuses) - 1` helped detect all of the input statuses from a Pimoroni Touch-Phat device.