### PR TITLE
experimental st7567: Minor cleanup

### DIFF
--- a/experimental/devices/st7567/st7567.go
+++ b/experimental/devices/st7567/st7567.go
@@ -305,7 +305,7 @@ func New(p spi.Port, dc gpio.PinOut, rst gpio.PinOut, cs gpio.PinIn, o *Opts) (*
 		cs:  cs,
 	}
 
-	cmd := make([]byte, 9)
+	var cmd []byte
 	cmd = append(cmd, byte(o.Bias))
 	cmd = append(cmd, byte(o.SegmentDirection))
 	cmd = append(cmd, byte(o.CommonDirection))

--- a/experimental/devices/st7567/st7567.go
+++ b/experimental/devices/st7567/st7567.go
@@ -305,19 +305,20 @@ func New(p spi.Port, dc gpio.PinOut, rst gpio.PinOut, cs gpio.PinIn, o *Opts) (*
 		cs:  cs,
 	}
 
-	var cmd []byte
-	cmd = append(cmd, byte(o.Bias))
-	cmd = append(cmd, byte(o.SegmentDirection))
-	cmd = append(cmd, byte(o.CommonDirection))
-	cmd = append(cmd, byte(o.Display))
-	cmd = append(cmd, setStartLine|o.StartLine)
-	cmd = append(cmd, powerControl)
-	cmd = append(cmd, byte(o.RegulationRatio.getValue()))
-	cmd = append(cmd, displayOn)
-	cmd = append(cmd, setContrast)
-	cmd = append(cmd, o.Contrast)
+	cmd := [...]byte{
+		byte(o.Bias),
+		byte(o.SegmentDirection),
+		byte(o.CommonDirection),
+		byte(o.Display),
+		setStartLine | o.StartLine,
+		powerControl,
+		byte(o.RegulationRatio.getValue()),
+		displayOn,
+		setContrast,
+		o.Contrast,
+	}
 
-	if err := d.sendCommand(cmd); err != nil {
+	if err := d.sendCommand(cmd[:]); err != nil {
 		return nil, err
 	}
 

--- a/experimental/devices/st7567/st7567.go
+++ b/experimental/devices/st7567/st7567.go
@@ -245,7 +245,7 @@ func (rr *RegulationResistor) String() string {
 type RegulationRatio []RegulationResistor
 
 func (rrs *RegulationRatio) String() string {
-	return "regulation resistor ratios"
+	return "Regulation resistor ratio"
 }
 
 func (rrs *RegulationRatio) Set(value string) error {
@@ -278,7 +278,7 @@ type Opts struct {
 	Bias Bias
 	// SegmentDirection is the direction of the segments.
 	SegmentDirection SegmentDirection
-	// CommonDirection is the direction of the segments.
+	// CommonDirection controls the common output status which changes the vertical display direction.
 	CommonDirection CommonDirection
 	// Display changes the selected and non-selected voltage of SEG.
 	Display Display


### PR DESCRIPTION
Hi,

two minor cleanups for the experimental st7567 device

* Fixes a comment for the CommonDirection
* Do not allocate unnecessary nulls for byte array
