### PR TITLE
host/pine64: improve detection

### DIFF
--- a/host/pine64/pine64.go
+++ b/host/pine64/pine64.go
@@ -6,12 +6,13 @@ package pine64
 
 import (
 	"errors"
-	"os"
+	"strings"
 
 	"periph.io/x/periph"
 	"periph.io/x/periph/conn/pin"
 	"periph.io/x/periph/conn/pin/pinreg"
 	"periph.io/x/periph/host/allwinner"
+	"periph.io/x/periph/host/distro"
 )
 
 // Present returns true if running on a Pine64 board.
@@ -19,9 +20,7 @@ import (
 // https://www.pine64.org/
 func Present() bool {
 	if isArm {
-		// This is iffy at best.
-		_, err := os.Stat("/boot/pine64.dtb")
-		return err == nil
+		return strings.HasPrefix(distro.DTModel(), "Pine64")
 	}
 	return false
 }


### PR DESCRIPTION
Read the model name from /proc/device-tree/model (via distro.DTModel())
instead of probing for /boot/pine64.dtb to be present.

There's various distros out there that don't have a /boot/pine64.dtb,
and /proc/device-tree/model is a much nicer way to do this.