### PR TITLE
nrzled: Don't set NoCS

### DIFF
--- a/experimental/devices/nrzled/nrzled.go
+++ b/experimental/devices/nrzled/nrzled.go
@@ -90,7 +90,7 @@ func NewSPI(p spi.Port, opts *Opts) (*Dev, error) {
 			return nil, errors.New("spi port buffer is too short for the specified number of pixels")
 		}
 	}
-	c, err := p.Connect(spiFreq, spi.Mode3|spi.NoCS, 8)
+	c, err := p.Connect(spiFreq, spi.Mode3, 8)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some SPI drivers don't support setting SPI_NO_CS, and fail entirely
configuring the port in that case.

In the case of nrzled, on the host side, we shouldn't really need to
configure if there's SPI CS happening or not.

If the nrzleds are just wired to the MOSI port directly, that's totally
fine - and if there's some proper CS going on, actually not setting
SPI_NO_CS would suddenly allow selecting different nrzled stripes
sequentially.